### PR TITLE
Enhance JaxToolbox report generation and update stats collection

### DIFF
--- a/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
@@ -55,32 +55,34 @@ class JaxToolboxReportGenerationStrategy(ReportGenerationStrategy):
     def _extract_times(self, directory_path: str) -> List[float]:
         """
         Extracts elapsed times from all error files matching the pattern in the directory,
-        excluding the first time value recorded in each file.
+        starting after the 10th occurrence of a line matching the "[PAX STATUS]: train_step() took" pattern.
 
         Args:
             directory_path (str): Directory containing error files.
 
         Returns:
-            List[float]: List of extracted times as floats, after excluding the first time from each file.
+            List[float]: List of extracted times as floats, starting from the epoch after the 10th occurrence.
         """
         times = []
         error_files = glob.glob(os.path.join(directory_path, "error-*.txt"))
         for stderr_path in error_files:
             file_times = []
+            epoch_count = 0
             with open(stderr_path, "r") as file:
                 for line in file:
-                    if "Elapsed time for" in line and "run" in line and ":434" in line:
-                        parts = line.split()
-                        time_str = parts[parts.index("<run>:") + 1]
-                        try:
-                            time_value = float(time_str.split("seconds")[0])
-                            file_times.append(time_value)
-                        except ValueError:
-                            continue  # Skip any lines where conversion fails
+                    if "[PAX STATUS]: train_step() took" in line:
+                        epoch_count += 1
+                        if epoch_count > 10:  # Start recording times after 10 epochs
+                            # Extract the time value right after the keyword
+                            parts = line.split("took")
+                            time_str = parts[1].strip().split("seconds")[0].strip()
+                            try:
+                                time_value = float(time_str)
+                                file_times.append(time_value)
+                            except ValueError:
+                                continue  # Skip any lines where conversion fails
 
-            # Exclude the first time record from each file if it exists
-            if file_times:
-                times.extend(file_times[1:])
+            times.extend(file_times)
 
         return times
 

--- a/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
@@ -49,6 +49,7 @@ class JaxToolboxReportGenerationStrategy(ReportGenerationStrategy):
                 "max": max(times),
                 "average": sum(times) / len(times),
                 "median": statistics.median(times),
+                "stdev": statistics.stdev(times) if len(times) > 1 else 0,
             }
             self._write_report(directory_path, stats)
 

--- a/tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py
+++ b/tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from cloudai.schema.test_template.jax_toolbox.report_generation_strategy import (
+    JaxToolboxReportGenerationStrategy,
+)
+
+
+class TestJaxExtractTime:
+    """Tests for the JaxToolboxReportGenerationStrategy class."""
+
+    def setup_method(self) -> None:
+        """Setup method for initializing JaxToolboxReportGenerationStrategy."""
+        self.js = JaxToolboxReportGenerationStrategy()
+
+    def test_no_files(self, tmp_path: Path) -> None:
+        """Test that no times are extracted when no files are present."""
+        assert self.js._extract_times(str(tmp_path)) == []
+
+    def test_no_matches(self, tmp_path: Path) -> None:
+        """Test that no times are extracted when no matching lines are present."""
+        (tmp_path / "error-1.txt").write_text("fake line")
+        assert self.js._extract_times(str(tmp_path)) == []
+
+    def test_one_match(self, tmp_path: Path) -> None:
+        """Test that the correct time is extracted when one matching line is present."""
+        err_file = tmp_path / "error-1.txt"
+        sample_line = (
+            "I0508 15:25:28.482553 140737334253888 programs.py:379] "
+            "[PAX STATUS]: train_step() took 38.727223 seconds.\n"
+        )
+        with err_file.open("w") as f:
+            for _ in range(11):
+                f.write(sample_line)
+        assert self.js._extract_times(str(err_file.parent)) == [38.727223]


### PR DESCRIPTION
## Summary
1. Collection of standard deviation in the JaxToolbox report generation strategy.
2. Update to stats collection, dropping the initial 10 epochs to avoid inconsistencies and reduce profiling overhead.
3. Added unit tests for JaxToolbox report generation (Guided by @amaslenn. I appreciate it!)

## Test Plan
```
$ python -m pytest -vv tests      
========================================================================================================= test session starts =========================================================================================================
platform darwin -- Python 3.10.2, pytest-8.1.1, pluggy-1.5.0 -- /Users/theo/venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/theo/cloudai
configfile: pyproject.toml
plugins: typeguard-2.13.3, mock-3.14.0, anyio-4.2.0
collected 40 items                                                                                                                                                                                                                    

tests/schema/system/slurm/test_slurm_system.py::test_parse_node_list_single PASSED                                                                                                                                              [  2%]
tests/schema/system/slurm/test_slurm_system.py::test_parse_node_list_range PASSED                                                                                                                                               [  5%]
tests/schema/system/slurm/test_slurm_system.py::test_parse_node_list_zero_padding PASSED                                                                                                                                        [  7%]
tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py::TestJaxExtractTime::test_no_files PASSED                                                                                                             [ 10%]
tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py::TestJaxExtractTime::test_no_matches PASSED                                                                                                           [ 12%]
tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py::TestJaxExtractTime::test_one_match PASSED                                                                                                            [ 15%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/sleep/test_scenario.toml] PASSED                                                                                                                      [ 17%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/ucc_test/test_scenario.toml] PASSED                                                                                                                   [ 20%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/nemo_launcher/test_scenario.toml] PASSED                                                                                                              [ 22%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/chakra_replay/test_scenario.toml] PASSED                                                                                                              [ 25%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/nemo_launcher_with_noise/test_scenario.toml] PASSED                                                                                                   [ 27%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/nccl_test/test_scenario.toml] PASSED                                                                                                                  [ 30%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_scatter.toml] PASSED                                                                                                                                 [ 32%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/chakra_replay.toml] PASSED                                                                                                                                     [ 35%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_1.toml] PASSED                                                                                                                                           [ 37%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_bisection.toml] PASSED                                                                                                                               [ 40%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_reduce_scatter.toml] PASSED                                                                                                                           [ 42%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_all_gather.toml] PASSED                                                                                                                              [ 45%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_alltoall.toml] PASSED                                                                                                                                [ 47%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_reduce_scatter.toml] PASSED                                                                                                                          [ 50%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_10.toml] PASSED                                                                                                                                          [ 52%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_all_reduce.toml] PASSED                                                                                                                              [ 55%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_hypercube.toml] PASSED                                                                                                                               [ 57%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_gather.toml] PASSED                                                                                                                                  [ 60%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_allreduce.toml] PASSED                                                                                                                                [ 62%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_broadcast.toml] PASSED                                                                                                                               [ 65%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_5.toml] PASSED                                                                                                                                           [ 67%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_20.toml] PASSED                                                                                                                                          [ 70%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_sendrecv.toml] PASSED                                                                                                                                [ 72%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_alltoall.toml] PASSED                                                                                                                                 [ 75%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_allgather.toml] PASSED                                                                                                                                [ 77%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_reduce.toml] PASSED                                                                                                                                  [ 80%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nemo_launcher.toml] PASSED                                                                                                                                     [ 82%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/system/standalone_system.toml] PASSED                                                                                                                               [ 85%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/system/example_slurm_cluster.toml] PASSED                                                                                                                           [ 87%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/chakra_replay.toml] PASSED                                                                                                                            [ 90%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/nccl_test.toml] PASSED                                                                                                                                [ 92%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/sleep.toml] PASSED                                                                                                                                    [ 95%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/ucc_test.toml] PASSED                                                                                                                                 [ 97%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/nemo_launcher.toml] PASSED                                                                                                                            [100%]

========================================================================================================== warnings summary ===========================================================================================================
../venv/lib/python3.10/site-packages/tensorflow/__init__.py:30
  /Users/theo/venv/lib/python3.10/site-packages/tensorflow/__init__.py:30: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    import distutils as _distutils

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================== 40 passed, 1 warning in 3.32s ====================================================================================================
```