### PR TITLE
Use logging.config and do not pass CLI args as a parameter

### DIFF
--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -221,7 +221,7 @@ def handle_dry_run_and_run(
             logging.error(result)
             exit(1)
 
-    test_scenario.pretty_print()
+    logging.info(test_scenario.pretty_print())
 
     runner = Runner(mode, system, test_scenario)
     asyncio.run(runner.run())

--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -15,8 +15,10 @@
 import argparse
 import asyncio
 import logging
-import os
+import logging.config
 import sys
+from pathlib import Path
+from typing import Optional
 
 from cloudai import Installer, Parser, ReportGenerator, Runner
 
@@ -33,12 +35,37 @@ def setup_logging(log_file: str, log_level: str) -> None:
     if not isinstance(numeric_level, int):
         raise ValueError(f"Invalid log level: {log_level}")
 
-    logging.basicConfig(
-        filename=log_file,
-        level=numeric_level,
-        format="%(asctime)s - %(levelname)s - %(message)s",
-        filemode="w",
-    )
+    LOGGING_CONFIG = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "standard": {"format": "%(asctime)s - %(levelname)s - %(message)s"},
+            "short": {"format": "[%(levelname)s] %(message)s"},
+        },
+        "handlers": {
+            "default": {
+                "level": log_level.upper(),
+                "formatter": "short",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+            "debug_file": {
+                "level": "DEBUG",
+                "formatter": "standard",
+                "class": "logging.FileHandler",
+                "filename": log_file,
+                "mode": "w",
+            },
+        },
+        "loggers": {
+            "": {
+                "handlers": ["default", "debug_file"],
+                "level": "DEBUG",
+                "propagate": False,
+            },
+        },
+    }
+    logging.config.dictConfig(LOGGING_CONFIG)
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -100,22 +127,26 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def handle_install_and_uninstall(args: argparse.Namespace) -> None:
+def handle_install_and_uninstall(
+    mode: str, system_config_path: Path, test_template_path: Path, output_path: Optional[Path] = None
+) -> None:
     """
     Manage the installation or uninstallation process for CloudAI.
 
     Based on user-specified mode, utilizing the Installer and Parser classes.
 
     Args:
-        args (argparse.Namespace): Parsed command-line arguments containing
-        user preferences.
+        mode (str): The mode of operation (e.g., install, uninstall).
+        system_config_path (Path): The path to the system configuration file.
+        test_template_path (Path): The path to the test template configuration directory.
+        output_path (Optional[Path]): The path to the output directory.
     """
     logging.info("Starting configuration parsing")
-    parser = Parser(args.system_config_path, args.test_template_path)
+    parser = Parser(str(system_config_path), str(test_template_path))
     system, test_templates = parser.parse_system_and_templates()
 
-    if args.output_path:
-        system.output_path = os.path.abspath(args.output_path)
+    if output_path:
+        system.output_path = str(output_path.absolute())
 
     system.update()
 
@@ -124,45 +155,56 @@ def handle_install_and_uninstall(args: argparse.Namespace) -> None:
 
     installer = Installer(system)
 
-    if args.mode == "install":
+    if mode == "install":
         logging.info("Installing test templates.")
         if installer.is_installed(test_templates):
-            print("CloudAI is already installed.")
+            logging.info("CloudAI is already installed.")
         else:
             result = installer.install(test_templates)
             if not result:
-                print(result)
-                sys.exit(1)
+                logging.error(result)
+                exit(1)
 
-    elif args.mode == "uninstall":
+    elif mode == "uninstall":
         logging.info("Uninstalling test templates.")
         result = installer.uninstall(test_templates)
         if not result:
-            print(result)
+            logging.error(result)
             sys.exit(1)
 
 
-def handle_dry_run_and_run(args: argparse.Namespace) -> None:
+def handle_dry_run_and_run(
+    mode: str,
+    system_config_path: Path,
+    test_template_path: Path,
+    test_path: Path,
+    test_scenario_path: Optional[Path] = None,
+    output_path: Optional[Path] = None,
+) -> None:
     """
     Execute the dry-run or run modes for CloudAI.
 
     Includes parsing configurations, verifying installations, and executing test scenarios.
 
     Args:
-        args (argparse.Namespace): Parsed command-line arguments containing
-        user preferences.
+        mode (str): The mode of operation (e.g., dry-run, run).
+        system_config_path (Path): The path to the system configuration file.
+        test_template_path (Path): The path to the test template configuration directory.
+        test_path (Path): The path to the test configuration directory.
+        test_scenario_path (Optional[Path]): The path to the test scenario file.
+        output_path (Optional[Path]): The path to the output directory.
     """
     logging.info("Starting configuration parsing")
     parser = Parser(
-        args.system_config_path,
-        args.test_template_path,
-        args.test_path,
-        args.test_scenario_path,
+        str(system_config_path),
+        str(test_template_path),
+        str(test_path),
+        str(test_scenario_path) if test_scenario_path else None,
     )
     system, test_templates, test_scenario = parser.parse()
 
-    if args.output_path:
-        system.output_path = os.path.abspath(args.output_path)
+    if output_path:
+        system.output_path = str(output_path.absolute())
 
     system.update()
 
@@ -170,24 +212,24 @@ def handle_dry_run_and_run(args: argparse.Namespace) -> None:
     logging.info(f"Scheduler: {system.scheduler}")
     logging.info(f"Test Scenario Name: {test_scenario.name}")
 
-    if args.mode == "run":
+    if mode == "run":
         logging.info("Checking if test templates are installed.")
         installer = Installer(system)
         result = installer.is_installed(test_templates)
         if not result:
-            print("CloudAI has not been installed. Please run install mode first.")
-            print(result)
-            sys.exit(1)
+            logging.error("CloudAI has not been installed. Please run install mode first.")
+            logging.error(result)
+            exit(1)
 
     test_scenario.pretty_print()
 
-    runner = Runner(args.mode, system, test_scenario)
+    runner = Runner(mode, system, test_scenario)
     asyncio.run(runner.run())
 
-    print(f"All test scenario results stored at: {runner.runner.output_path}")
+    logging.info(f"All test scenario results stored at: {runner.runner.output_path}")
 
-    if args.mode == "run":
-        print(
+    if mode == "run":
+        logging.info(
             "All test scenario execution attempts are complete. Please review"
             " the 'debug.log' file to confirm successful completion or to"
             " identify any issues."
@@ -197,27 +239,36 @@ def handle_dry_run_and_run(args: argparse.Namespace) -> None:
         generator.generate_report(test_scenario)
 
 
-def handle_generate_report(args: argparse.Namespace) -> None:
+def handle_generate_report(
+    system_config_path: Path,
+    test_template_path: Path,
+    test_path: Path,
+    output_path: Path,
+    test_scenario_path: Optional[Path] = None,
+) -> None:
     """
     Generate a report based on the existing configuration and test results.
 
     Args:
-        args (argparse.Namespace): Parsed command-line arguments containing
-        user preferences.
+        system_config_path (Path): The path to the system configuration file.
+        test_template_path (Path): The path to the test template configuration directory.
+        test_path (Path): The path to the test configuration directory.
+        output_path (Path): The path to the output directory.
+        test_scenario_path (Optional[Path]): The path to the test scenario file.
     """
     logging.info("Generating report based on system and test templates")
     parser = Parser(
-        args.system_config_path,
-        args.test_template_path,
-        args.test_path,
-        args.test_scenario_path,
+        str(system_config_path),
+        str(test_template_path),
+        str(test_path),
+        str(test_scenario_path),
     )
     system, test_templates, test_scenario = parser.parse()
 
-    generator = ReportGenerator(args.output_path)
+    generator = ReportGenerator(str(output_path))
     generator.generate_report(test_scenario)
 
-    print("Report generation completed.")
+    logging.info("Report generation completed.")
 
 
 def main() -> None:
@@ -225,16 +276,23 @@ def main() -> None:
 
     setup_logging(args.log_file, args.log_level)
 
-    if args.mode == "generate-report" and not args.output_path:
-        print("Error: --output_path is required when mode is generate-report.")
-        sys.exit(1)
+    system_config_path = Path(args.system_config_path)
+    test_template_path = Path(args.test_template_path)
+    test_path = Path(args.test_path)
+    test_scenario_path = Path(args.test_scenario_path) if args.test_scenario_path else None
+    output_path = Path(args.output_path) if args.output_path else None
 
     if args.mode in ["install", "uninstall"]:
-        handle_install_and_uninstall(args)
+        handle_install_and_uninstall(args.mode, system_config_path, test_template_path, output_path=output_path)
     elif args.mode in ["dry-run", "run"]:
-        handle_dry_run_and_run(args)
+        handle_dry_run_and_run(
+            args.mode, system_config_path, test_template_path, test_path, test_scenario_path, output_path
+        )
     elif args.mode == "generate-report":
-        handle_generate_report(args)
+        if not output_path:
+            logging.error("Error: --output_path is required when mode is generate-report.")
+            exit(1)
+        handle_generate_report(system_config_path, test_template_path, test_path, output_path, test_scenario_path)
 
 
 if __name__ == "__main__":

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -128,8 +128,8 @@ class BaseInstaller:
         all_success = all(result == "Success" for result in install_results.values())
         if all_success:
             return InstallStatusResult(True, "All test templates installed successfully.")
-        else:
-            return InstallStatusResult(False, "Some test templates failed to install.", install_results)
+
+        return InstallStatusResult(False, "Some test templates failed to install.", install_results)
 
     def uninstall(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
         """

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -22,8 +22,6 @@ from cloudai._core.install_status_result import InstallStatusResult
 from .system import System
 from .test_template import TestTemplate
 
-logger = logging.getLogger(__name__)
-
 
 class BaseInstaller:
     """
@@ -45,7 +43,7 @@ class BaseInstaller:
             system (System): The system schema object.
         """
         self.system = system
-        logger.info(f"BaseInstaller initialized for {self.system.scheduler}.")
+        logging.info(f"BaseInstaller initialized for {self.system.scheduler}.")
 
     def _is_binary_installed(self, binary_name: str) -> bool:
         """
@@ -57,7 +55,7 @@ class BaseInstaller:
         Returns:
             bool: True if the binary is installed, False otherwise.
         """
-        logger.debug(f"Checking if binary '{binary_name}' is installed.")
+        logging.debug(f"Checking if binary '{binary_name}' is installed.")
         return shutil.which(binary_name) is not None
 
     def _check_prerequisites(self) -> InstallStatusResult:
@@ -69,7 +67,7 @@ class BaseInstaller:
         Returns
             InstallStatusResult: Result containing the status and any error message.
         """
-        logger.info("Checking for common prerequisites.")
+        logging.info("Checking for common prerequisites.")
         return InstallStatusResult(True)
 
     def is_installed(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
@@ -84,7 +82,7 @@ class BaseInstaller:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        logger.info("Verifying installation status of test templates.")
+        logging.info("Verifying installation status of test templates.")
         not_installed = {}
         for test_template in test_templates:
             result = test_template.is_installed()
@@ -106,7 +104,7 @@ class BaseInstaller:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if any.
         """
-        logger.info("Starting installation of test templates.")
+        logging.info("Starting installation of test templates.")
         prerequisites_result = self._check_prerequisites()
         if not prerequisites_result:
             return prerequisites_result
@@ -123,7 +121,7 @@ class BaseInstaller:
                     else:
                         install_results[test_template.name] = result.message
                 except Exception as e:
-                    logger.error(f"Installation failed for {test_template.name}: {e}")
+                    logging.error(f"Installation failed for {test_template.name}: {e}")
                     install_results[test_template.name] = str(e)
 
         all_success = all(result == "Success" for result in install_results.values())
@@ -142,7 +140,7 @@ class BaseInstaller:
         Returns:
             InstallStatusResult: Result containing the uninstallation status and error message if any.
         """
-        logger.info("Uninstalling test templates.")
+        logging.info("Uninstalling test templates.")
         uninstall_results = {}
         with ThreadPoolExecutor() as executor:
             futures = {executor.submit(test_template.uninstall): test_template for test_template in test_templates}
@@ -155,7 +153,7 @@ class BaseInstaller:
                     else:
                         uninstall_results[test_template.name] = result.message
                 except Exception as e:
-                    logger.error(f"Uninstallation failed for {test_template.name}: {e}")
+                    logging.error(f"Uninstallation failed for {test_template.name}: {e}")
                     uninstall_results[test_template.name] = str(e)
 
         all_success = all(result == "Success" for result in uninstall_results.values())

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -22,6 +22,8 @@ from cloudai._core.install_status_result import InstallStatusResult
 from .system import System
 from .test_template import TestTemplate
 
+logger = logging.getLogger(__name__)
+
 
 class BaseInstaller:
     """
@@ -43,8 +45,7 @@ class BaseInstaller:
             system (System): The system schema object.
         """
         self.system = system
-        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
-        self.logger.info(f"BaseInstaller initialized for {self.system.scheduler}.")
+        logger.info(f"BaseInstaller initialized for {self.system.scheduler}.")
 
     def _is_binary_installed(self, binary_name: str) -> bool:
         """
@@ -56,7 +57,7 @@ class BaseInstaller:
         Returns:
             bool: True if the binary is installed, False otherwise.
         """
-        self.logger.debug(f"Checking if binary '{binary_name}' is installed.")
+        logger.debug(f"Checking if binary '{binary_name}' is installed.")
         return shutil.which(binary_name) is not None
 
     def _check_prerequisites(self) -> InstallStatusResult:
@@ -68,7 +69,7 @@ class BaseInstaller:
         Returns
             InstallStatusResult: Result containing the status and any error message.
         """
-        self.logger.info("Checking for common prerequisites.")
+        logger.info("Checking for common prerequisites.")
         return InstallStatusResult(True)
 
     def is_installed(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
@@ -83,7 +84,7 @@ class BaseInstaller:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        self.logger.info("Verifying installation status of test templates.")
+        logger.info("Verifying installation status of test templates.")
         not_installed = {}
         for test_template in test_templates:
             result = test_template.is_installed()
@@ -105,7 +106,7 @@ class BaseInstaller:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if any.
         """
-        self.logger.info("Starting installation of test templates.")
+        logger.info("Starting installation of test templates.")
         prerequisites_result = self._check_prerequisites()
         if not prerequisites_result:
             return prerequisites_result
@@ -122,7 +123,7 @@ class BaseInstaller:
                     else:
                         install_results[test_template.name] = result.message
                 except Exception as e:
-                    self.logger.error(f"Installation failed for {test_template.name}: {e}")
+                    logger.error(f"Installation failed for {test_template.name}: {e}")
                     install_results[test_template.name] = str(e)
 
         all_success = all(result == "Success" for result in install_results.values())
@@ -141,7 +142,7 @@ class BaseInstaller:
         Returns:
             InstallStatusResult: Result containing the uninstallation status and error message if any.
         """
-        self.logger.info("Uninstalling test templates.")
+        logger.info("Uninstalling test templates.")
         uninstall_results = {}
         with ThreadPoolExecutor() as executor:
             futures = {executor.submit(test_template.uninstall): test_template for test_template in test_templates}
@@ -154,7 +155,7 @@ class BaseInstaller:
                     else:
                         uninstall_results[test_template.name] = result.message
                 except Exception as e:
-                    self.logger.error(f"Uninstallation failed for {test_template.name}: {e}")
+                    logger.error(f"Uninstallation failed for {test_template.name}: {e}")
                     uninstall_results[test_template.name] = str(e)
 
         all_success = all(result == "Success" for result in uninstall_results.values())

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -174,8 +174,7 @@ class BaseRunner(ABC):
             self.test_to_job_map[test] = job
         except JobSubmissionError as e:
             logger.error(e)
-            print(e, file=sys.stdout)
-            sys.exit(1)
+            exit(1)
 
     async def delayed_submit_test(self, test: Test, delay: int):
         """

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -30,6 +30,8 @@ from .system import System
 from .test import Test
 from .test_scenario import TestScenario
 
+logger = logging.getLogger(__name__)
+
 
 class BaseRunner(ABC):
     """
@@ -72,8 +74,7 @@ class BaseRunner(ABC):
         self.monitor_interval = system.monitor_interval
         self.jobs: List[BaseJob] = []
         self.test_to_job_map: Dict[Test, BaseJob] = {}
-        self.logger = logging.getLogger(self.__class__.__name__)
-        self.logger.info(f"{self.__class__.__name__} initialized")
+        logger.info(f"{self.__class__.__name__} initialized")
         self.shutting_down = False
         self.register_signal_handlers()
 
@@ -127,17 +128,17 @@ class BaseRunner(ABC):
             None
         """
         self.shutting_down = True
-        self.logger.info(f"Signal {signum} received, shutting down...")
+        logger.info(f"Signal {signum} received, shutting down...")
         asyncio.create_task(self.shutdown())
 
     async def shutdown(self):
         """Gracefully shut down the runner, terminating all outstanding jobs."""
         if not self.jobs:
             return
-        self.logger.info("Terminating all jobs...")
+        logger.info("Terminating all jobs...")
         for job in self.jobs:
             self.kill_job(job)
-        self.logger.info("All jobs have been killed.")
+        logger.info("All jobs have been killed.")
 
         sys.exit(0)
 
@@ -146,7 +147,7 @@ class BaseRunner(ABC):
         if self.shutting_down:
             return
 
-        self.logger.info("Starting test scenario execution.")
+        logger.info("Starting test scenario execution.")
         total_tests = len(self.test_scenario.tests)
         completed_jobs_count = 0
 
@@ -166,13 +167,13 @@ class BaseRunner(ABC):
         Args:
             test (Test): The test to be started.
         """
-        self.logger.info(f"Starting test: {test.section_name}")
+        logger.info(f"Starting test: {test.section_name}")
         try:
             job = self._submit_test(test)
             self.jobs.append(job)
             self.test_to_job_map[test] = job
         except JobSubmissionError as e:
-            self.logger.error(e)
+            logger.error(e)
             print(e, file=sys.stdout)
             sys.exit(1)
 
@@ -184,7 +185,7 @@ class BaseRunner(ABC):
             test (Test): The test to start after a delay.
             delay (int): Delay in seconds before starting the test.
         """
-        self.logger.info(f"Delayed start for test {test.section_name} by {delay} seconds.")
+        logger.info(f"Delayed start for test {test.section_name} by {delay} seconds.")
         await asyncio.sleep(delay)
         await self.submit_test(test)
 
@@ -285,7 +286,7 @@ class BaseRunner(ABC):
         """
         successful_jobs_count = 0
 
-        self.logger.debug("Monitoring jobs.")
+        logger.debug("Monitoring jobs.")
         for job in list(self.jobs):
             if self.is_job_completed(job):
                 if self.mode == "dry-run":
@@ -299,7 +300,7 @@ class BaseRunner(ABC):
                         error_message = (
                             f"Job {job.id} for test {job.test.section_name} failed: {job_status_result.error_message}"
                         )
-                        self.logger.error(error_message)
+                        logger.error(error_message)
                         print(error_message, file=sys.stdout)
                         await self.shutdown()
                         raise JobFailureError(job.test.section_name, error_message, job_status_result.error_message)
@@ -325,13 +326,13 @@ class BaseRunner(ABC):
         Args:
             completed_job (BaseJob): The job that has just been completed.
         """
-        self.logger.info(f"Job completed: {completed_job.test.section_name}")
+        logger.info(f"Job completed: {completed_job.test.section_name}")
         self.jobs.remove(completed_job)
         del self.test_to_job_map[completed_job.test]
         completed_job.increment_iteration()
         if not completed_job.terminated_by_dependency and completed_job.test.has_more_iterations():
             msg = f"Re-running job for iteration {completed_job.test.current_iteration}"
-            self.logger.info(msg)
+            logger.info(msg)
             await self.submit_test(completed_job.test)
         else:
             await self.handle_dependencies(completed_job)
@@ -410,7 +411,7 @@ class BaseRunner(ABC):
             job (BaseJob): The job to be terminated.
             delay (int): Delay in seconds after which the job should be terminated.
         """
-        self.logger.info(f"Scheduling termination of job {job.id} after {delay} seconds.")
+        logger.info(f"Scheduling termination of job {job.id} after {delay} seconds.")
         await asyncio.sleep(delay)
         job.terminated_by_dependency = True
         self.kill_job(job)

--- a/src/cloudai/_core/grader.py
+++ b/src/cloudai/_core/grader.py
@@ -20,6 +20,8 @@ from typing import Dict, List
 from .test import Test
 from .test_scenario import TestScenario
 
+logger = logging.getLogger(__name__)
+
 
 class Grader:
     """
@@ -33,7 +35,6 @@ class Grader:
 
     def __init__(self, output_path: str) -> None:
         self.output_path = output_path
-        self.logger = logging.getLogger(__name__)
 
     def grade(self, test_scenario: TestScenario) -> str:
         """
@@ -56,7 +57,7 @@ class Grader:
         for test in test_scenario.tests:
             section_name = str(test.section_name) if test.section_name else ""
             if not section_name:
-                self.logger.warning(f"Missing section name for test {test.name}")
+                logger.warning(f"Missing section name for test {test.name}")
                 continue
             test_output_dir = os.path.join(self.output_path, section_name)
             perfs = self._get_perfs_from_subdirs(test_output_dir, test)

--- a/src/cloudai/_core/grader.py
+++ b/src/cloudai/_core/grader.py
@@ -20,8 +20,6 @@ from typing import Dict, List
 from .test import Test
 from .test_scenario import TestScenario
 
-logger = logging.getLogger(__name__)
-
 
 class Grader:
     """
@@ -57,7 +55,7 @@ class Grader:
         for test in test_scenario.tests:
             section_name = str(test.section_name) if test.section_name else ""
             if not section_name:
-                logger.warning(f"Missing section name for test {test.name}")
+                logging.warning(f"Missing section name for test {test.name}")
                 continue
             test_output_dir = os.path.join(self.output_path, section_name)
             perfs = self._get_perfs_from_subdirs(test_output_dir, test)

--- a/src/cloudai/_core/parser.py
+++ b/src/cloudai/_core/parser.py
@@ -23,6 +23,8 @@ from .test_scenario_parser import TestScenarioParser
 from .test_template import TestTemplate
 from .test_template_parser import TestTemplateParser
 
+logger = logging.getLogger(__name__)
+
 
 class Parser:
     """
@@ -56,8 +58,7 @@ class Parser:
         self.test_template_path: str = test_template_path
         self.test_path: Optional[str] = test_path
         self.test_scenario_path: Optional[str] = test_scenario_path
-        self.logger = logging.getLogger(__name__ + ".Parser")
-        self.logger.debug("Initialized with system and template paths")
+        logger.debug("Initialized with system and template paths")
 
     def parse_system_and_templates(self) -> Tuple[System, List[TestTemplate]]:
         """
@@ -69,11 +70,11 @@ class Parser:
         """
         system_parser = SystemParser(self.system_config_path)
         system = system_parser.parse()
-        self.logger.debug("Parsed system config")
+        logger.debug("Parsed system config")
 
         test_template_parser = TestTemplateParser(system, self.test_template_path)
         test_templates = test_template_parser.parse_all()
-        self.logger.debug(f"Parsed {len(test_templates)} test templates")
+        logger.debug(f"Parsed {len(test_templates)} test templates")
 
         return system, test_templates
 
@@ -88,22 +89,22 @@ class Parser:
         """
         system_parser = SystemParser(self.system_config_path)
         system = system_parser.parse()
-        self.logger.debug("Parsed system config")
+        logger.debug("Parsed system config")
 
         test_template_parser = TestTemplateParser(system, self.test_template_path)
         test_templates = test_template_parser.parse_all()
         test_template_mapping = {t.name: t for t in test_templates}
-        self.logger.debug(f"Parsed {len(test_templates)} test templates")
+        logger.debug(f"Parsed {len(test_templates)} test templates")
 
         assert self.test_path is not None, "Tests path must be provided for experiments."
         test_parser = TestParser(self.test_path, test_template_mapping)
         tests = test_parser.parse_all()
         test_mapping = {t.name: t for t in tests}
-        self.logger.debug(f"Parsed {len(tests)} tests")
+        logger.debug(f"Parsed {len(tests)} tests")
 
         assert self.test_scenario_path is not None, "Test scenarios path must be provided for experiments."
         test_scenario_parser = TestScenarioParser(self.test_scenario_path, system, test_mapping)
         test_scenario = test_scenario_parser.parse()
-        self.logger.debug("Parsed test scenario")
+        logger.debug("Parsed test scenario")
 
         return system, test_templates, test_scenario

--- a/src/cloudai/_core/parser.py
+++ b/src/cloudai/_core/parser.py
@@ -23,8 +23,6 @@ from .test_scenario_parser import TestScenarioParser
 from .test_template import TestTemplate
 from .test_template_parser import TestTemplateParser
 
-logger = logging.getLogger(__name__)
-
 
 class Parser:
     """
@@ -58,7 +56,7 @@ class Parser:
         self.test_template_path: str = test_template_path
         self.test_path: Optional[str] = test_path
         self.test_scenario_path: Optional[str] = test_scenario_path
-        logger.debug("Initialized with system and template paths")
+        logging.debug("Initialized with system and template paths")
 
     def parse_system_and_templates(self) -> Tuple[System, List[TestTemplate]]:
         """
@@ -70,11 +68,11 @@ class Parser:
         """
         system_parser = SystemParser(self.system_config_path)
         system = system_parser.parse()
-        logger.debug("Parsed system config")
+        logging.debug("Parsed system config")
 
         test_template_parser = TestTemplateParser(system, self.test_template_path)
         test_templates = test_template_parser.parse_all()
-        logger.debug(f"Parsed {len(test_templates)} test templates")
+        logging.debug(f"Parsed {len(test_templates)} test templates")
 
         return system, test_templates
 
@@ -89,22 +87,22 @@ class Parser:
         """
         system_parser = SystemParser(self.system_config_path)
         system = system_parser.parse()
-        logger.debug("Parsed system config")
+        logging.debug("Parsed system config")
 
         test_template_parser = TestTemplateParser(system, self.test_template_path)
         test_templates = test_template_parser.parse_all()
         test_template_mapping = {t.name: t for t in test_templates}
-        logger.debug(f"Parsed {len(test_templates)} test templates")
+        logging.debug(f"Parsed {len(test_templates)} test templates")
 
         assert self.test_path is not None, "Tests path must be provided for experiments."
         test_parser = TestParser(self.test_path, test_template_mapping)
         tests = test_parser.parse_all()
         test_mapping = {t.name: t for t in tests}
-        logger.debug(f"Parsed {len(tests)} tests")
+        logging.debug(f"Parsed {len(tests)} tests")
 
         assert self.test_scenario_path is not None, "Test scenarios path must be provided for experiments."
         test_scenario_parser = TestScenarioParser(self.test_scenario_path, system, test_mapping)
         test_scenario = test_scenario_parser.parse()
-        logger.debug("Parsed test scenario")
+        logging.debug("Parsed test scenario")
 
         return system, test_templates, test_scenario

--- a/src/cloudai/_core/runner.py
+++ b/src/cloudai/_core/runner.py
@@ -19,6 +19,8 @@ from .registry import Registry
 from .system import System
 from .test_scenario import TestScenario
 
+logger = logging.getLogger(__name__)
+
 
 class Runner:
     """
@@ -41,8 +43,7 @@ class Runner:
     _runners = {}
 
     def __init__(self, mode: str, system: System, test_scenario: TestScenario):
-        self.logger = logging.getLogger(__name__ + ".Runner")
-        self.logger.info("Initializing Runner")
+        logger.info("Initializing Runner")
         self.runner = self.create_runner(mode, system, test_scenario)
 
     def create_runner(self, mode: str, system: System, test_scenario: TestScenario) -> BaseRunner:
@@ -64,10 +65,10 @@ class Runner:
         scheduler_type = system.scheduler.lower()
         if scheduler_type not in registry.runners_map:
             msg = f"No runner registered for scheduler: {scheduler_type}"
-            self.logger.error(msg)
+            logger.error(msg)
             raise NotImplementedError(msg)
         runner_class = registry.runners_map[scheduler_type]
-        self.logger.info(f"Creating {runner_class.__name__}")
+        logger.info(f"Creating {runner_class.__name__}")
         return runner_class(mode, system, test_scenario)
 
     async def run(self):

--- a/src/cloudai/_core/runner.py
+++ b/src/cloudai/_core/runner.py
@@ -19,8 +19,6 @@ from .registry import Registry
 from .system import System
 from .test_scenario import TestScenario
 
-logger = logging.getLogger(__name__)
-
 
 class Runner:
     """
@@ -43,7 +41,7 @@ class Runner:
     _runners = {}
 
     def __init__(self, mode: str, system: System, test_scenario: TestScenario):
-        logger.info("Initializing Runner")
+        logging.info("Initializing Runner")
         self.runner = self.create_runner(mode, system, test_scenario)
 
     def create_runner(self, mode: str, system: System, test_scenario: TestScenario) -> BaseRunner:
@@ -65,10 +63,10 @@ class Runner:
         scheduler_type = system.scheduler.lower()
         if scheduler_type not in registry.runners_map:
             msg = f"No runner registered for scheduler: {scheduler_type}"
-            logger.error(msg)
+            logging.error(msg)
             raise NotImplementedError(msg)
         runner_class = registry.runners_map[scheduler_type]
-        logger.info(f"Creating {runner_class.__name__}")
+        logging.info(f"Creating {runner_class.__name__}")
         return runner_class(mode, system, test_scenario)
 
     async def run(self):

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -49,20 +49,21 @@ class TestScenario:
         test_names = ", ".join([test.name for test in self.tests])
         return f"TestScenario(name={self.name}, tests=[{test_names}])"
 
-    def pretty_print(self) -> None:
+    def pretty_print(self) -> str:
         """Print each test in the scenario along with its section name, description, and visualized dependencies."""
-        print(f"Test Scenario: {self.name}")
+        s = f"Test Scenario: {self.name}\n"
         for test in self.tests:
-            print(f"\nSection Name: {test.section_name}")
-            print(f"  Test Name: {test.name}")
-            print(f"  Description: {test.description}")
+            s += f"\nSection Name: {test.section_name}\n"
+            s += f"  Test Name: {test.name}\n"
+            s += f"  Description: {test.description}\n"
             if test.dependencies:
                 for dep_type, dependency in test.dependencies.items():
                     if dependency:
-                        print(
+                        s += (
                             f"  {dep_type.replace('_', ' ').title()}: "
                             f"{dependency.test.section_name}, "
                             f"Time: {dependency.time} seconds"
                         )
             else:
-                print("  No dependencies")
+                s += "  No dependencies"
+        return s

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from typing import Any, Dict, List, Optional
 
 from .command_gen_strategy import CommandGenStrategy
@@ -24,8 +23,6 @@ from .job_status_result import JobStatusResult
 from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
-
-logger = logging.getLogger(__name__)
 
 
 class TestTemplate:

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -94,8 +94,8 @@ class TestTemplate:
         """
         if self.install_strategy is not None:
             return self.install_strategy.is_installed()
-        else:
-            return InstallStatusResult(success=True)
+
+        return InstallStatusResult(success=True)
 
     def install(self) -> InstallStatusResult:
         """
@@ -106,8 +106,8 @@ class TestTemplate:
         """
         if self.install_strategy is not None:
             return self.install_strategy.install()
-        else:
-            return InstallStatusResult(success=True)
+
+        return InstallStatusResult(success=True)
 
     def uninstall(self) -> InstallStatusResult:
         """
@@ -118,8 +118,8 @@ class TestTemplate:
         """
         if self.install_strategy is not None:
             return self.install_strategy.uninstall()
-        else:
-            return InstallStatusResult(success=True)
+
+        return InstallStatusResult(success=True)
 
     def gen_exec_command(
         self,

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -25,6 +25,8 @@ from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
 
+logger = logging.getLogger(__name__)
+
 
 class TestTemplate:
     """
@@ -68,7 +70,6 @@ class TestTemplate:
         self.name = name
         self.env_vars = env_vars
         self.cmd_args = cmd_args
-        self.logger = logging.getLogger(__name__ + ".TestTemplate")
         self.install_strategy: Optional[InstallStrategy] = None
         self.command_gen_strategy: Optional[CommandGenStrategy] = None
         self.job_id_retrieval_strategy: Optional[JobIdRetrievalStrategy] = None

--- a/src/cloudai/_core/test_template_parser.py
+++ b/src/cloudai/_core/test_template_parser.py
@@ -27,8 +27,6 @@ from .system import System
 from .test_template import TestTemplate
 from .test_template_strategy import TestTemplateStrategy
 
-logger = logging.getLogger(__name__)
-
 
 class TestTemplateParser(BaseMultiFileParser):
     """
@@ -90,7 +88,7 @@ class TestTemplateParser(BaseMultiFileParser):
             else:
                 return strategy_type()
 
-        logger.warning(
+        logging.warning(
             f"No {strategy_interface.__name__} found for " f"{type(self).__name__} and " f"{type(self.system).__name__}"
         )
         return None

--- a/src/cloudai/installer/installer.py
+++ b/src/cloudai/installer/installer.py
@@ -21,8 +21,6 @@ from cloudai._core.registry import Registry
 from cloudai._core.system import System
 from cloudai._core.test_template import TestTemplate
 
-logger = logging.getLogger(__name__)
-
 
 class Installer:
     """
@@ -42,7 +40,7 @@ class Installer:
         Args:
             system (System): The system schema object.
         """
-        logger.info("Initializing Installer with system configuration.")
+        logging.info("Initializing Installer with system configuration.")
         self.installer = self.create_installer(system)
 
     @classmethod
@@ -76,7 +74,7 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        logger.info("Checking installation status of components.")
+        logging.info("Checking installation status of components.")
         return self.installer.is_installed(test_templates)
 
     def install(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
@@ -89,7 +87,7 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        logger.info("Installing test templates.")
+        logging.info("Installing test templates.")
         return self.installer.install(test_templates)
 
     def uninstall(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
@@ -102,5 +100,5 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        logger.info("Uninstalling test templates.")
+        logging.info("Uninstalling test templates.")
         return self.installer.uninstall(test_templates)

--- a/src/cloudai/installer/installer.py
+++ b/src/cloudai/installer/installer.py
@@ -21,6 +21,8 @@ from cloudai._core.registry import Registry
 from cloudai._core.system import System
 from cloudai._core.test_template import TestTemplate
 
+logger = logging.getLogger(__name__)
+
 
 class Installer:
     """
@@ -40,8 +42,7 @@ class Installer:
         Args:
             system (System): The system schema object.
         """
-        self.logger = logging.getLogger(__name__ + ".Installer")
-        self.logger.info("Initializing Installer with system configuration.")
+        logger.info("Initializing Installer with system configuration.")
         self.installer = self.create_installer(system)
 
     @classmethod
@@ -75,7 +76,7 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        self.logger.info("Checking installation status of components.")
+        logger.info("Checking installation status of components.")
         return self.installer.is_installed(test_templates)
 
     def install(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
@@ -88,7 +89,7 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        self.logger.info("Installing test templates.")
+        logger.info("Installing test templates.")
         return self.installer.install(test_templates)
 
     def uninstall(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
@@ -101,5 +102,5 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        self.logger.info("Uninstalling test templates.")
+        logger.info("Uninstalling test templates.")
         return self.installer.uninstall(test_templates)

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -86,7 +86,7 @@ class SlurmInstaller(BaseInstaller):
         """Check for the presence of required binaries, raising an error if any are missing."""
         for binary in self.PREREQUISITES:
             if not self._is_binary_installed(binary):
-                raise EnvironmentError(f"Required binary {binary} is not installed.")
+                raise EnvironmentError(f"Required binary '{binary}' is not installed.")
 
     def _check_srun_options(self) -> None:
         """

--- a/src/cloudai/report_generator/report_generator.py
+++ b/src/cloudai/report_generator/report_generator.py
@@ -18,8 +18,6 @@ import os
 from cloudai._core.test import Test
 from cloudai._core.test_scenario import TestScenario
 
-logger = logging.getLogger(__name__)
-
 
 class ReportGenerator:
     """
@@ -51,11 +49,11 @@ class ReportGenerator:
         for test in test_scenario.tests:
             section_name = str(test.section_name) if test.section_name else ""
             if not section_name:
-                logger.warning(f"Missing section name for test {test.name}")
+                logging.warning(f"Missing section name for test {test.name}")
                 continue
             test_output_dir = os.path.join(self.output_path, section_name)
             if not os.path.exists(test_output_dir):
-                logger.warning(f"Directory '{section_name}' not found.")
+                logging.warning(f"Directory '{section_name}' not found.")
                 continue
 
             self._generate_test_report(test_output_dir, test)

--- a/src/cloudai/report_generator/report_generator.py
+++ b/src/cloudai/report_generator/report_generator.py
@@ -18,6 +18,8 @@ import os
 from cloudai._core.test import Test
 from cloudai._core.test_scenario import TestScenario
 
+logger = logging.getLogger(__name__)
+
 
 class ReportGenerator:
     """
@@ -35,7 +37,6 @@ class ReportGenerator:
             output_path (str): Output directory path.
         """
         self.output_path = output_path
-        self.logger = logging.getLogger(__name__)
 
     def generate_report(self, test_scenario: TestScenario) -> None:
         """
@@ -50,11 +51,11 @@ class ReportGenerator:
         for test in test_scenario.tests:
             section_name = str(test.section_name) if test.section_name else ""
             if not section_name:
-                self.logger.warning(f"Missing section name for test {test.name}")
+                logger.warning(f"Missing section name for test {test.name}")
                 continue
             test_output_dir = os.path.join(self.output_path, section_name)
             if not os.path.exists(test_output_dir):
-                self.logger.warning(f"Directory '{section_name}' not found.")
+                logger.warning(f"Directory '{section_name}' not found.")
                 continue
 
             self._generate_test_report(test_output_dir, test)

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -26,8 +26,6 @@ from cloudai.util import CommandShell
 
 from .slurm_job import SlurmJob
 
-logger = logging.getLogger(__name__)
-
 
 class SlurmRunner(BaseRunner):
     """
@@ -70,10 +68,10 @@ class SlurmRunner(BaseRunner):
         Returns:
             SlurmJob: A SlurmJob object
         """
-        logger.info(f"Running test: {test.section_name}")
+        logging.info(f"Running test: {test.section_name}")
         job_output_path = self.get_job_output_path(test)
         exec_cmd = test.gen_exec_command(job_output_path)
-        logger.info(f"Executing command for test {test.section_name}: {exec_cmd}")
+        logging.info(f"Executing command for test {test.section_name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
             stdout, stderr = self.cmd_shell.execute(exec_cmd).communicate()

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import cast
 
 from cloudai._core.base_job import BaseJob
@@ -24,6 +25,8 @@ from cloudai.systems import SlurmSystem
 from cloudai.util import CommandShell
 
 from .slurm_job import SlurmJob
+
+logger = logging.getLogger(__name__)
 
 
 class SlurmRunner(BaseRunner):
@@ -67,10 +70,10 @@ class SlurmRunner(BaseRunner):
         Returns:
             SlurmJob: A SlurmJob object
         """
-        self.logger.info(f"Running test: {test.section_name}")
+        logger.info(f"Running test: {test.section_name}")
         job_output_path = self.get_job_output_path(test)
         exec_cmd = test.gen_exec_command(job_output_path)
-        self.logger.info(f"Executing command for test {test.section_name}: {exec_cmd}")
+        logger.info(f"Executing command for test {test.section_name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
             stdout, stderr = self.cmd_shell.execute(exec_cmd).communicate()

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -25,8 +25,6 @@ from cloudai.util import CommandShell
 
 from .standalone_job import StandaloneJob
 
-logger = logging.getLogger(__name__)
-
 
 class StandaloneRunner(BaseRunner):
     """
@@ -69,10 +67,10 @@ class StandaloneRunner(BaseRunner):
         Returns:
             StandaloneJob: A StandaloneJob object
         """
-        logger.info(f"Running test: {test.section_name}")
+        logging.info(f"Running test: {test.section_name}")
         job_output_path = self.get_job_output_path(test)
         exec_cmd = test.gen_exec_command(job_output_path)
-        logger.info(f"Executing command for test {test.section_name}: {exec_cmd}")
+        logging.info(f"Executing command for test {test.section_name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
             pid = self.cmd_shell.execute(exec_cmd).pid
@@ -114,7 +112,7 @@ class StandaloneRunner(BaseRunner):
 
         s_job = cast(StandaloneJob, job)
         command = f"ps -p {s_job.id}"
-        logger.debug(f"Checking job status with command: {command}")
+        logging.debug(f"Checking job status with command: {command}")
         stdout = self.cmd_shell.execute(command).communicate()[0]
         return str(s_job.id) not in stdout
 
@@ -127,5 +125,5 @@ class StandaloneRunner(BaseRunner):
         """
         s_job = cast(StandaloneJob, job)
         cmd = f"kill -9 {s_job.id}"
-        logger.info(f"Executing termination command for job {s_job.id}: {cmd}")
+        logging.info(f"Executing termination command for job {s_job.id}: {cmd}")
         self.cmd_shell.execute(cmd)

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import cast
 
 from cloudai._core.base_job import BaseJob
@@ -23,6 +24,8 @@ from cloudai._core.test_scenario import TestScenario
 from cloudai.util import CommandShell
 
 from .standalone_job import StandaloneJob
+
+logger = logging.getLogger(__name__)
 
 
 class StandaloneRunner(BaseRunner):
@@ -66,10 +69,10 @@ class StandaloneRunner(BaseRunner):
         Returns:
             StandaloneJob: A StandaloneJob object
         """
-        self.logger.info(f"Running test: {test.section_name}")
+        logger.info(f"Running test: {test.section_name}")
         job_output_path = self.get_job_output_path(test)
         exec_cmd = test.gen_exec_command(job_output_path)
-        self.logger.info(f"Executing command for test {test.section_name}: {exec_cmd}")
+        logger.info(f"Executing command for test {test.section_name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
             pid = self.cmd_shell.execute(exec_cmd).pid
@@ -111,7 +114,7 @@ class StandaloneRunner(BaseRunner):
 
         s_job = cast(StandaloneJob, job)
         command = f"ps -p {s_job.id}"
-        self.logger.debug(f"Checking job status with command: {command}")
+        logger.debug(f"Checking job status with command: {command}")
         stdout = self.cmd_shell.execute(command).communicate()[0]
         return str(s_job.id) not in stdout
 
@@ -124,5 +127,5 @@ class StandaloneRunner(BaseRunner):
         """
         s_job = cast(StandaloneJob, job)
         cmd = f"kill -9 {s_job.id}"
-        self.logger.info(f"Executing termination command for job {s_job.id}: {cmd}")
+        logger.info(f"Executing termination command for job {s_job.id}: {cmd}")
         self.cmd_shell.execute(cmd)

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -15,7 +15,6 @@
 import logging
 import os
 import subprocess
-import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List
 
@@ -23,6 +22,8 @@ from cloudai._core.install_status_result import InstallStatusResult
 from cloudai._core.system import System
 from cloudai.systems.slurm import SlurmNodeState
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class DatasetCheckResult:
@@ -67,8 +68,6 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         self.repository_url = self._validate_cmd_arg(cmd_args, "repository_url")
         self.repository_commit_hash = self._validate_cmd_arg(cmd_args, "repository_commit_hash")
         self.docker_image_url = self._validate_cmd_arg(cmd_args, "docker_image_url")
-        self.logger = logging.getLogger(__name__)
-        self._configure_logging()
 
     def _validate_cmd_arg(self, cmd_args: Dict[str, Any], arg_name: str) -> str:
         """
@@ -89,25 +88,6 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         if arg_value is None:
             raise ValueError(f"{arg_name} not specified or default value is None in command-line arguments.")
         return arg_value
-
-    def _configure_logging(self):
-        """
-        Configure logging to output error messages to stdout.
-
-        This method sets the logger's level to INFO, capturing messages at this level and above. It also configures a
-        StreamHandler for error messages (ERROR level and above), directing them to stdout for immediate visibility.
-
-        StreamHandler formatting includes the logger's name, the log level, and the message.
-        """
-        self.logger.setLevel(logging.INFO)
-
-        c_handler = logging.StreamHandler(sys.stdout)
-        c_handler.setLevel(logging.ERROR)
-
-        c_format = logging.Formatter("%(name)s - %(levelname)s - %(message)s")
-        c_handler.setFormatter(c_format)
-
-        self.logger.addHandler(c_handler)
 
     def is_installed(self) -> InstallStatusResult:
         subdir_path = os.path.join(self.install_path, self.SUBDIR_PATH)
@@ -240,7 +220,7 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         idle_nodes = [node.name for node in partition_nodes if node.state == SlurmNodeState.IDLE]
 
         if not idle_nodes:
-            self.logger.info(
+            logger.info(
                 "There are no idle nodes in the default partition to check. "
                 "Skipping NeMo-Launcher dataset verification."
             )
@@ -301,13 +281,13 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
             subdir_path (str): Subdirectory path for installation.
         """
         repo_path = os.path.join(subdir_path, self.REPOSITORY_NAME)
-        self.logger.info("Cloning NeMo-Launcher repository into %s", repo_path)
+        logger.info("Cloning NeMo-Launcher repository into %s", repo_path)
         clone_cmd = ["git", "clone", self.repository_url, repo_path]
         result = subprocess.run(clone_cmd, capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError(f"Failed to clone repository '{self.repository_url}': {result.stderr}")
 
-        self.logger.info("Checking out specific commit %s in repository", self.repository_commit_hash)
+        logger.info("Checking out specific commit %s in repository", self.repository_commit_hash)
         checkout_cmd = ["git", "checkout", self.repository_commit_hash]
         result = subprocess.run(checkout_cmd, cwd=repo_path, capture_output=True, text=True)
         if result.returncode != 0:

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -23,8 +23,6 @@ from cloudai._core.system import System
 from cloudai.systems.slurm import SlurmNodeState
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 
-logger = logging.getLogger(__name__)
-
 
 class DatasetCheckResult:
     """
@@ -220,7 +218,7 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         idle_nodes = [node.name for node in partition_nodes if node.state == SlurmNodeState.IDLE]
 
         if not idle_nodes:
-            logger.info(
+            logging.info(
                 "There are no idle nodes in the default partition to check. "
                 "Skipping NeMo-Launcher dataset verification."
             )
@@ -281,13 +279,13 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
             subdir_path (str): Subdirectory path for installation.
         """
         repo_path = os.path.join(subdir_path, self.REPOSITORY_NAME)
-        logger.info("Cloning NeMo-Launcher repository into %s", repo_path)
+        logging.info("Cloning NeMo-Launcher repository into %s", repo_path)
         clone_cmd = ["git", "clone", self.repository_url, repo_path]
         result = subprocess.run(clone_cmd, capture_output=True, text=True)
         if result.returncode != 0:
             raise RuntimeError(f"Failed to clone repository '{self.repository_url}': {result.stderr}")
 
-        logger.info("Checking out specific commit %s in repository", self.repository_commit_hash)
+        logging.info("Checking out specific commit %s in repository", self.repository_commit_hash)
         checkout_cmd = ["git", "checkout", self.repository_commit_hash]
         result = subprocess.run(checkout_cmd, cwd=repo_path, capture_output=True, text=True)
         if result.returncode != 0:

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -305,7 +305,7 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         clone_cmd = ["git", "clone", self.repository_url, repo_path]
         result = subprocess.run(clone_cmd, capture_output=True, text=True)
         if result.returncode != 0:
-            raise RuntimeError(f"Failed to clone repository: {result.stderr}")
+            raise RuntimeError(f"Failed to clone repository '{self.repository_url}': {result.stderr}")
 
         self.logger.info("Checking out specific commit %s in repository", self.repository_commit_hash)
         checkout_cmd = ["git", "checkout", self.repository_commit_hash]

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -22,6 +22,8 @@ from cloudai.util import CommandShell
 
 from .slurm_node import SlurmNode, SlurmNodeState
 
+logger = logging.getLogger(__name__)
+
 
 class SlurmSystem(System):
     """
@@ -219,8 +221,7 @@ class SlurmSystem(System):
         self.groups = groups if groups is not None else {}
         self.global_env_vars = global_env_vars if global_env_vars is not None else {}
         self.cmd_shell = CommandShell()
-        self.logger = logging.getLogger(self.__class__.__name__)
-        self.logger.info(f"{self.__class__.__name__} initialized")
+        logger.info(f"{self.__class__.__name__} initialized")
 
     def __repr__(self) -> str:
         """
@@ -389,7 +390,7 @@ class SlurmSystem(System):
             )
 
         # Log allocation details
-        self.logger.info(
+        logger.info(
             "Allocated nodes from group '{}' in partition '{}': {}".format(
                 group_name,
                 partition_name,
@@ -437,12 +438,12 @@ class SlurmSystem(System):
         command = f"squeue -j {job_id} --noheader --format=%T"
 
         while retry_count < retry_threshold:
-            self.logger.debug(f"Executing command to check job status: {command}")
+            logger.debug(f"Executing command to check job status: {command}")
             stdout, stderr = self.cmd_shell.execute(command).communicate()
 
             if "Socket timed out" in stderr or "slurm_load_jobs error" in stderr:
                 retry_count += 1
-                self.logger.warning(f"Transient error encountered. Retrying... " f"({retry_count}/{retry_threshold})")
+                logger.warning(f"Transient error encountered. Retrying... " f"({retry_count}/{retry_threshold})")
                 continue
 
             if stderr:
@@ -483,11 +484,11 @@ class SlurmSystem(System):
         retry_count = 0
         while retry_count < retry_threshold:
             command = f"squeue -j {job_id}"
-            self.logger.debug(f"Checking job status with command: {command}")
+            logger.debug(f"Checking job status with command: {command}")
             stdout, stderr = self.cmd_shell.execute(command).communicate()
             if "Socket timed out" in stderr:
                 retry_count += 1
-                self.logger.warning(f"Retrying job status check (attempt {retry_count}/" f"{retry_threshold})")
+                logger.warning(f"Retrying job status check (attempt {retry_count}/" f"{retry_threshold})")
                 continue
 
             if stderr:
@@ -549,10 +550,10 @@ class SlurmSystem(System):
         Returns:
             Tuple[str, str]: The stdout and stderr from the command execution.
         """
-        self.logger.debug(f"Executing command: {command}")
+        logger.debug(f"Executing command: {command}")
         stdout, stderr = self.cmd_shell.execute(command).communicate()
         if stderr:
-            self.logger.error(f"Error executing command '{command}': {stderr}")
+            logger.error(f"Error executing command '{command}': {stderr}")
         return stdout, stderr
 
     def parse_squeue_output(self, squeue_output: str) -> Dict[str, str]:
@@ -668,7 +669,7 @@ class SlurmSystem(System):
             if abbrev in state_abbreviations:
                 return state_abbreviations[abbrev]
             else:
-                self.logger.warning(f"Unknown state: {core_state}")
+                logger.warning(f"Unknown state: {core_state}")
                 return SlurmNodeState.UNKNOWN_STATE
 
     def parse_nodes(self, nodes: List[str]) -> List[str]:

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -22,8 +22,6 @@ from cloudai.util import CommandShell
 
 from .slurm_node import SlurmNode, SlurmNodeState
 
-logger = logging.getLogger(__name__)
-
 
 class SlurmSystem(System):
     """
@@ -221,7 +219,7 @@ class SlurmSystem(System):
         self.groups = groups if groups is not None else {}
         self.global_env_vars = global_env_vars if global_env_vars is not None else {}
         self.cmd_shell = CommandShell()
-        logger.info(f"{self.__class__.__name__} initialized")
+        logging.info(f"{self.__class__.__name__} initialized")
 
     def __repr__(self) -> str:
         """
@@ -390,7 +388,7 @@ class SlurmSystem(System):
             )
 
         # Log allocation details
-        logger.info(
+        logging.info(
             "Allocated nodes from group '{}' in partition '{}': {}".format(
                 group_name,
                 partition_name,
@@ -438,12 +436,12 @@ class SlurmSystem(System):
         command = f"squeue -j {job_id} --noheader --format=%T"
 
         while retry_count < retry_threshold:
-            logger.debug(f"Executing command to check job status: {command}")
+            logging.debug(f"Executing command to check job status: {command}")
             stdout, stderr = self.cmd_shell.execute(command).communicate()
 
             if "Socket timed out" in stderr or "slurm_load_jobs error" in stderr:
                 retry_count += 1
-                logger.warning(f"Transient error encountered. Retrying... " f"({retry_count}/{retry_threshold})")
+                logging.warning(f"Transient error encountered. Retrying... " f"({retry_count}/{retry_threshold})")
                 continue
 
             if stderr:
@@ -484,11 +482,11 @@ class SlurmSystem(System):
         retry_count = 0
         while retry_count < retry_threshold:
             command = f"squeue -j {job_id}"
-            logger.debug(f"Checking job status with command: {command}")
+            logging.debug(f"Checking job status with command: {command}")
             stdout, stderr = self.cmd_shell.execute(command).communicate()
             if "Socket timed out" in stderr:
                 retry_count += 1
-                logger.warning(f"Retrying job status check (attempt {retry_count}/" f"{retry_threshold})")
+                logging.warning(f"Retrying job status check (attempt {retry_count}/" f"{retry_threshold})")
                 continue
 
             if stderr:
@@ -550,10 +548,10 @@ class SlurmSystem(System):
         Returns:
             Tuple[str, str]: The stdout and stderr from the command execution.
         """
-        logger.debug(f"Executing command: {command}")
+        logging.debug(f"Executing command: {command}")
         stdout, stderr = self.cmd_shell.execute(command).communicate()
         if stderr:
-            logger.error(f"Error executing command '{command}': {stderr}")
+            logging.error(f"Error executing command '{command}': {stderr}")
         return stdout, stderr
 
     def parse_squeue_output(self, squeue_output: str) -> Dict[str, str]:
@@ -669,7 +667,7 @@ class SlurmSystem(System):
             if abbrev in state_abbreviations:
                 return state_abbreviations[abbrev]
             else:
-                logger.warning(f"Unknown state: {core_state}")
+                logging.warning(f"Unknown state: {core_state}")
                 return SlurmNodeState.UNKNOWN_STATE
 
     def parse_nodes(self, nodes: List[str]) -> List[str]:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -304,8 +304,9 @@ class DockerImageCacheManager:
                 logging.debug(msg)
                 return PrerequisiteCheckResult(False, msg)
         except requests.RequestException as e:
-            logging.debug(f"Failed to access Docker image URL {docker_image_url}. Error: {e}")
-            return PrerequisiteCheckResult(False, f"Docker image is not accessible URL={docker_image_url}. Error: {e}")
+            msg = f"Failed to check access Docker image URL {docker_image_url}. Error: {e}"
+            logging.debug(msg)
+            return PrerequisiteCheckResult(False, msg)
 
     def uninstall_cached_image(self, subdir_name: str, docker_image_filename: str) -> DockerImageCacheResult:
         """

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -1,4 +1,3 @@
-import argparse
 from pathlib import Path
 from typing import Dict
 
@@ -22,17 +21,14 @@ def test_slurm(tmp_path: Path, scenario: Dict):
     test_scenario_path = scenario["path"]
     expected_dirs_number = scenario.get("expected_dirs_number")
 
-    args = argparse.Namespace(
-        log_file=None,
-        log_level=None,
-        mode="dry-run",
-        output_path=str(tmp_path),
-        system_config_path="conf/v0.6/general/system/example_slurm_cluster.toml",
-        test_scenario_path=str(test_scenario_path),
-        test_path="conf/v0.6/general/test",
-        test_template_path="conf/v0.6/general/test_template",
+    handle_dry_run_and_run(
+        "dry-run",
+        Path("conf/v0.6/general/system/example_slurm_cluster.toml"),
+        Path("conf/v0.6/general/test_template"),
+        Path("conf/v0.6/general/test"),
+        test_scenario_path,
+        tmp_path,
     )
-    handle_dry_run_and_run(args)
 
     results_output = list(tmp_path.glob("*"))[0]
     test_dirs = list(results_output.iterdir())

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -196,7 +196,10 @@ class TestDockerImageCacheManager(unittest.TestCase):
             "registry-1.docker.io/v2/library/hello-world/manifests:latest"
         )
         self.assertTrue(result.success)
-        self.assertEqual(result.message, "Docker image URL is accessible.")
+        self.assertEqual(
+            result.message,
+            "Docker image URL https://registry-1.docker.io/v2/library/hello-world/manifests:latest is accessible.",
+        )
 
     @patch("requests.head")
     def test_check_docker_image_accessibility_not_found(self, mock_head):


### PR DESCRIPTION
## Summary
1. Use `logging.config`, always write `DEBUG` logs into debug file.
2. Use module-level `logger` object for better configurability on user end.
3. Use explicit arguments instead of `argparse`'s args for high level function. It will simplify code re-use for users.

## Test Plan
CI

## Additional Notes
—
