### PR TITLE
Generate CSV reports in NCCL-tests

### DIFF
--- a/src/cloudai/report_generator/tool/csv_report_tool.py
+++ b/src/cloudai/report_generator/tool/csv_report_tool.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pandas as pd
+
+from .report_tool_interface import ReportToolInterface
+
+
+class CSVReportTool(ReportToolInterface):
+    """
+    Tool for creating CSV reports.
+
+    Attributes
+        output_directory (str): Directory to save the generated reports.
+        dataframe (pd.DataFrame): DataFrame containing the data to be saved.
+    """
+
+    def __init__(self, output_directory: str):
+        self.output_directory = output_directory
+        self.dataframe = None
+
+    def set_dataframe(self, df: pd.DataFrame):
+        """
+        Set the DataFrame to be used in the report.
+
+        Args:
+            df (pd.DataFrame): DataFrame containing the data to be saved.
+        """
+        self.dataframe = df
+
+    def finalize_report(self, output_filename: str):
+        """
+        Save the DataFrame to a CSV file.
+
+        Args:
+            output_filename (str): The filename to save the final report.
+        """
+        if self.dataframe is None:
+            raise ValueError("No DataFrame has been set for the report.")
+
+        output_filepath = os.path.join(self.output_directory, output_filename)
+        self.dataframe.to_csv(output_filepath, index=False)
+        self.dataframe = None

--- a/src/cloudai/schema/test_template/nccl_test/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/report_generation_strategy.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Tuple
 import pandas as pd
 
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
+from cloudai.report_generator.tool.csv_report_tool import CSVReportTool
 from cloudai.report_generator.util import add_human_readable_sizes
 from cloudai.schema.core.strategy import ReportGenerationStrategy, StrategyRegistry
 from cloudai.schema.system import SlurmSystem
@@ -76,7 +77,8 @@ class NcclTestReportGenerationStrategy(ReportGenerationStrategy):
             df["Algbw (GB/s) In-place"] = df["Algbw (GB/s) In-place"].astype(float)
             df["Busbw (GB/s) In-place"] = df["Busbw (GB/s) In-place"].astype(float)
             df = add_human_readable_sizes(df, "Size (B)", "Size Human-readable")
-            self._generate_plots(test_name, df, directory_path, sol)
+            self._generate_bokeh_report(test_name, df, directory_path, sol)
+            self._generate_csv_report(df, directory_path)
 
     def _parse_output(self, directory_path: str) -> Tuple[List[List[str]], Optional[float]]:
         """
@@ -99,7 +101,9 @@ class NcclTestReportGenerationStrategy(ReportGenerationStrategy):
                 return data, avg_bus_bw
         return [], None
 
-    def _generate_plots(self, test_name: str, df: pd.DataFrame, directory_path: str, sol: Optional[float]) -> None:
+    def _generate_bokeh_report(
+        self, test_name: str, df: pd.DataFrame, directory_path: str, sol: Optional[float]
+    ) -> None:
         """
         Create and saves plots to visualize NCCL test metrics.
 
@@ -138,3 +142,15 @@ class NcclTestReportGenerationStrategy(ReportGenerationStrategy):
         )
 
         report_tool.finalize_report("cloudai_nccl_test_bokeh_report.html")
+
+    def _generate_csv_report(self, df: pd.DataFrame, directory_path: str) -> None:
+        """
+        Generate a CSV report from the DataFrame.
+
+        Args:
+            df (pd.DataFrame): DataFrame containing the NCCL test data.
+            directory_path (str): Output directory path for saving the CSV report.
+        """
+        csv_report_tool = CSVReportTool(directory_path)
+        csv_report_tool.set_dataframe(df)
+        csv_report_tool.finalize_report("cloudai_nccl_test_csv_report.csv")

--- a/tests/test_csv_report_tool.py
+++ b/tests/test_csv_report_tool.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pandas as pd
+import pytest
+from cloudai.report_generator.tool.csv_report_tool import CSVReportTool
+
+
+@pytest.fixture
+def output_directory(tmpdir):
+    return tmpdir.mkdir("reports")
+
+
+@pytest.fixture
+def example_dataframe():
+    data = {"A": [1, 2, 3], "B": [4, 5, 6]}
+    return pd.DataFrame(data)
+
+
+def test_set_dataframe(example_dataframe):
+    csv_tool = CSVReportTool(output_directory=".")
+    csv_tool.set_dataframe(example_dataframe)
+    assert csv_tool.dataframe is not None, "The dataframe was not set."
+    assert csv_tool.dataframe.equals(example_dataframe), "The dataframe was not set correctly."
+
+
+def test_finalize_report_no_dataframe(output_directory):
+    csv_tool = CSVReportTool(output_directory=str(output_directory))
+    with pytest.raises(ValueError, match="No DataFrame has been set for the report."):
+        csv_tool.finalize_report("report.csv")
+
+
+def test_finalize_report(output_directory, example_dataframe):
+    csv_tool = CSVReportTool(output_directory=str(output_directory))
+    csv_tool.set_dataframe(example_dataframe)
+    output_filename = "report.csv"
+    csv_tool.finalize_report(output_filename)
+
+    output_filepath = os.path.join(str(output_directory), output_filename)
+    assert os.path.exists(output_filepath), "The report file was not created."
+
+    saved_df = pd.read_csv(output_filepath)
+    assert saved_df.equals(example_dataframe), "The saved dataframe does not match the original dataframe."
+
+
+def test_finalize_report_resets_dataframe(output_directory, example_dataframe):
+    csv_tool = CSVReportTool(output_directory=str(output_directory))
+    csv_tool.set_dataframe(example_dataframe)
+    csv_tool.finalize_report("report.csv")
+    assert csv_tool.dataframe is None, "The dataframe was not reset after finalizing the report."


### PR DESCRIPTION
## Summary
- Added `CSVReportTool` for generating CSV reports and implemented unit tests for it.
- Updated `NcclTestReportGenerationStrategy` to generate CSV reports using the new `CSVReportTool` alongside existing Bokeh reports.
## Test Plan
1. Added unit tests
2. Generated reports
```
$ cloudai ... --mode=generate-report ... 
$ find . -name '*report*'
./Tests.1/0/cloudai_nccl_test_report.csv
./Tests.1/0/cloudai_nccl_test_bokeh_report.html
./Tests.3/0/cloudai_nccl_test_report.csv
./Tests.3/0/cloudai_nccl_test_bokeh_report.html
./Tests.4/0/cloudai_nccl_test_report.csv
./Tests.4/0/cloudai_nccl_test_bokeh_report.html
./Tests.2/0/cloudai_nccl_test_report.csv
./Tests.2/0/cloudai_nccl_test_bokeh_report.html
```