### PR TITLE
Identify job completion status after each test

### DIFF
--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -17,6 +17,7 @@ from ._core.grader import Grader
 from ._core.grading_strategy import GradingStrategy
 from ._core.install_strategy import InstallStrategy
 from ._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
+from ._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from ._core.parser import Parser
 from ._core.registry import Registry
 from ._core.report_generation_strategy import ReportGenerationStrategy
@@ -39,6 +40,7 @@ from .schema.test_template.chakra_replay.report_generation_strategy import Chakr
 from .schema.test_template.chakra_replay.slurm_command_gen_strategy import ChakraReplaySlurmCommandGenStrategy
 from .schema.test_template.chakra_replay.slurm_install_strategy import ChakraReplaySlurmInstallStrategy
 from .schema.test_template.chakra_replay.template import ChakraReplay
+from .schema.test_template.common.default_job_status_retrieval_strategy import DefaultJobStatusRetrievalStrategy
 from .schema.test_template.common.slurm_job_id_retrieval_strategy import SlurmJobIdRetrievalStrategy
 from .schema.test_template.common.standalone_job_id_retrieval_strategy import StandaloneJobIdRetrievalStrategy
 from .schema.test_template.jax_toolbox.grading_strategy import JaxToolboxGradingStrategy
@@ -102,6 +104,13 @@ Registry().add_strategy(
     JobIdRetrievalStrategy, [SlurmSystem], [ChakraReplay, JaxToolbox, NcclTest, UCCTest], SlurmJobIdRetrievalStrategy
 )
 Registry().add_strategy(JobIdRetrievalStrategy, [StandaloneSystem], [Sleep], StandaloneJobIdRetrievalStrategy)
+Registry().add_strategy(JobStatusRetrievalStrategy, [StandaloneSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
+Registry().add_strategy(
+    JobStatusRetrievalStrategy,
+    [SlurmSystem],
+    [ChakraReplay, JaxToolbox, NcclTest, UCCTest, NeMoLauncher],
+    DefaultJobStatusRetrievalStrategy,
+)
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmCommandGenStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [ChakraReplay], ChakraReplaySlurmInstallStrategy)
 Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [ChakraReplay], ChakraReplayReportGenerationStrategy)

--- a/src/cloudai/_core/base_job.py
+++ b/src/cloudai/_core/base_job.py
@@ -22,19 +22,22 @@ class BaseJob:
     Attributes
         id (int): The unique identifier of the job.
         test (Test): The test instance associated with this job.
+        output_path (str): The path where the job's output is stored.
         terminated_by_dependency (bool): Flag to indicate if the job was terminated due to a dependency.
     """
 
-    def __init__(self, job_id: int, test: Test):
+    def __init__(self, job_id: int, test: Test, output_path: str):
         """
         Initialize a BaseJob instance.
 
         Args:
             job_id (int): The unique identifier of the job.
+            output_path (str): The path where the job's output is stored.
             test (Test): The test instance associated with the job.
         """
         self.id = job_id
         self.test = test
+        self.output_path = output_path
         self.terminated_by_dependency = False
 
     def increment_iteration(self):

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -283,17 +283,17 @@ class BaseRunner(ABC):
         Returns
             int: The number of completed jobs.
         """
-        completed_jobs_count = 0
+        successful_jobs_count = 0
 
         self.logger.debug("Monitoring jobs.")
         for job in list(self.jobs):
             if self.is_job_completed(job):
                 if self.mode == "dry-run":
-                    completed_jobs_count += 1
+                    successful_jobs_count += 1
                 else:
                     job_status_result = self.get_job_status(job)
                     if job_status_result.is_successful:
-                        completed_jobs_count += 1
+                        successful_jobs_count += 1
                         await self.handle_job_completion(job)
                     else:
                         error_message = (
@@ -304,7 +304,7 @@ class BaseRunner(ABC):
                         await self.shutdown()
                         raise JobFailureError(job.test.section_name, error_message, job_status_result.error_message)
 
-        return completed_jobs_count
+        return successful_jobs_count
 
     def get_job_status(self, job: BaseJob) -> JobStatusResult:
         """

--- a/src/cloudai/_core/exceptions.py
+++ b/src/cloudai/_core/exceptions.py
@@ -69,3 +69,42 @@ class JobIdRetrievalError(JobSubmissionError):
     """
 
     pass
+
+
+class JobFailureError(Exception):
+    """
+    Exception raised for errors that occur during job execution.
+
+    Attributes
+        test_name (str): The name of the test that failed.
+        message (str): A custom message describing the error.
+        details (str): Additional details about the job failure.
+    """
+
+    def __init__(self, test_name: str, message: str, details: str = ""):
+        """
+        Initialize a JobFailureError instance.
+
+        Args:
+            test_name (str): The name of the test associated with the job.
+            message (str): A custom message describing the error.
+            details (str): Additional details about the job failure.
+        """
+        super().__init__(message)
+        self.test_name = test_name
+        self.message = message
+        self.details = details.strip()
+
+    def __str__(self):
+        """
+        Return a formatted string representation of the JobFailureError instance.
+
+        Returns
+            str: A formatted string with detailed error information.
+        """
+        return (
+            f"\nERROR: Job Execution Failed\n"
+            f"\tTest Name: {self.test_name}\n"
+            f"\tMessage: {self.message}\n"
+            f"\tDetails: '{self.details}'\n"
+        )

--- a/src/cloudai/_core/job_status_result.py
+++ b/src/cloudai/_core/job_status_result.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 class JobStatusResult:
     """
     Encapsulates the result of a job status retrieval.

--- a/src/cloudai/_core/job_status_result.py
+++ b/src/cloudai/_core/job_status_result.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .default_job_status_retrieval_strategy import DefaultJobStatusRetrievalStrategy
-from .slurm_job_id_retrieval_strategy import SlurmJobIdRetrievalStrategy
-from .standalone_job_id_retrieval_strategy import StandaloneJobIdRetrievalStrategy
 
-__all__ = [
-    "DefaultJobStatusRetrievalStrategy",
-    "SlurmJobIdRetrievalStrategy",
-    "StandaloneJobIdRetrievalStrategy",
-]
+
+class JobStatusResult:
+    """
+    Encapsulates the result of a job status retrieval.
+
+    Attributes
+        is_successful (bool): Indicates if the job was successful.
+        error_message (str): Error message if the job was not successful.
+    """
+
+    def __init__(self, is_successful: bool, error_message: str = ""):
+        self.is_successful = is_successful
+        self.error_message = error_message
+
+    def __str__(self):
+        return f"JobStatusResult(is_successful={self.is_successful}, error_message={self.error_message})"

--- a/src/cloudai/_core/job_status_retrieval_strategy.py
+++ b/src/cloudai/_core/job_status_retrieval_strategy.py
@@ -12,12 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .default_job_status_retrieval_strategy import DefaultJobStatusRetrievalStrategy
-from .slurm_job_id_retrieval_strategy import SlurmJobIdRetrievalStrategy
-from .standalone_job_id_retrieval_strategy import StandaloneJobIdRetrievalStrategy
+from abc import abstractmethod
 
-__all__ = [
-    "DefaultJobStatusRetrievalStrategy",
-    "SlurmJobIdRetrievalStrategy",
-    "StandaloneJobIdRetrievalStrategy",
-]
+from .job_status_result import JobStatusResult
+
+
+class JobStatusRetrievalStrategy:
+    """Abstract class to define a strategy for retrieving job statuses from a given output directory."""
+
+    @abstractmethod
+    def get_job_status(self, output_path: str) -> JobStatusResult:
+        """
+        Retrieve the job status from a specified output directory.
+
+        Args:
+            output_path (str): Path to the output directory.
+
+        Returns:
+            JobStatusResult: The result containing the job status and an optional error message.
+        """
+        pass

--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -18,6 +18,7 @@ from .base_installer import BaseInstaller
 from .base_runner import BaseRunner
 from .base_system_parser import BaseSystemParser
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
+from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
 from .test_template import TestTemplate
@@ -42,11 +43,15 @@ class Registry(metaclass=Singleton):
     runners_map: Dict[str, Type[BaseRunner]] = {}
     strategies_map: Dict[
         Tuple[
-            Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+            Type[
+                Union[
+                    TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy
+                ]
+            ],
             Type[System],
             Type[TestTemplate],
         ],
-        Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+        Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]],
     ] = {}
     test_templates_map: Dict[str, Type[TestTemplate]] = {}
     installers_map: Dict[str, Type[BaseInstaller]] = {}
@@ -113,10 +118,14 @@ class Registry(metaclass=Singleton):
 
     def add_strategy(
         self,
-        strategy_interface: Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+        strategy_interface: Type[
+            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+        ],
         system_types: List[Type[System]],
         template_types: List[Type[TestTemplate]],
-        strategy: Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+        strategy: Type[
+            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+        ],
     ) -> None:
         for system_type in system_types:
             for template_type in template_types:
@@ -128,20 +137,27 @@ class Registry(metaclass=Singleton):
     def update_strategy(
         self,
         key: Tuple[
-            Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+            Type[
+                Union[
+                    TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy
+                ]
+            ],
             Type[System],
             Type[TestTemplate],
         ],
-        value: Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+        value: Type[
+            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+        ],
     ) -> None:
         if not (
             issubclass(key[0], TestTemplateStrategy)
             or issubclass(key[0], ReportGenerationStrategy)
             or issubclass(key[0], JobIdRetrievalStrategy)
+            or issubclass(key[0], JobStatusRetrievalStrategy)
         ):
             raise ValueError(
                 "Invalid strategy interface type, should be subclass of 'TestTemplateStrategy' or "
-                "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy'."
+                "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy' or 'JobStatusRetrievalStrategy'."
             )
         if not issubclass(key[1], System):
             raise ValueError("Invalid system type, should be subclass of 'System'.")
@@ -152,6 +168,7 @@ class Registry(metaclass=Singleton):
             issubclass(value, TestTemplateStrategy)
             or issubclass(value, ReportGenerationStrategy)
             or issubclass(value, JobIdRetrievalStrategy)
+            or issubclass(value, JobStatusRetrievalStrategy)
         ):
             raise ValueError(f"Invalid strategy implementation {value}, should be subclass of 'TestTemplateStrategy'.")
         self.strategies_map[key] = value

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -15,6 +15,7 @@
 import sys
 from typing import Dict, List, Optional, Union
 
+from .job_status_result import JobStatusResult
 from .test_template import TestTemplate
 
 
@@ -158,6 +159,18 @@ class Test:
             Optional[int]: The retrieved job ID, or None if not found.
         """
         return self.test_template.get_job_id(stdout, stderr)
+
+    def get_job_status(self, output_path: str) -> JobStatusResult:
+        """
+        Determine the status of a job based on the outputs located in the given output directory.
+
+        Args:
+            output_path (str): Path to the output directory.
+
+        Returns:
+            JobStatusResult: The result containing the job status and an optional error message.
+        """
+        return self.test_template.get_job_status(output_path)
 
     def has_more_iterations(self) -> bool:
         """

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -19,6 +19,8 @@ from .command_gen_strategy import CommandGenStrategy
 from .grading_strategy import GradingStrategy
 from .install_strategy import InstallStrategy
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
+from .job_status_result import JobStatusResult
+from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
 
@@ -40,6 +42,7 @@ class TestTemplate:
         job_id_retrieval_strategy (JobIdRetrievalStrategy): Strategy for retrieving job IDs.
         report_generation_strategy (ReportGenerationStrategy): Strategy for generating reports.
         grading_strategy (GradingStrategy): Strategy for grading performance based on test outcomes.
+        job_status_retrieval_strategy (JobStatusRetrievalStrategy): Strategy for determining job statuses.
     """
 
     __test__ = False
@@ -68,6 +71,7 @@ class TestTemplate:
         self.install_strategy: Optional[InstallStrategy] = None
         self.command_gen_strategy: Optional[CommandGenStrategy] = None
         self.job_id_retrieval_strategy: Optional[JobIdRetrievalStrategy] = None
+        self.job_status_retrieval_strategy: Optional[JobStatusRetrievalStrategy] = None
         self.report_generation_strategy: Optional[ReportGenerationStrategy] = None
         self.grading_strategy: Optional[GradingStrategy] = None
 
@@ -155,6 +159,19 @@ class TestTemplate:
         """
         assert self.job_id_retrieval_strategy is not None
         return self.job_id_retrieval_strategy.get_job_id(stdout, stderr)
+
+    def get_job_status(self, output_path: str) -> JobStatusResult:
+        """
+        Determine the job status by evaluating the contents or results in a specified output directory.
+
+        Args:
+            output_path (str): Path to the output directory.
+
+        Returns:
+            JobStatusResult: The result containing the job status and an optional error message.
+        """
+        assert self.job_status_retrieval_strategy is not None
+        return self.job_status_retrieval_strategy.get_job_status(output_path)
 
     def can_handle_directory(self, directory_path: str) -> bool:
         """

--- a/src/cloudai/_core/test_template_parser.py
+++ b/src/cloudai/_core/test_template_parser.py
@@ -20,6 +20,7 @@ from .command_gen_strategy import CommandGenStrategy
 from .grading_strategy import GradingStrategy
 from .install_strategy import InstallStrategy
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
+from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .registry import Registry
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
@@ -53,19 +54,24 @@ class TestTemplateParser(BaseMultiFileParser):
         self.system = system
         self.directory_path: str = directory_path
 
-    def _fetch_strategy(
+    def _fetch_strategy(  # noqa: D417
         self,
-        strategy_interface: Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]],
+        strategy_interface: Type[
+            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+        ],
         system_type: Type[System],
         test_template_type: Type[TestTemplate],
         env_vars: Dict[str, Any],
         cmd_args: Dict[str, Any],
-    ) -> Optional[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]]:
+    ) -> Optional[
+        Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+    ]:
         """
         Fetch a strategy from the registry based on system and template.
 
         Args:
-            strategy_interface (Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy]):
+            strategy_interface (Type[Union[TestTemplateStrategy, ReportGenerationStrategy,
+                JobIdRetrievalStrategy, JobStatusRetrievalStrategy]]):
                 The strategy interface to fetch.
             system_type (Type[System]): The system type.
             test_template_type (Type[TestTemplate]): The test template type.
@@ -123,6 +129,10 @@ class TestTemplateParser(BaseMultiFileParser):
         obj.job_id_retrieval_strategy = cast(
             JobIdRetrievalStrategy,
             self._fetch_strategy(JobIdRetrievalStrategy, type(obj.system), type(obj), env_vars, cmd_args),
+        )
+        obj.job_status_retrieval_strategy = cast(
+            JobStatusRetrievalStrategy,
+            self._fetch_strategy(JobStatusRetrievalStrategy, type(obj.system), type(obj), env_vars, cmd_args),
         )
         obj.report_generation_strategy = cast(
             ReportGenerationStrategy,

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -83,7 +83,7 @@ class SlurmRunner(BaseRunner):
                     stderr=stderr,
                     message="Failed to retrieve job ID from command output.",
                 )
-        return SlurmJob(job_id, test)
+        return SlurmJob(job_id, test, job_output_path)
 
     def is_job_running(self, job: BaseJob) -> bool:
         """

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -82,7 +82,7 @@ class StandaloneRunner(BaseRunner):
                     stderr="",
                     message="Failed to retrieve job ID from command output.",
                 )
-        return StandaloneJob(job_id, test)
+        return StandaloneJob(job_id, test, job_output_path)
 
     def is_job_running(self, job: BaseJob) -> bool:
         """

--- a/src/cloudai/schema/test_template/common/default_job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/common/default_job_status_retrieval_strategy.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .default_job_status_retrieval_strategy import DefaultJobStatusRetrievalStrategy
-from .slurm_job_id_retrieval_strategy import SlurmJobIdRetrievalStrategy
-from .standalone_job_id_retrieval_strategy import StandaloneJobIdRetrievalStrategy
 
-__all__ = [
-    "DefaultJobStatusRetrievalStrategy",
-    "SlurmJobIdRetrievalStrategy",
-    "StandaloneJobIdRetrievalStrategy",
-]
+from cloudai._core.job_status_result import JobStatusResult
+from cloudai._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
+
+
+class DefaultJobStatusRetrievalStrategy(JobStatusRetrievalStrategy):
+    """
+    Dummy strategy for retrieving job statuses.
+
+    This strategy is used in scenarios where job status retrieval logic is not required or is yet to be implemented.
+    It always returns a success result, indicating that the job has successfully completed.
+    """
+
+    def get_job_status(self, output_path: str) -> JobStatusResult:
+        return JobStatusResult(is_successful=True)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,7 @@ from cloudai._core.base_installer import BaseInstaller
 from cloudai._core.base_runner import BaseRunner
 from cloudai._core.base_system_parser import BaseSystemParser
 from cloudai._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
+from cloudai._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from cloudai._core.registry import Registry
 from cloudai._core.report_generation_strategy import ReportGenerationStrategy
 from cloudai._core.system import System
@@ -115,6 +116,10 @@ class MyJobIdRetrievalStrategy(JobIdRetrievalStrategy):
     pass
 
 
+class MyJobStatusRetrievalStrategy(JobStatusRetrievalStrategy):
+    pass
+
+
 class TestRegistry__StrategiesMap:
     """This test verifies Registry class functionality.
 
@@ -126,6 +131,7 @@ class TestRegistry__StrategiesMap:
         registry.add_strategy(MyStrategy, [MySystem], [MyTestTemplate], MyStrategy)
         registry.add_strategy(MyReportGenerationStrategy, [MySystem], [MyTestTemplate], MyReportGenerationStrategy)
         registry.add_strategy(MyJobIdRetrievalStrategy, [MySystem], [MyTestTemplate], MyJobIdRetrievalStrategy)
+        registry.add_strategy(MyJobStatusRetrievalStrategy, [MySystem], [MyTestTemplate], MyJobStatusRetrievalStrategy)
 
         assert registry.strategies_map[(MyStrategy, MySystem, MyTestTemplate)] == MyStrategy
         assert (
@@ -133,6 +139,10 @@ class TestRegistry__StrategiesMap:
             == MyReportGenerationStrategy
         )
         assert registry.strategies_map[(MyJobIdRetrievalStrategy, MySystem, MyTestTemplate)] == MyJobIdRetrievalStrategy
+        assert (
+            registry.strategies_map[(MyJobStatusRetrievalStrategy, MySystem, MyTestTemplate)]
+            == MyJobStatusRetrievalStrategy
+        )
 
     def test_add_strategy_duplicate(self, registry: Registry):
         with pytest.raises(ValueError) as exc_info:
@@ -148,7 +158,7 @@ class TestRegistry__StrategiesMap:
             registry.update_strategy((str, MySystem, MyTestTemplate), MyStrategy)  # pyright: ignore
         err = (
             "Invalid strategy interface type, should be subclass of 'TestTemplateStrategy' or "
-            "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy'."
+            "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy' or 'JobStatusRetrievalStrategy'."
         )
         assert err in str(exc_info.value)
 


### PR DESCRIPTION
## Summary
* This PR has been introduced to identify job completion status after each test.
  * This PR introduces a new strategy called JobStatusRetrievalStrategy.
  * By default, all tests use DefaultJobStatusRetrievalStrategy, which always returns True.
  * If a job fails, the base runner identifies it and raises an exception. This PR also introduces JobFailureError for this purpose.

## Test Plan
* CI pipelines passing.
* Tests were updated to accommodate the new strategy.