### PR TITLE
Pass install_path to SlurmInstallStrategy

### DIFF
--- a/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
@@ -38,6 +38,7 @@ class SlurmInstallStrategy(InstallStrategy):
     ) -> None:
         super().__init__(system, env_vars, cmd_args)
         self.slurm_system = cast(SlurmSystem, self.system)
+        self.install_path = self.slurm_system.install_path
         self.docker_image_cache_manager = DockerImageCacheManager(
             self.slurm_system.install_path, self.slurm_system.cache_docker_images_locally
         )

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+from cloudai.systems import SlurmSystem
+from cloudai.systems.slurm import SlurmNode, SlurmNodeState
+from cloudai.systems.slurm.strategy import SlurmInstallStrategy
+
+
+@pytest.fixture
+def slurm_system(tmp_path: Path) -> SlurmSystem:
+    slurm_system = SlurmSystem(
+        name="TestSystem",
+        install_path=str(tmp_path / "install"),
+        output_path=str(tmp_path / "output"),
+        default_partition="main",
+        partitions={
+            "main": [
+                SlurmNode(name="node1", partition="main", state=SlurmNodeState.IDLE),
+                SlurmNode(name="node2", partition="main", state=SlurmNodeState.IDLE),
+                SlurmNode(name="node3", partition="main", state=SlurmNodeState.IDLE),
+                SlurmNode(name="node4", partition="main", state=SlurmNodeState.IDLE),
+            ]
+        },
+    )
+    Path(slurm_system.install_path).mkdir()
+    Path(slurm_system.output_path).mkdir()
+    return slurm_system
+
+
+@pytest.fixture
+def slurm_install_strategy(slurm_system: SlurmSystem) -> SlurmInstallStrategy:
+    env_vars = {"TEST_VAR": "VALUE"}
+    cmd_args = {"docker_image_url": {"default": "http://example.com/docker_image"}}
+    strategy = SlurmInstallStrategy(slurm_system, env_vars, cmd_args)
+    return strategy
+
+
+def test_install_path_attribute(slurm_install_strategy: SlurmInstallStrategy, slurm_system: SlurmSystem):
+    assert slurm_install_strategy.install_path == slurm_system.install_path


### PR DESCRIPTION
## Summary
Pass install_path to SlurmInstallStrategy. Issue identified and fixed by @lappazos at https://github.com/NVIDIA/cloudai/pull/63

## Test Plan
**1. Run on a real system.**
Before fix
```
$ cloudai --mode run --system_config_path conf/v0.6/general/system/... --test_scenario_path conf/v0.6/general/test_scenario/nccl_test.toml
Cloud AI has not been installed. Please run install mode first.
Some test templates are not installed.
NeMoLauncher: Not installed
```

After fix
```
$ cloudai --mode run --system_config_path conf/v0.6/general/system/... --test_scenario_path conf/v0.6/general/test_scenario/nccl_test.toml
Test Scenario: nccl-test

Section Name: Tests.1
  Test Name: nccl_test_all_reduce
  Description: all_reduce
  No dependencies
```
**2. Unit tests**
Added test cases.