### PR TITLE
Fix install path

### DIFF
--- a/src/cloudai/_core/test_template_strategy.py
+++ b/src/cloudai/_core/test_template_strategy.py
@@ -47,7 +47,6 @@ class TestTemplateStrategy:
             cmd_args (Dict[str, Any]): Default command-line arguments.
         """
         self.system = system
-        self.install_path = ""
         self.env_vars = env_vars
         self.cmd_args = cmd_args
         self.default_env_vars = self._construct_default_env_vars()

--- a/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
@@ -30,9 +30,10 @@ class SlurmInstallStrategy(InstallStrategy):
 
     def __init__(
         self,
-        system: System,
+        system: SlurmSystem,
         env_vars: Dict[str, Any],
         cmd_args: Dict[str, Any],
     ) -> None:
         super().__init__(system, env_vars, cmd_args)
-        self.slurm_system = cast(SlurmSystem, self.system)
+        self.slurm_system = system
+        self.install_path = self.slurm_system.install_path


### PR DESCRIPTION
## Summary
Fix a bug where in mode install, cloudAI ignores my install path provided in system schema

## Test Plan
python ./cloudaix --mode install --system_config_path conf/v0.6/general/system/israel_1.toml
python ./cloudaix.py --mode run --system_config_path conf/v0.6/general/system/israel_1.toml --test_scenario_path conf/v0.6/general/test_scenario/nccl_test.toml

## Additional Notes
create a similar mechanism to the one in src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
