### PR TITLE
Fix ci_tools/check_copyright_headers.py and add missing copyright headers

### DIFF
--- a/ci_tools/check_copyright_headers.py
+++ b/ci_tools/check_copyright_headers.py
@@ -87,7 +87,7 @@ def main(directories: List[str], header: str):
 
 
 if __name__ == "__main__":
-    dirs_to_check = ["cloudai", "ci_tools"]
+    dirs_to_check = ["src", "ci_tools"]
     copyright_header = """\
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #

--- a/src/cloudai/_core/__init__.py
+++ b/src/cloudai/_core/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict, List, Tuple, Type, Union
 
 from .base_installer import BaseInstaller

--- a/src/cloudai/installer/__init__.py
+++ b/src/cloudai/installer/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/cloudai/runner/__init__.py
+++ b/src/cloudai/runner/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
## Summary
Fix ci_tools/check_copyright_headers.py and add missing copyright headers

## Test Plan
CI pipelines passing.