### PR TITLE
Llama

### DIFF
--- a/conf/v0.6/general/test/gpt.toml
+++ b/conf/v0.6/general/test/gpt.toml
@@ -1,0 +1,5 @@
+name = "gpt"
+description = "gpt"
+test_template_name = "NeMoLauncher"
+
+[cmd_args]

--- a/conf/v0.6/general/test/gpt.toml
+++ b/conf/v0.6/general/test/gpt.toml
@@ -1,5 +1,3 @@
 name = "gpt"
 description = "gpt"
 test_template_name = "NeMoLauncher"
-
-[cmd_args]

--- a/conf/v0.6/general/test/llama.toml
+++ b/conf/v0.6/general/test/llama.toml
@@ -1,8 +1,9 @@
 name = "llama"
 description = "Llama2 70b"
 test_template_name = "NeMoLauncher"
-# FIX ME : ~training.model.position_embedding_type is a quick fix that should be changed with newer version of container
-# the commit that should fix this issue is : 5b296e8af832c67d361fdfb80a165db3affaf76a
+# FIX ME : ~training.model.position_embedding_type was added in the extra_cmd_args in order to fix a bug from NeMo repository (https://github.com/NVIDIA/NeMo).
+# the commit that should fix this issue in NeMo is : 5b296e8af832c67d361fdfb80a165db3affaf76a.
+# Once the new release of NeMoLauncher includes this commit (check by downloading the corresponding container and look inside /opt for this commit), ~training.model.position_embedding_type should be removed from the extra args
 extra_cmd_args = "~training.model.position_embedding_type +training.model.fsdp=True ~training.model.optim.bucket_cap_mb ~training.model.optim.overlap_grad_sync ~training.model.optim.overlap_param_sync ~training.model.optim.contiguous_grad_buffer training.model.virtual_pipeline_model_parallel_size=null training.model.megatron_amp_O2=False training.model.activations_checkpoint_num_layers=null training.model.gradient_accumulation_fusion=False training.model.use_cpu_initialization=True training.model.optim.name=fused_adam training.model.tokenizer.model=TOKENIZER_MODEL training.exp_manager.create_wandb_logger=False"
 
 [cmd_args]

--- a/conf/v0.6/general/test/llama.toml
+++ b/conf/v0.6/general/test/llama.toml
@@ -1,7 +1,7 @@
 name = "llama"
 description = "Llama2 70b"
 test_template_name = "NeMoLauncher"
-# FIX ME : ~training.model.position_embedding_type was added in the extra_cmd_args in order to fix a bug from NeMo repository (https://github.com/NVIDIA/NeMo).
+# FIXME : ~training.model.position_embedding_type was added in the extra_cmd_args in order to fix a bug from NeMo repository (https://github.com/NVIDIA/NeMo).
 # the commit that should fix this issue in NeMo is : 5b296e8af832c67d361fdfb80a165db3affaf76a.
 # Once the new release of NeMoLauncher includes this commit (check by downloading the corresponding container and look inside /opt for this commit), ~training.model.position_embedding_type should be removed from the extra args
 extra_cmd_args = "~training.model.position_embedding_type +training.model.fsdp=True ~training.model.optim.bucket_cap_mb ~training.model.optim.overlap_grad_sync ~training.model.optim.overlap_param_sync ~training.model.optim.contiguous_grad_buffer training.model.virtual_pipeline_model_parallel_size=null training.model.megatron_amp_O2=False training.model.activations_checkpoint_num_layers=null training.model.gradient_accumulation_fusion=False training.model.use_cpu_initialization=True training.model.optim.name=fused_adam training.model.tokenizer.model=TOKENIZER_MODEL training.exp_manager.create_wandb_logger=False"

--- a/conf/v0.6/general/test/llama.toml
+++ b/conf/v0.6/general/test/llama.toml
@@ -1,0 +1,12 @@
+name = "llama"
+description = "Llama2 70b"
+test_template_name = "NeMoLauncher"
+# FIX ME : ~training.model.position_embedding_type is a quick fix that should be changed with newer version of container
+# the commit that should fix this issue is : 5b296e8af832c67d361fdfb80a165db3affaf76a
+extra_cmd_args = "~training.model.position_embedding_type +training.model.fsdp=True ~training.model.optim.bucket_cap_mb ~training.model.optim.overlap_grad_sync ~training.model.optim.overlap_param_sync ~training.model.optim.contiguous_grad_buffer training.model.virtual_pipeline_model_parallel_size=null training.model.megatron_amp_O2=False training.model.activations_checkpoint_num_layers=null training.model.gradient_accumulation_fusion=False training.model.use_cpu_initialization=True training.model.optim.name=fused_adam training.model.tokenizer.model=TOKENIZER_MODEL training.exp_manager.create_wandb_logger=False"
+
+[cmd_args]
+"training" = "llama/llama2_70b"
+"training.trainer.max_steps" = "120"
+"training.model.global_batch_size" = "256"
+"training.model.pipeline_model_parallel_size" = "1"

--- a/conf/v0.6/general/test/nemo_launcher.toml
+++ b/conf/v0.6/general/test/nemo_launcher.toml
@@ -1,3 +1,0 @@
-name = "nemo_launcher"
-description = "NeMo-Launcher"
-test_template_name = "NeMoLauncher"

--- a/conf/v0.6/general/test_template/nemo_launcher.toml
+++ b/conf/v0.6/general/test_template/nemo_launcher.toml
@@ -33,7 +33,7 @@ name = "NeMoLauncher"
     default = "8"
 
   [cmd_args.training]
-  values = ["gpt3/40b_improved"]
+  values = ["gpt3/40b_improved", "llama/llama2_70b"]
   default = "gpt3/40b_improved"
     [cmd_args.training.exp_manager]
       [cmd_args.training.exp_manager.create_checkpoint_callback]
@@ -42,9 +42,8 @@ name = "NeMoLauncher"
 
     [cmd_args.training.trainer]
       [cmd_args.training.trainer.max_steps]
-      type = "preset"
-      values = ["100", "500", "1000", "2000"]
-      default = "100"
+      type = "int"
+      default = "400"
 
       [cmd_args.training.trainer.val_check_interval]
       type = "preset"
@@ -62,8 +61,7 @@ name = "NeMoLauncher"
 
     [cmd_args.training.model]
       [cmd_args.training.model.global_batch_size]
-      type = "preset"
-      values = ["8", "16", "32", "128"]
+      type = "int"
       default = "128"
 
       [cmd_args.training.model.micro_batch_size]


### PR DESCRIPTION
## Summary
Based on PR 20
enable to use Llama tests
create llama toml file and adapt NeMo gen command

**There is a FIXME inside this PR (in the Llama.toml file):** 
> FIXME : ~training.model.position_embedding_type was added in the extra_cmd_args in order to fix a bug from NeMo repository (https://github.com/NVIDIA/NeMo).
the commit that should fix this issue in NeMo is : 5b296e8af832c67d361fdfb80a165db3affaf76a.
Once the new release of NeMoLauncher includes this commit (check by downloading the corresponding container and look inside /opt for this commit), ~training.model.position_embedding_type should be removed from the extra args


## Test Plan
Test by @amaslenn
CI
Test by @jeffnvidia
2.1 Slurm command generation
$ python ./cloudaix.py --mode run --system_config_path conf/v0.6/general/system/... --test_scenario_path conf/v0.6/general/test_scenario/llama/llama.toml

## Additional Notes

Llama 16 nodes alone (3, 5, 8) : /auto/mtrsysgwork/jmahou/git/asap_cloudai/results/2024-05-01_12-17-26

![image](https://github.com/NVIDIA/cloudai/assets/152798700/73474076-32ad-47e5-a52a-2437a5e73ecb)

cmd : $ python ./cloudaix.py --mode run --system_config_path conf/v0.6/general/system/... --test_scenario_path conf/v0.6/general/test_scenario/llama/llama.toml
Llama 16 nodes (3, 5, 8) + bisection noise 72 nodes : /auto/mtrsysgwork/jmahou/git/asap_cloudai/results/2024-05-01_13-42-47

![image](https://github.com/NVIDIA/cloudai/assets/152798700/5e915631-91b1-459f-a528-708673d0ffa9)

cmd : $ python ./cloudaix.py --mode run --system_config_path conf/v0.6/general/system/... --test_scenario_path conf/v0.6/general/test_scenario/llama/llama_with_noise.toml