### PR TITLE
Bump package version to v0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloudai"
-version = "0.6"
+version = "0.7"
 dependencies = [
     "bokeh==3.4.1",
     "pandas==2.2.1",


### PR DESCRIPTION
## Summary
Bump package version to v0.7. Otherwise it still reports itself as v0.6.

## Test Plan
—

## Additional Notes
—
