### PR TITLE
Cast `num_nodes` to int in TestScenarioParser to ensure correct data type

### DIFF
--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -122,7 +122,7 @@ class TestScenarioParser:
         test = copy.deepcopy(self.test_mapping[test_name])
         test.test_template = self.test_mapping[test_name].test_template
         test.section_name = section
-        test.num_nodes = test_info.get("num_nodes", 1)
+        test.num_nodes = int(test_info.get("num_nodes", 1))
         test.nodes = test_info.get("nodes", [])
         return test
 


### PR DESCRIPTION
## Summary
Cast `num_nodes` to int in TestScenarioParser to ensure correct data type.

Error in `main`
```
...
Traceback (most recent call last):
...
    sys.exit(main())
             ^^^^^^
  File "/home/theo/cloudai/src/cloudai/__main__.py", line 229, in main
    handle_dry_run_and_run(args)
  File "/home/theo/cloudai/src/cloudai/__main__.py", line 179, in handle_dry_run_and_run
    asyncio.run(runner.run())
  File "/home/theo/miniconda3/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/theo/cloudai/src/cloudai/_core/runner.py", line 75, in run
    await self.runner.run()
  File "/home/theo/cloudai/src/cloudai/_core/base_runner.py", line 155, in run
    await self.submit_test(test)
  File "/home/theo/cloudai/src/cloudai/_core/base_runner.py", line 171, in submit_test
    job = self._submit_test(test)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/cloudai/src/cloudai/runner/slurm/slurm_runner.py", line 72, in _submit_test
    exec_cmd = test.gen_exec_command(job_output_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/cloudai/src/cloudai/_core/test.py", line 140, in gen_exec_command
    return self.test_template.gen_exec_command(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/cloudai/src/cloudai/_core/test_template.py", line 139, in gen_exec_command
    return self.command_gen_strategy.gen_exec_command(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/cloudai/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py", line 43, in gen_exec_command
    per_gpu_combine_threshold = int(combine_threshold_bytes / (int(final_cmd_args["gpus_per_node"]) * num_nodes))
                                    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Test Plan
Ran the same command, and it works.
```
...
All test scenario results stored at: /home/theo/cloudai_results/2024-05-31_15-07-00
All test scenario execution attempts are complete. Please review the 'debug.log' file to confirm successful completion or to identify any issues.
```