### PR TITLE
Handle missing subdirectories and pass partition name dynamically in DockerImageCacheManager

### DIFF
--- a/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
@@ -40,7 +40,9 @@ class SlurmInstallStrategy(InstallStrategy):
         self.slurm_system = cast(SlurmSystem, self.system)
         self.install_path = self.slurm_system.install_path
         self.docker_image_cache_manager = DockerImageCacheManager(
-            self.slurm_system.install_path, self.slurm_system.cache_docker_images_locally
+            self.slurm_system.install_path,
+            self.slurm_system.cache_docker_images_locally,
+            self.slurm_system.default_partition,
         )
         docker_image_url_info = self.cmd_args.get("docker_image_url")
         if docker_image_url_info is not None:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -213,10 +213,10 @@ class DockerImageCacheManager:
             return DockerImageCacheResult(False, "", f"No permission to write in install path {self.install_path}.")
 
         if not os.path.exists(subdir_path):
-            return DockerImageCacheResult(False, "", f"Subdirectory path {subdir_path} does not exist.")
-
-        if not os.access(subdir_path, os.W_OK):
-            return DockerImageCacheResult(False, "", f"No permission to write in subdirectory path {subdir_path}.")
+            try:
+                os.makedirs(subdir_path)
+            except OSError as e:
+                return DockerImageCacheResult(False, "", f"Failed to create subdirectory {subdir_path}. Error: {e}")
 
         enroot_import_cmd = (
             f"srun --export=ALL --partition=default "

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -107,11 +107,13 @@ class DockerImageCacheManager:
     Attributes
         install_path (str): The base installation path.
         cache_docker_images_locally (bool): Whether to cache Docker image files locally.
+        partition_name (str): The partition name to use in the srun command.
     """
 
-    def __init__(self, install_path: str, cache_docker_images_locally: bool) -> None:
+    def __init__(self, install_path: str, cache_docker_images_locally: bool, partition_name: str) -> None:
         self.install_path = install_path
         self.cache_docker_images_locally = cache_docker_images_locally
+        self.partition_name = partition_name
 
     def ensure_docker_image(
         self, docker_image_url: str, subdir_name: str, docker_image_filename: str
@@ -219,7 +221,7 @@ class DockerImageCacheManager:
                 return DockerImageCacheResult(False, "", f"Failed to create subdirectory {subdir_path}. Error: {e}")
 
         enroot_import_cmd = (
-            f"srun --export=ALL --partition=default "
+            f"srun --export=ALL --partition={self.partition_name} "
             f"enroot import -o {docker_image_path} docker://{docker_image_url}"
         )
 


### PR DESCRIPTION
## Summary
This PR addresses two key issues in the `DockerImageCacheManager`:

1. **Handling Missing Subdirectories**:
   - Updated the `cache_docker_image` method to create the necessary subdirectory if it does not exist. This ensures that the caching process does not fail due to missing subdirectories.

2. **Passing Partition Name Dynamically**:
   - Updated the `DockerImageCacheManager` to accept a partition name during initialization and use it in the `enroot import` command. Removed the incorrect default partition keyword handling to improve command compatibility and functionality in various environments.

Additionally, the unit tests for `DockerImageCacheManager` have been updated to reflect these changes, including new test cases for the creation of missing subdirectories and the dynamic use of the partition name in the `enroot import` command.

## Test Plan
**1. Added unit tests.**
**2. Ran on a real system**
```
$ python ./cloudaix.py --mode install --system_config_path conf/v0.6/general/system/...
srun: job 142418 queued and waiting for resources
srun: job 142418 has been allocated resources
[INFO] Querying registry for permission grant
[INFO] Querying registry for permission grant
[INFO] Authenticating with user: $oauthtoken
[INFO] Using credentials from file: /labhome/theo/.config/enroot/.credentials
[INFO] Authenticating with user: $oauthtoken
[INFO] Using credentials from file: /labhome/theo/.config/enroot/.credentials
[INFO] Authentication succeeded
[INFO] Fetching image manifest list
[INFO] Authentication succeeded
[INFO] Fetching image manifest list
[INFO] Fetching image manifest
[INFO] Fetching image manifest
[INFO] Found all layers in cache
[INFO] Extracting image layers...
[INFO] Downloading 52 missing layers...
```