### PR TITLE
Remove redundant installation check from run mode

### DIFF
--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -170,15 +170,6 @@ def handle_dry_run_and_run(args: argparse.Namespace) -> None:
     logging.info(f"Scheduler: {system.scheduler}")
     logging.info(f"Test Scenario Name: {test_scenario.name}")
 
-    if args.mode == "run":
-        logging.info("Checking if test templates are installed.")
-        installer = Installer(system)
-        result = installer.is_installed(test_templates)
-        if not result:
-            print("CloudAI has not been installed. Please run install mode first.")
-            print(result)
-            sys.exit(1)
-
     test_scenario.pretty_print()
 
     runner = Runner(args.mode, system, test_scenario)


### PR DESCRIPTION
## Summary
Currently, CloudAI checks the installation status of all available test templates before running any experiments. This check occurs in the "run" mode and can unnecessarily block the progress of users who are only interested in specific test templates.

## Test Plan
Before this PR
```
$ cloudai --mode run --test_scenario_path ../nccl_test.toml 
CloudAI has not been installed. Please run install mode first.
Some test templates are not installed.
  - NeMoLauncher: NeMo datasets are not installed on some nodes. Nodes without datasets:... This directory should contain all necessary datasets for NeMo Launcher to function properly.
```
After this PR
```
$ cloudai --mode run --test_scenario_path ../nccl_test.toml 
Test Scenario: nccl-test                    
                                                      
Section Name: Tests.1                                                                                                                                                                                                   
  Test Name: nccl_test_all_reduce                                                                                                                                                                                       
  Description: all_reduce                                                                                                                                                                                               
  No dependencies                                                                                                                                                                                                       
                                                                                                                                                                                                                        
Section Name: Tests.2                                                                                                                                                                                                   
  Test Name: nccl_test_all_gather                                                                                                                                                                                       
  Description: all_gather         
  Start Post Comp: Tests.1, Time: 0 seconds                                                                 
                                                      
Section Name: Tests.3                                                                                       
  Test Name: nccl_test_reduce_scatter
  Description: reduce_scatter                                                                               
  Start Post Comp: Tests.2, Time: 0 seconds                                                                 
                                                                                                            
Section Name: Tests.4                                                                                       
  Test Name: nccl_test_alltoall                                                                             
  Description: alltoall                                                                                                                                                                                                 
  Start Post Comp: Tests.3, Time: 0 seconds                                
```