### PR TITLE
Allow overriding of runner mappings in Runner class

### DIFF
--- a/src/cloudai/runner/core/runner.py
+++ b/src/cloudai/runner/core/runner.py
@@ -61,8 +61,6 @@ class Runner:
         """
 
         def decorator(runner_class: Type[BaseRunner]) -> Type[BaseRunner]:
-            if system_type in cls._runners:
-                raise KeyError(f"Runner for {system_type} already registered.")
             cls._runners[system_type] = runner_class
             return runner_class
 

--- a/tests/runner/core/test_runner.py
+++ b/tests/runner/core/test_runner.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+from cloudai.runner.core import BaseRunner, Runner
+
+
+def test_register_multiple_runners():
+    """
+    Test registering multiple different runners for the same type to ensure that
+    only the last registered runner is kept.
+    """
+    with patch.dict("cloudai.runner.Runner._runners", clear=True):
+
+        @Runner.register("slurm")
+        class FirstSlurmRunner(BaseRunner):
+            pass
+
+        @Runner.register("slurm")
+        class SecondSlurmRunner(BaseRunner):
+            pass
+
+        assert Runner._runners["slurm"] is SecondSlurmRunner


### PR DESCRIPTION
## Summary
Allow overriding of runner mappings in Runner class

## Test Plan
```
$ python -m pytest -vv tests
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.10.2, pytest-8.1.1, pluggy-1.5.0 -- /Users/theo/venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/theo/cloudai
configfile: pyproject.toml
plugins: typeguard-2.13.3, mock-3.14.0, anyio-4.2.0
collected 41 items                                                                                                                                                       

tests/runner/core/test_runner.py::test_register_multiple_runners PASSED                                                                                            [  2%]
tests/schema/system/slurm/test_slurm_system.py::test_parse_node_list_single PASSED                                                                                 [  4%]
tests/schema/system/slurm/test_slurm_system.py::test_parse_node_list_range PASSED                                                                                  [  7%]
tests/schema/system/slurm/test_slurm_system.py::test_parse_node_list_zero_padding PASSED                                                                           [  9%]
tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py::TestJaxExtractTime::test_no_files PASSED                                                [ 12%]
tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py::TestJaxExtractTime::test_no_matches PASSED                                              [ 14%]
tests/schema/test_template/jax_toolbox/test_report_generation_strategy.py::TestJaxExtractTime::test_one_match PASSED                                               [ 17%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/sleep/test_scenario.toml] PASSED                                                         [ 19%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/ucc_test/test_scenario.toml] PASSED                                                      [ 21%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/nemo_launcher/test_scenario.toml] PASSED                                                 [ 24%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/chakra_replay/test_scenario.toml] PASSED                                                 [ 26%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/nemo_launcher_with_noise/test_scenario.toml] PASSED                                      [ 29%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_scenario/nccl_test/test_scenario.toml] PASSED                                                     [ 31%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_scatter.toml] PASSED                                                                    [ 34%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/chakra_replay.toml] PASSED                                                                        [ 36%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_1.toml] PASSED                                                                              [ 39%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_bisection.toml] PASSED                                                                  [ 41%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_reduce_scatter.toml] PASSED                                                              [ 43%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_all_gather.toml] PASSED                                                                 [ 46%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_alltoall.toml] PASSED                                                                   [ 48%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_reduce_scatter.toml] PASSED                                                             [ 51%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_10.toml] PASSED                                                                             [ 53%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_all_reduce.toml] PASSED                                                                 [ 56%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_hypercube.toml] PASSED                                                                  [ 58%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_gather.toml] PASSED                                                                     [ 60%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_allreduce.toml] PASSED                                                                   [ 63%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_broadcast.toml] PASSED                                                                  [ 65%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_5.toml] PASSED                                                                              [ 68%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/sleep_20.toml] PASSED                                                                             [ 70%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_sendrecv.toml] PASSED                                                                   [ 73%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_alltoall.toml] PASSED                                                                    [ 75%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/ucc_test_allgather.toml] PASSED                                                                   [ 78%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nccl_test_reduce.toml] PASSED                                                                     [ 80%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test/nemo_launcher.toml] PASSED                                                                        [ 82%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/system/standalone_system.toml] PASSED                                                                  [ 85%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/system/example_slurm_cluster.toml] PASSED                                                              [ 87%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/chakra_replay.toml] PASSED                                                               [ 90%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/nccl_test.toml] PASSED                                                                   [ 92%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/sleep.toml] PASSED                                                                       [ 95%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/ucc_test.toml] PASSED                                                                    [ 97%]
tests/test_toml_files.py::test_toml_files[conf/v0.6/general/test_template/nemo_launcher.toml] PASSED                                                               [100%]

============================================================================ warnings summary ============================================================================
../venv/lib/python3.10/site-packages/tensorflow/__init__.py:30
  /Users/theo/venv/lib/python3.10/site-packages/tensorflow/__init__.py:30: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    import distutils as _distutils

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== 41 passed, 1 warning in 18.68s =====================================================================
```
