### PR TITLE
Support empty queues in sinfo

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -591,6 +591,8 @@ class SlurmSystem(System):
             if not line.strip():
                 continue
             parts = line.split()
+            if len(parts) < 6:
+                continue
             partition, _, _, _, state, nodelist = parts[:6]
             partition = partition.rstrip("*")
             node_names = self.parse_node_list(nodelist)

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -47,6 +47,7 @@ def test_parse_sinfo_output(slurm_system):
     main    up    3:00:00      2   resv node-[034-035]
     main    up    3:00:00     24  alloc node-[033,037-044,047-058,060,063-064]
     backup    up   12:00:00     8  idle node[01-08]
+    empty_queue up infinite     0    n/a
     """
     node_user_map = {
         "": "user1",


### PR DESCRIPTION
## Summary
Support empty queues in sinfo

Error before bugfix.
```
        def parse_sinfo_output(self, sinfo_output: str, node_user_map: Dict[str, str]) -> None:
            """                                                                       
            Parse the output from the 'sinfo' command to update node states.
                                    
            Args:                
                sinfo_output (str): The output from the sinfo command.
                node_user_map (dict): A dictionary mapping node names to users.
            """                                                                       
            for line in sinfo_output.split("\n")[1:]:  # Skip the header line
                if not line.strip():                                                  
                    continue                                                          
                parts = line.split()
>               partition, _, _, _, state, nodelist = parts[:6]
E               ValueError: not enough values to unpack (expected 6, got 5)
```

## Test Plan
Updated a test case to cover empty queues.