### PR TITLE
Rename report file names to include 'cloudai' prefix

### DIFF
--- a/src/cloudai/schema/test_template/nccl_test/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/report_generation_strategy.py
@@ -135,4 +135,4 @@ class NcclTestReportGenerationStrategy(ReportGenerationStrategy):
             sol=sol,
         )
 
-        report_tool.finalize_report("nccl_test_bokeh_report.html")
+        report_tool.finalize_report("cloudai_nccl_test_bokeh_report.html")

--- a/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
@@ -62,4 +62,4 @@ class NeMoLauncherReportGenerationStrategy(ReportGenerationStrategy):
                     color="black",
                 )
 
-        report_tool.finalize_report("nemo_launcher_bokeh_report.html")
+        report_tool.finalize_report("cloudai_nemo_launcher_bokeh_report.html")

--- a/src/cloudai/schema/test_template/ucc_test/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/report_generation_strategy.py
@@ -126,4 +126,4 @@ class UCCTestReportGenerationStrategy(ReportGenerationStrategy):
             sol=sol,
         )
 
-        report_tool.finalize_report("ucc_test_bokeh_report.html")
+        report_tool.finalize_report("cloudai_ucc_test_bokeh_report.html")


### PR DESCRIPTION
## Summary
Rename report file names to include 'cloudai' prefix

## Test Plan
```
$ cloudai --mode generate-report --output_path ~/Downloads/2024-04-17_22-13-25/ --system_config_path [system_config_path] --test_scenario_path [test_scenario_path]
$ cd ~/Downloads/2024-04-17_22-13-25/
$ ls  | grep report
cloudai_nccl_test_bokeh_report.html
```