### PR TITLE
Use DockerImageCacheManager in CommandGenStrategy

### DIFF
--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -47,17 +47,6 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
-    def get_docker_image_path(self, cmd_args: Dict[str, str]) -> str:
-        if os.path.isfile(cmd_args["docker_image_url"]):
-            image_path = cmd_args["docker_image_url"]
-        else:
-            image_path = os.path.join(
-                self.install_path,
-                NcclTestSlurmInstallStrategy.SUBDIR_PATH,
-                NcclTestSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
-            )
-        return image_path
-
     def _parse_slurm_args(
         self,
         job_name_prefix: str,
@@ -68,7 +57,11 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     ) -> Dict[str, Any]:
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, num_nodes, nodes)
 
-        image_path = self.get_docker_image_path(cmd_args)
+        image_path = self.docker_image_cache_manager.ensure_docker_image(
+            self.docker_image_url,
+            NcclTestSlurmInstallStrategy.SUBDIR_PATH,
+            NcclTestSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
+        ).docker_image_path
 
         container_mounts = ""
         if "NCCL_TOPO_FILE" in env_vars and "DOCKER_NCCL_TOPO_FILE" in env_vars:

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -75,7 +75,11 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         else:
             self.final_cmd_args["training.trainer.num_nodes"] = num_nodes
 
-        self.set_container_arg()
+        self.final_cmd_args["container"] = self.docker_image_cache_manager.ensure_docker_image(
+            self.docker_image_url,
+            NeMoLauncherSlurmInstallStrategy.SUBDIR_PATH,
+            NeMoLauncherSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
+        ).docker_image_path
 
         del self.final_cmd_args["repository_url"]
         del self.final_cmd_args["repository_commit_hash"]
@@ -95,16 +99,6 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         full_cmd = f"{env_vars_str} {full_cmd}" if env_vars_str else full_cmd
 
         return full_cmd.strip()
-
-    def set_container_arg(self) -> None:
-        if os.path.isfile(self.final_cmd_args["docker_image_url"]):
-            self.final_cmd_args["container"] = self.final_cmd_args["docker_image_url"]
-        else:
-            self.final_cmd_args["container"] = os.path.join(
-                self.install_path,
-                NeMoLauncherSlurmInstallStrategy.SUBDIR_PATH,
-                NeMoLauncherSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
-            )
 
     def _handle_special_keys(self, key: str, value: Any, launcher_path: str, output_path: str) -> Any:
         """

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from typing import Any, Dict, List
 
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
@@ -57,15 +56,13 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     ) -> Dict[str, Any]:
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, num_nodes, nodes)
 
-        image_path = os.path.join(
-            self.install_path,
-            UCCTestSlurmInstallStrategy.SUBDIR_PATH,
-            UCCTestSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
-        )
-
         base_args.update(
             {
-                "image_path": image_path,
+                "image_path": self.docker_image_cache_manager.ensure_docker_image(
+                    self.docker_image_url,
+                    UCCTestSlurmInstallStrategy.SUBDIR_PATH,
+                    UCCTestSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
+                ).docker_image_path,
             }
         )
 

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List
 
 from cloudai import CommandGenStrategy
 from cloudai.systems import SlurmSystem
+from cloudai.util.docker_image_cache_manager import DockerImageCacheManager
 
 
 class SlurmCommandGenStrategy(CommandGenStrategy):
@@ -48,6 +49,17 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         self.slurm_system = system
         self.install_path = self.slurm_system.install_path
         self.default_env_vars.update(self.slurm_system.global_env_vars)
+
+        self.docker_image_cache_manager = DockerImageCacheManager(
+            self.slurm_system.install_path,
+            self.slurm_system.cache_docker_images_locally,
+            self.slurm_system.default_partition,
+        )
+        docker_image_url_info = self.cmd_args.get("docker_image_url")
+        if docker_image_url_info is not None:
+            self.docker_image_url = docker_image_url_info.get("default")
+        else:
+            self.docker_image_url = ""
 
     def _format_env_vars(self, env_vars: Dict[str, Any]) -> str:
         """

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from cloudai.schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 from cloudai.schema.test_template.nemo_launcher.slurm_command_gen_strategy import (
     REQUIRE_ENV_VARS,
     NeMoLauncherSlurmCommandGenStrategy,
@@ -97,48 +96,6 @@ def test_only_nodes(strategy_fixture: SlurmCommandGenStrategy):
     slurm_args = strategy_fixture._parse_slurm_args(job_name_prefix, env_vars, cmd_args, num_nodes, nodes)
 
     assert slurm_args["num_nodes"] == len(nodes)
-
-
-class TestNcclTestSlurmCommandGenStrategy__GetDockerImagePath:
-    @pytest.fixture
-    def nccl_slurm_cmd_gen_strategy_fixture(self, slurm_system: SlurmSystem) -> NcclTestSlurmCommandGenStrategy:
-        env_vars = {"TEST_VAR": "VALUE"}
-        cmd_args = {"test_arg": "test_value"}
-        strategy = NcclTestSlurmCommandGenStrategy(slurm_system, env_vars, cmd_args)
-        return strategy
-
-    def test_cmd_arg_file_doesnt_exist(self, nccl_slurm_cmd_gen_strategy_fixture: NcclTestSlurmCommandGenStrategy):
-        cmd_args = {"docker_image_url": f"{nccl_slurm_cmd_gen_strategy_fixture.install_path}/docker_image"}
-        image_path = nccl_slurm_cmd_gen_strategy_fixture.get_docker_image_path(cmd_args)
-        assert image_path == f"{nccl_slurm_cmd_gen_strategy_fixture.install_path}/nccl-test/nccl_test.sqsh"
-
-    def test_cmd_arg_file_exists(self, nccl_slurm_cmd_gen_strategy_fixture: NcclTestSlurmCommandGenStrategy):
-        cmd_args = {"docker_image_url": f"{nccl_slurm_cmd_gen_strategy_fixture.install_path}/docker_image"}
-        Path(cmd_args["docker_image_url"]).touch()
-        image_path = nccl_slurm_cmd_gen_strategy_fixture.get_docker_image_path(cmd_args)
-        assert image_path == cmd_args["docker_image_url"]
-
-
-class TestNeMoLauncherSlurmCommandGenStrategy__SetContainerArg:
-    @pytest.fixture
-    def nemo_cmd_gen(self, slurm_system: SlurmSystem) -> NeMoLauncherSlurmCommandGenStrategy:
-        env_vars = {"TEST_VAR": "VALUE"}
-        cmd_args = {"test_arg": "test_value"}
-        strategy = NeMoLauncherSlurmCommandGenStrategy(slurm_system, env_vars, cmd_args)
-        return strategy
-
-    def test_docker_image_url_is_not_file(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
-        nemo_cmd_gen.final_cmd_args["docker_image_url"] = f"{nemo_cmd_gen.install_path}/docker_image"
-        nemo_cmd_gen.set_container_arg()
-        assert (
-            nemo_cmd_gen.final_cmd_args["container"] == f"{nemo_cmd_gen.install_path}/NeMo-Launcher/nemo_launcher.sqsh"
-        )
-
-    def test_docker_image_url_is_file(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
-        nemo_cmd_gen.final_cmd_args["docker_image_url"] = f"{nemo_cmd_gen.install_path}/docker_image"
-        Path(nemo_cmd_gen.final_cmd_args["docker_image_url"]).touch()
-        nemo_cmd_gen.set_container_arg()
-        assert nemo_cmd_gen.final_cmd_args["container"] == nemo_cmd_gen.final_cmd_args["docker_image_url"]
 
 
 class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:


### PR DESCRIPTION
## Summary
DockerImageCacheManager is used in CloudAI to optionally cache Docker images. While it has been used in InstallStrategy, it was missing in CommandGenStrategy. This caused the commands generated by CommandGenStrategy to not properly reflect the caching option or path. This PR fixes the bug by integrating DockerImageCacheManager into CommandGenStrategy.

## Test Plan
Tested on a real system manually.

**1. NCCL test**
```
2024-06-05 18:32:44,030 - INFO - Executing command for test Tests.1: sbatch ... cloudai_sbatch_script.sh
```
```
srun \
--mpi=pmix \
--container-image=[DOCKER URL] \
/usr/local/bin/all_reduce_perf_mpi \
--nthreads 1 \
--ngpus 1 \
--minbytes 128 \
--maxbytes 16G \
--stepbytes 1M \
--op sum \
--datatype float \
--root 0 \
--iters 100 \
--warmup_iters 50 \
--agg_iters 1 \
--average 1 \
--parallel_init 0 \
--check 1 \
--blocking 0 \
--cudagraph 0 \
--stepfactor 2
```

**2. UCC Test**
```
2024-06-05 18:32:44,030 - INFO - Executing command for test Tests.1: sbatch ... cloudai_sbatch_script.sh
```
```
srun \
--mpi=pmix \
--container-image=[DOCKER URL] \
/opt/hpcx/ucc/bin/ucc_perftest \
-c alltoall \
-b 1 \
-e 8M \
-m cuda \
-F
```

**3. NeMo Launcher**
```
2024-06-05 18:43:47,990 - INFO - Executing command for test Tests.1: ... container=[DOCKER URL]
```