### PR TITLE
Update `_clone_repository` to handle existing repository path

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -295,7 +295,7 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
 
     def _clone_repository(self, subdir_path: str) -> None:
         """
-        Clones NeMo-Launcher repository into specified path if it does not already exist, otherwise pulls the latest.
+        Clones NeMo-Launcher repository into specified path if it does not already exist.
 
         Args:
             subdir_path (str): Subdirectory path for installation.
@@ -303,16 +303,7 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         repo_path = os.path.join(subdir_path, self.REPOSITORY_NAME)
 
         if os.path.exists(repo_path):
-            self.logger.info("Repository already exists at %s. Pulling latest changes.", repo_path)
-            pull_cmd = ["git", "pull", "origin", "main"]
-            result = subprocess.run(pull_cmd, cwd=repo_path, capture_output=True, text=True)
-            if result.returncode != 0:
-                if "Please specify which branch you want to merge with" in result.stderr:
-                    self.logger.info("Repository not on a branch, pulling from origin main.")
-                    pull_cmd = ["git", "pull", "origin", "main"]
-                    result = subprocess.run(pull_cmd, cwd=repo_path, capture_output=True, text=True)
-                if result.returncode != 0:
-                    raise RuntimeError(f"Failed to pull latest changes: {result.stderr}")
+            self.logger.info("Repository already exists at %s. Checking out specific commit.", repo_path)
         else:
             self.logger.info("Cloning NeMo-Launcher repository into %s", repo_path)
             clone_cmd = ["git", "clone", self.repository_url, repo_path]

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -132,6 +132,64 @@ class TestNeMoLauncherSlurmInstallStrategy:
                 and "Docker image" in result.message
             )
 
+    def test_clone_repository_when_path_does_not_exist(self, strategy: NeMoLauncherSlurmInstallStrategy):
+        subdir_path = Path(strategy.slurm_system.install_path) / strategy.SUBDIR_PATH
+        repo_path = subdir_path / strategy.REPOSITORY_NAME
+        assert not repo_path.exists()
+
+        with patch("subprocess.run") as mock_run, patch("os.path.exists") as mock_exists:
+            mock_run.return_value.returncode = 0
+            mock_exists.side_effect = lambda path: path == str(subdir_path)
+            strategy._clone_repository(str(subdir_path))
+
+            mock_run.assert_any_call(
+                ["git", "clone", strategy.repository_url, str(repo_path)], capture_output=True, text=True
+            )
+            mock_run.assert_any_call(
+                ["git", "checkout", strategy.repository_commit_hash],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+            )
+
+    def test_clone_repository_when_path_exists(self, strategy: NeMoLauncherSlurmInstallStrategy):
+        subdir_path = Path(strategy.slurm_system.install_path) / strategy.SUBDIR_PATH
+        repo_path = subdir_path / strategy.REPOSITORY_NAME
+        repo_path.mkdir(parents=True)
+
+        with patch("subprocess.run") as mock_run, patch("os.path.exists") as mock_exists:
+
+            def run_side_effect(cmd, **kwargs):  # noqa
+                if cmd == ["git", "pull"]:
+                    result = MagicMock()
+                    result.returncode = 1
+                    result.stderr = "You are not currently on a branch."
+                    return result
+                elif cmd == ["git", "pull", "origin", "main"]:
+                    result = MagicMock()
+                    result.returncode = 0
+                    return result
+                else:
+                    result = MagicMock()
+                    result.returncode = 0
+                    return result
+
+            mock_run.side_effect = run_side_effect
+            mock_exists.side_effect = lambda path: path in [str(subdir_path), str(repo_path)]
+            strategy._clone_repository(str(subdir_path))
+
+            # Ensure that the fallback pull command was run
+            mock_run.assert_any_call(
+                ["git", "pull", "origin", "main"], cwd=str(repo_path), capture_output=True, text=True
+            )
+            # Ensure that checkout command was run
+            mock_run.assert_any_call(
+                ["git", "checkout", strategy.repository_commit_hash],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+            )
+
 
 class TestUCCTestSlurmInstallStrategy:
     @pytest.fixture

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -158,31 +158,11 @@ class TestNeMoLauncherSlurmInstallStrategy:
         repo_path.mkdir(parents=True)
 
         with patch("subprocess.run") as mock_run, patch("os.path.exists") as mock_exists:
-
-            def run_side_effect(cmd, **kwargs):  # noqa
-                if cmd == ["git", "pull"]:
-                    result = MagicMock()
-                    result.returncode = 1
-                    result.stderr = "You are not currently on a branch."
-                    return result
-                elif cmd == ["git", "pull", "origin", "main"]:
-                    result = MagicMock()
-                    result.returncode = 0
-                    return result
-                else:
-                    result = MagicMock()
-                    result.returncode = 0
-                    return result
-
-            mock_run.side_effect = run_side_effect
+            mock_run.return_value.returncode = 0
             mock_exists.side_effect = lambda path: path in [str(subdir_path), str(repo_path)]
             strategy._clone_repository(str(subdir_path))
 
-            # Ensure that the fallback pull command was run
-            mock_run.assert_any_call(
-                ["git", "pull", "origin", "main"], cwd=str(repo_path), capture_output=True, text=True
-            )
-            # Ensure that checkout command was run
+            # Ensure that the checkout command was run
             mock_run.assert_any_call(
                 ["git", "checkout", strategy.repository_commit_hash],
                 cwd=str(repo_path),


### PR DESCRIPTION
## Summary
This PR updates the _clone_repository method to properly handle cases where the repository path already exists. Previously, if the NeMo-Launcher repository directory was already present, the installation would fail due to the existing directory. The updated method now skips pulling the latest changes and directly checks out the specified commit, ensuring a smoother installation process.

## Test Plan
**1. Add unit tests
2. Ran on a real system**
Before Bugfix
```
Some test templates failed to install.
  - ChakraReplay: Success
  - Sleep: Success
  - NcclTest: Success
  - UCCTest: Success
  - NeMoLauncher: Failed to clone repository: fatal: destination path '/.../install/NeMo-Launcher/NeMo-Launcher' already exists and is not an empty directory.
```

After Bugfix
```
$ python ./cloudaix.py --mode install 
[Silently check out the latest changes]
```