### PR TITLE
New CLI args and filter tests templates for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,31 +38,31 @@ Please make sure to use the correct system configuration file that corresponds t
 ```bash
 cloudai\
     --mode install\
-    --system_config_path conf/v0.6/general/system/example_slurm_cluster.toml
+    --system-config conf/v0.6/general/system/example_slurm_cluster.toml
 ```
 
 To simulate running experiments without execution, use the dry-run mode:
 ```bash
 cloudai\
     --mode dry-run\
-    --system_config_path conf/v0.6/general/system/example_slurm_cluster.toml\
-    --test_scenario_path conf/v0.6/general/test_scenario/sleep.toml
+    --system-config conf/v0.6/general/system/example_slurm_cluster.toml\
+    --test-scenario conf/v0.6/general/test_scenario/sleep.toml
 ```
 
 To run experiments, execute CloudAI CLI in run mode:
 ```bash
 cloudai\
     --mode run\
-    --system_config_path conf/v0.6/general/system/example_slurm_cluster.toml\
-    --test_scenario_path conf/v0.6/general/test_scenario/sleep.toml
+    --system-config conf/v0.6/general/system/example_slurm_cluster.toml\
+    --test-scenario conf/v0.6/general/test_scenario/sleep.toml
 ```
 
 To generate reports, execute CloudAI CLI in generate-report mode:
 ```bash
 cloudai\
     --mode generate-report\
-    --system_config_path conf/v0.6/general/system/example_slurm_cluster.toml\
-    --output_path /path/to/output_directory
+    --system-config conf/v0.6/general/system/example_slurm_cluster.toml\
+    --output-dir /path/to/output_directory
 ```
 In the generate-report mode, use the --output_path argument to specify a subdirectory under the result directory.
 This subdirectory is usually named with a timestamp for unique identification.
@@ -71,7 +71,7 @@ To uninstall test templates, run CloudAI CLI in uninstall mode:
 ```bash
 cloudai\
     --mode uninstall\
-    --system_config_path conf/v0.6/general/system/example_slurm_cluster.toml
+    --system-config conf/v0.6/general/system/example_slurm_cluster.toml
 ```
 
 # Contributing

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -23,6 +23,8 @@ from ._core.registry import Registry
 from ._core.report_generation_strategy import ReportGenerationStrategy
 from ._core.runner import Runner
 from ._core.system import System
+from ._core.test import Test
+from ._core.test_scenario import TestScenario
 from ._core.test_template import TestTemplate
 from ._core.test_template_strategy import TestTemplateStrategy
 from .installer.installer import Installer
@@ -142,6 +144,8 @@ __all__ = [
     "ReportGenerator",
     "Runner",
     "System",
+    "Test",
+    "TestScenario",
     "TestTemplate",
     "TestTemplateStrategy",
 ]

--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -102,12 +102,12 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--test-templates-dir",
-        default="conf/v0.6/general/test_template",
+        required=True,
         help="Path to the test template configuration directory.",
     )
     parser.add_argument(
         "--tests-dir",
-        default="conf/v0.6/general/test",
+        required=True,
         help="Path to the test configuration directory.",
     )
     parser.add_argument(

--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -18,7 +18,7 @@ import logging
 import logging.config
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from cloudai import Installer, Parser, ReportGenerator, Runner, System, Test, TestScenario
 
@@ -112,7 +112,7 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--test-scenario",
-        required=True,
+        required=False,
         help="Path to the test scenario file.",
     )
     parser.add_argument("--output-dir", help="Path to the output directory.")
@@ -229,7 +229,7 @@ def main() -> None:
     system_config_path = Path(args.system_config)
     test_templates_dir = Path(args.test_templates_dir)
     tests_dir = Path(args.tests_dir)
-    test_scenario_path = Path(args.test_scenario)
+    test_scenario_path = Path(args.test_scenario) if args.test_scenario else None
     output_dir = Path(args.output_dir) if args.output_dir else None
 
     logging.info(f"System configuration file: {system_config_path}")
@@ -248,15 +248,15 @@ def main() -> None:
     if args.mode in ["install", "uninstall"]:
         handle_install_and_uninstall(args.mode, system, tests)
     else:
-        if not test_scenario_path:
-            logging.error(f"Error: --test_scenario_path is required for mode={args.mode}")
+        if not test_scenario:
+            logging.error(f"Error: --test-scenario is required for mode={args.mode}")
             exit(1)
 
         elif args.mode in ["dry-run", "run"]:
             handle_dry_run_and_run(args.mode, system, tests, test_scenario)
         elif args.mode == "generate-report":
             if not output_dir:
-                logging.error("Error: --output_path is required when mode is generate-report.")
+                logging.error("Error: --output-dir is required when mode is generate-report.")
                 exit(1)
             handle_generate_report(test_scenario, output_dir)
 

--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -96,29 +96,29 @@ def parse_arguments() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--system_config_path",
+        "--system-config",
         required=True,
         help="Path to the system configuration file.",
     )
     parser.add_argument(
-        "--test_template_path",
+        "--test-templates-dir",
         default="conf/v0.6/general/test_template",
         help="Path to the test template configuration directory.",
     )
     parser.add_argument(
-        "--test_path",
+        "--tests-dir",
         default="conf/v0.6/general/test",
         help="Path to the test configuration directory.",
     )
     parser.add_argument(
-        "--test_scenario_path",
+        "--test-scenario",
         required=False,
         help="Path to the test scenario file.",
     )
-    parser.add_argument("--output_path", help="Path to the output directory.")
-    parser.add_argument("--log_file", default="debug.log", help="The name of the log file.")
+    parser.add_argument("--output-dir", help="Path to the output directory.")
+    parser.add_argument("--log-file", default="debug.log", help="The name of the log file.")
     parser.add_argument(
-        "--log_level",
+        "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Set the logging level (e.g., DEBUG, INFO, WARNING, ERROR, CRITICAL)",

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -20,7 +20,6 @@ from typing import Iterable
 from .install_status_result import InstallStatusResult
 from .system import System
 from .test import Test
-from .test_template import TestTemplate
 
 
 class BaseInstaller:

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -110,19 +110,26 @@ class BaseInstaller:
             return prerequisites_result
 
         install_results = {}
-        with ThreadPoolExecutor() as executor:
-            futures = {executor.submit(test_template.install): test_template for test_template in test_templates}
-            for future in as_completed(futures):
-                test_template = futures[future]
-                try:
-                    result = future.result()
-                    if result.success:
-                        install_results[test_template.name] = "Success"
-                    else:
-                        install_results[test_template.name] = result.message
-                except Exception as e:
-                    logging.error(f"Installation failed for {test_template.name}: {e}")
-                    install_results[test_template.name] = str(e)
+        # with ThreadPoolExecutor() as executor:
+        #     futures = {executor.submit(test_template.install): test_template for test_template in test_templates}
+        #     for future in as_completed(futures):
+        #         test_template = futures[future]
+        #         try:
+        #             result = future.result()
+        #             if result.success:
+        #                 install_results[test_template.name] = "Success"
+        #             else:
+        #                 install_results[test_template.name] = result.message
+        #         except Exception as e:
+        #             logging.error(f"Installation failed for {test_template.name}: {e}")
+        #             install_results[test_template.name] = str(e)
+        for template in test_templates:
+            logging.info(f"Installing {template.name}")
+            result = template.install()
+            if result.success:
+                install_results[template.name] = "Success"
+            else:
+                install_results[template.name] = result.message
 
         all_success = all(result == "Success" for result in install_results.values())
         if all_success:

--- a/src/cloudai/_core/base_multi_file_parser.py
+++ b/src/cloudai/_core/base_multi_file_parser.py
@@ -14,6 +14,7 @@
 
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import toml
@@ -32,8 +33,8 @@ class BaseMultiFileParser(ABC):
         directory_path (str): Path to the directory with configuration files.
     """
 
-    def __init__(self, directory_path: str):
-        self.directory_path: str = directory_path
+    def __init__(self, directory_path: Path):
+        self.directory_path = directory_path
 
     @abstractmethod
     def _parse_data(self, data: Dict[str, Any]) -> Union[Test, TestTemplate]:
@@ -58,14 +59,12 @@ class BaseMultiFileParser(ABC):
             List[Any]: List of objects from the configuration files.
         """
         objects: List[Any] = []
-        for filename in os.listdir(self.directory_path):
-            if filename.endswith(".toml"):
-                file_path: str = os.path.join(self.directory_path, filename)
-                with open(file_path, "r") as file:
-                    data: Dict[str, Any] = toml.load(file)
-                    parsed_object = self._parse_data(data)
-                    obj_name: str = parsed_object.name
-                    if obj_name in objects:
-                        raise ValueError(f"Duplicate name found: {obj_name}")
-                    objects.append(parsed_object)
+        for f in self.directory_path.glob("*.toml"):
+            with f.open() as fh:
+                data: Dict[str, Any] = toml.load(fh)
+                parsed_object = self._parse_data(data)
+                obj_name: str = parsed_object.name
+                if obj_name in objects:
+                    raise ValueError(f"Duplicate name found: {obj_name}")
+                objects.append(parsed_object)
         return objects

--- a/src/cloudai/_core/base_multi_file_parser.py
+++ b/src/cloudai/_core/base_multi_file_parser.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Union
@@ -60,6 +60,7 @@ class BaseMultiFileParser(ABC):
         """
         objects: List[Any] = []
         for f in self.directory_path.glob("*.toml"):
+            logging.debug(f"Parsing file: {f}")
             with f.open() as fh:
                 data: Dict[str, Any] = toml.load(fh)
                 parsed_object = self._parse_data(data)

--- a/src/cloudai/_core/parser.py
+++ b/src/cloudai/_core/parser.py
@@ -40,8 +40,8 @@ class Parser:
         self,
         system_config_path: str,
         test_template_path: str,
-        test_path: Optional[str] = None,
-        test_scenario_path: Optional[str] = None,
+        # test_path: str,
+        # test_scenario_path: str,
     ) -> None:
         """
         Initialize a Parser instance.
@@ -52,11 +52,11 @@ class Parser:
             test_path (str): The file path for test configurations.
             test_scenario_path (str): The file path for test scenario configurations.
         """
-        self.system_config_path: str = system_config_path
-        self.test_template_path: str = test_template_path
-        self.test_path: Optional[str] = test_path
-        self.test_scenario_path: Optional[str] = test_scenario_path
-        logging.debug("Initialized with system and template paths")
+        logging.debug(f"Initializing parser with: {system_config_path=} {test_template_path=}")
+        self.system_config_path = system_config_path
+        self.test_template_path = test_template_path
+        # self.test_path = test_path
+        # self.test_scenario_path = test_scenario_path
 
     def parse_system_and_templates(self) -> Tuple[System, List[TestTemplate]]:
         """
@@ -76,7 +76,7 @@ class Parser:
 
         return system, test_templates
 
-    def parse(self) -> Tuple[System, List[TestTemplate], TestScenario]:
+    def parse(self, test_path: str, test_scenario_path: str) -> Tuple[System, List[TestTemplate], TestScenario]:
         """
         Parse configurations for system, test templates, and test scenarios.
 
@@ -94,14 +94,12 @@ class Parser:
         test_template_mapping = {t.name: t for t in test_templates}
         logging.debug(f"Parsed {len(test_templates)} test templates")
 
-        assert self.test_path is not None, "Tests path must be provided for experiments."
-        test_parser = TestParser(self.test_path, test_template_mapping)
+        test_parser = TestParser(test_path, test_template_mapping)
         tests = test_parser.parse_all()
         test_mapping = {t.name: t for t in tests}
         logging.debug(f"Parsed {len(tests)} tests")
 
-        assert self.test_scenario_path is not None, "Test scenarios path must be provided for experiments."
-        test_scenario_parser = TestScenarioParser(self.test_scenario_path, system, test_mapping)
+        test_scenario_parser = TestScenarioParser(test_scenario_path, system, test_mapping)
         test_scenario = test_scenario_parser.parse()
         logging.debug("Parsed test scenario")
 

--- a/src/cloudai/_core/parser.py
+++ b/src/cloudai/_core/parser.py
@@ -71,12 +71,12 @@ class Parser:
         test_template_parser = TestTemplateParser(system, self.test_template_path)
         test_templates: List[TestTemplate] = test_template_parser.parse_all()
         test_template_mapping = {t.name: t for t in test_templates}
-        logging.debug(f"Parsed {len(test_templates)} test templates")
+        logging.debug(f"Parsed {len(test_templates)} test templates: {[t.name for t in test_templates]}")
 
         test_parser = TestParser(test_path, test_template_mapping)
         tests: List[Test] = test_parser.parse_all()
         test_mapping = {t.name: t for t in tests}
-        logging.debug(f"Parsed {len(tests)} tests")
+        logging.debug(f"Parsed {len(tests)} tests: {[t.name for t in tests]}")
 
         test_scenario_parser = TestScenarioParser(str(test_scenario_path), system, test_mapping)
         test_scenario = test_scenario_parser.parse()

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -50,7 +50,7 @@ class Test:
         self,
         name: str,
         description: str,
-        test_template: "TestTemplate",
+        test_template: TestTemplate,
         env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],

--- a/src/cloudai/_core/test_parser.py
+++ b/src/cloudai/_core/test_parser.py
@@ -15,8 +15,6 @@
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
-import toml
-
 from .base_multi_file_parser import BaseMultiFileParser
 from .test import Test
 from .test_template import TestTemplate
@@ -48,20 +46,6 @@ class TestParser(BaseMultiFileParser):
         """
         super().__init__(directory_path)
         self.test_template_mapping: Dict[str, TestTemplate] = test_template_mapping
-
-    def load_test_names(self) -> Set[str]:
-        if not self.directory_path.exists():
-            raise FileNotFoundError(f"Test path '{self.directory_path}' does not exist.")
-        if not self.directory_path.is_dir():
-            raise NotADirectoryError(f"Test path '{self.directory_path}' is not a directory.")
-
-        tests: Set[str] = set()
-        for file in self.directory_path.glob("*.toml"):
-            with open(file, "r") as f:
-                data: Dict[str, Any] = toml.load(f)
-                tests.add(data["name"])
-
-        return tests
 
     def _parse_data(self, data: Dict[str, Any]) -> Test:
         """

--- a/src/cloudai/_core/test_parser.py
+++ b/src/cloudai/_core/test_parser.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Any, Dict, List, Set
+
+import toml
 
 from .base_multi_file_parser import BaseMultiFileParser
 from .test import Test
@@ -32,7 +35,7 @@ class TestParser(BaseMultiFileParser):
 
     def __init__(
         self,
-        directory_path: str,
+        directory_path: Path,
         test_template_mapping: Dict[str, TestTemplate],
     ) -> None:
         """
@@ -45,6 +48,20 @@ class TestParser(BaseMultiFileParser):
         """
         super().__init__(directory_path)
         self.test_template_mapping: Dict[str, TestTemplate] = test_template_mapping
+
+    def load_test_names(self) -> Set[str]:
+        if not self.directory_path.exists():
+            raise FileNotFoundError(f"Test path '{self.directory_path}' does not exist.")
+        if not self.directory_path.is_dir():
+            raise NotADirectoryError(f"Test path '{self.directory_path}' is not a directory.")
+
+        tests: Set[str] = set()
+        for file in self.directory_path.glob("*.toml"):
+            with open(file, "r") as f:
+                data: Dict[str, Any] = toml.load(f)
+                tests.add(data["name"])
+
+        return tests
 
     def _parse_data(self, data: Dict[str, Any]) -> Test:
         """

--- a/src/cloudai/_core/test_template_parser.py
+++ b/src/cloudai/_core/test_template_parser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from pathlib import Path
 from typing import Any, Dict, Optional, Type, Union, cast
 
 from .base_multi_file_parser import BaseMultiFileParser
@@ -40,7 +41,7 @@ class TestTemplateParser(BaseMultiFileParser):
 
     VALID_DATA_TYPES = ["preset", "bool", "int", "str"]
 
-    def __init__(self, system: System, directory_path: str) -> None:
+    def __init__(self, system: System, directory_path: Path) -> None:
         """
         Initialize a TestTemplateParser with a specific system and directory path.
 
@@ -50,7 +51,7 @@ class TestTemplateParser(BaseMultiFileParser):
         """
         super().__init__(directory_path)
         self.system = system
-        self.directory_path: str = directory_path
+        self.directory_path = directory_path
 
     def _fetch_strategy(  # noqa: D417
         self,

--- a/src/cloudai/installer/installer.py
+++ b/src/cloudai/installer/installer.py
@@ -15,11 +15,10 @@
 import logging
 from typing import Iterable
 
-from cloudai._core.base_installer import BaseInstaller
 from cloudai._core.install_status_result import InstallStatusResult
 from cloudai._core.registry import Registry
 from cloudai._core.system import System
-from cloudai._core.test_template import TestTemplate
+from cloudai._core.test import Test
 
 
 class Installer:
@@ -29,7 +28,6 @@ class Installer:
     This class facilitates the initialization of the appropriate installer based on the system.
 
     Attributes
-        logger (logging.Logger): Logger for capturing installation activities.
         installer (BaseInstaller): The specific installer instance for the system.
     """
 
@@ -40,65 +38,48 @@ class Installer:
         Args:
             system (System): The system schema object.
         """
-        logging.info("Initializing Installer with system configuration.")
-        self.installer = self.create_installer(system)
-
-    @classmethod
-    def create_installer(cls, system: System) -> BaseInstaller:
-        """
-        Create an installer instance based on the system's scheduler type.
-
-        Args:
-            system (System): The system schema object.
-
-        Returns:
-            BaseInstaller: An instance of a subclass of BaseInstaller suitable for the given system's scheduler.
-
-        Raises:
-            NotImplementedError: If no installer is available for the system's scheduler.
-        """
         scheduler_type = system.scheduler
         registry = Registry()
         installer_class = registry.installers_map.get(scheduler_type)
         if installer_class is None:
             raise NotImplementedError(f"No installer available for scheduler: {scheduler_type}")
-        return installer_class(system)
+        self.installer = installer_class(system)
 
-    def is_installed(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
+    def is_installed(self, tests: Iterable[Test]) -> InstallStatusResult:
         """
         Check if the necessary components for the provided test templates are already installed.
 
         Args:
-            test_templates (Iterable[TestTemplate]): The list of test templates to check for installation.
+            tests (Iterable[Test]): The list of test templates to check.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
         logging.info("Checking installation status of components.")
-        return self.installer.is_installed(test_templates)
+        return self.installer.is_installed(tests)
 
-    def install(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
+    def install(self, tests: Iterable[Test]) -> InstallStatusResult:
         """
         Check if the necessary components are installed and install them if not using the instantiated installer.
 
         Args:
-            test_templates (Iterable[TestTemplate]): The list of test templates to install.
+            tests (Iterable[Test]): The list of test templates to install.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
         logging.info("Installing test templates.")
-        return self.installer.install(test_templates)
+        return self.installer.install(tests)
 
-    def uninstall(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
+    def uninstall(self, tests: Iterable[Test]) -> InstallStatusResult:
         """
         Uninstall the benchmarks or test templates using the instantiated installer.
 
         Args:
-            test_templates (Iterable[TestTemplate]): The list of test templates to uninstall.
+            tests (Iterable[Test]): The list of test templates to uninstall.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
         logging.info("Uninstalling test templates.")
-        return self.installer.uninstall(test_templates)
+        return self.installer.uninstall(tests)

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -23,6 +23,7 @@ import toml
 from cloudai._core.base_installer import BaseInstaller
 from cloudai._core.install_status_result import InstallStatusResult
 from cloudai._core.system import System
+from cloudai._core.test import Test
 from cloudai._core.test_template import TestTemplate
 from cloudai.systems import SlurmSystem
 
@@ -140,14 +141,14 @@ class SlurmInstaller(BaseInstaller):
         if os.path.exists(self.config_path):
             os.remove(self.config_path)
 
-    def is_installed(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
+    def is_installed(self, tests: Iterable[Test]) -> InstallStatusResult:
         """
-        Check if the necessary components for the provided test templates are already installed.
+        Check if the necessary components for the provided test are already installed.
 
         Verify the existence of the configuration file and the installation status of each test template.
 
         Args:
-            test_templates (Iterable[TestTemplate]): The list of test templates to check for installation.
+            tests (Iterable[Test]): The tests to check for installation.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
@@ -164,16 +165,16 @@ class SlurmInstaller(BaseInstaller):
         except FileNotFoundError as e:
             return InstallStatusResult(False, str(e))
 
-        return super().is_installed(test_templates)
+        return super().is_installed(tests)
 
-    def install(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
+    def install(self, tests: Iterable[Test]) -> InstallStatusResult:
         """
         Check if the necessary components are installed and install them if not.
 
         Requires the installation path to be set.
 
         Args:
-            test_templates (Iterable[TestTemplate]): The list of test templates to be installed.
+            tests (Iterable[Test]): The tests to install.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if any.
@@ -195,26 +196,26 @@ class SlurmInstaller(BaseInstaller):
         if not os.access(self.install_path, os.W_OK):
             return InstallStatusResult(False, f"The installation path {self.install_path} is not writable.")
 
-        super_result = super().install(test_templates)
+        super_result = super().install(tests)
         if not super_result:
             return super_result
 
         config_result = self._write_config()
         return config_result
 
-    def uninstall(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
+    def uninstall(self, tests: Iterable[Test]) -> InstallStatusResult:
         """
-        Uninstall the benchmarks or test templates from the installation path and remove the configuration file.
+        Uninstall the benchmarks or test from the installation path and remove the configuration file.
 
         This method does not require the installation path to be set in advance.
 
         Args:
-            test_templates (Iterable[TestTemplate]): The list of test templates to be uninstalled.
+            tests (Iterable[Test]): The tests to uninstall.
 
         Returns:
             InstallStatusResult: Result containing the uninstallation status and error message if any.
         """
-        super_result = super().uninstall(test_templates)
+        super_result = super().uninstall(tests)
         if not super_result:
             return super_result
 

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -24,7 +24,6 @@ from cloudai._core.base_installer import BaseInstaller
 from cloudai._core.install_status_result import InstallStatusResult
 from cloudai._core.system import System
 from cloudai._core.test import Test
-from cloudai._core.test_template import TestTemplate
 from cloudai.systems import SlurmSystem
 
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -26,7 +26,9 @@ def test_slurm(tmp_path: Path, scenario: Dict):
         Path("conf/v0.6/general/system/example_slurm_cluster.toml"), Path("conf/v0.6/general/test_template")
     )
     system, tests, test_scenario = parser.parse(Path("conf/v0.6/general/test"), test_scenario_path)
-    handle_dry_run_and_run("dry-run", system, tests, test_scenario, tmp_path)
+    system.output_path = str(tmp_path)
+    assert test_scenario is not None, "Test scenario is None"
+    handle_dry_run_and_run("dry-run", system, tests, test_scenario)
 
     results_output = list(tmp_path.glob("*"))[0]
     test_dirs = list(results_output.iterdir())

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Dict
 
 import pytest
+from cloudai import Parser
 from cloudai.__main__ import handle_dry_run_and_run
 
 SLURM_TEST_SCENARIOS = [
@@ -21,14 +22,11 @@ def test_slurm(tmp_path: Path, scenario: Dict):
     test_scenario_path = scenario["path"]
     expected_dirs_number = scenario.get("expected_dirs_number")
 
-    handle_dry_run_and_run(
-        "dry-run",
-        Path("conf/v0.6/general/system/example_slurm_cluster.toml"),
-        Path("conf/v0.6/general/test_template"),
-        Path("conf/v0.6/general/test"),
-        test_scenario_path,
-        tmp_path,
+    parser = Parser(
+        Path("conf/v0.6/general/system/example_slurm_cluster.toml"), Path("conf/v0.6/general/test_template")
     )
+    system, tests, test_scenario = parser.parse(Path("conf/v0.6/general/test"), test_scenario_path)
+    handle_dry_run_and_run("dry-run", system, tests, test_scenario, tmp_path)
 
     results_output = list(tmp_path.glob("*"))[0]
     test_dirs = list(results_output.iterdir())

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -1,16 +1,17 @@
 from concurrent.futures import Future
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from cloudai._core.base_installer import BaseInstaller
 from cloudai._core.install_status_result import InstallStatusResult
+from cloudai._core.test import Test
 from cloudai._core.test_template import TestTemplate
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm import SlurmNode, SlurmNodeState
 
 
 @pytest.fixture
-def slurm_system():
+def slurm_system() -> SlurmSystem:
     nodes = [SlurmNode(name=f"node-0{i}", partition="main", state=SlurmNodeState.UNKNOWN_STATE) for i in range(33, 65)]
     backup_nodes = [
         SlurmNode(name=f"node0{i}", partition="backup", state=SlurmNodeState.UNKNOWN_STATE) for i in range(1, 9)
@@ -27,21 +28,25 @@ def slurm_system():
 
 
 @pytest.fixture
-def test_template_success():
+def test_success() -> Test:
     template = MagicMock(spec=TestTemplate)
     template.name = "test_template_success"
     template.install.return_value = InstallStatusResult(success=True)
     template.uninstall.return_value = InstallStatusResult(success=True)
-    return template
+    test = Mock(spec=Test)
+    test.test_template = template
+    return test
 
 
 @pytest.fixture
-def test_template_failure():
+def test_failure() -> Test:
     template = MagicMock(spec=TestTemplate)
     template.name = "test_template_failure"
     template.install.return_value = InstallStatusResult(success=False, message="Installation failed")
     template.uninstall.return_value = InstallStatusResult(success=False, message="Uninstallation failed")
-    return template
+    test = Mock(spec=Test)
+    test.test_template = template
+    return test
 
 
 def create_real_future(result):
@@ -51,48 +56,48 @@ def create_real_future(result):
 
 
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
-def test_install_success(mock_executor, slurm_system, test_template_success):
+def test_install_success(mock_executor: Mock, slurm_system: SlurmSystem, test_success: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_template_success.install.return_value)
+    mock_future = create_real_future(test_success.test_template.install.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
-    result = installer.install([test_template_success])
+    result = installer.install([test_success])
 
     assert result.success
     assert result.message == "All test templates installed successfully."
 
 
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
-def test_install_failure(mock_executor, slurm_system, test_template_failure):
+def test_install_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_failure: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_template_failure.install.return_value)
+    mock_future = create_real_future(test_failure.test_template.install.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
-    result = installer.install([test_template_failure])
+    result = installer.install([test_failure])
 
     assert not result.success
     assert result.message == "Some test templates failed to install."
 
 
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
-def test_uninstall_success(mock_executor, slurm_system, test_template_success):
+def test_uninstall_success(mock_executor: Mock, slurm_system: SlurmSystem, test_success: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_template_success.uninstall.return_value)
+    mock_future = create_real_future(test_success.test_template.uninstall.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
-    result = installer.uninstall([test_template_success])
+    result = installer.uninstall([test_success])
 
     assert result.success
     assert result.message == "All test templates uninstalled successfully."
 
 
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
-def test_uninstall_failure(mock_executor, slurm_system, test_template_failure):
+def test_uninstall_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_failure: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_template_failure.uninstall.return_value)
+    mock_future = create_real_future(test_failure.test_template.uninstall.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
-    result = installer.uninstall([test_template_failure])
+    result = installer.uninstall([test_failure])
 
     assert not result.success
     assert result.message == "Some test templates failed to uninstall."

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,14 +20,14 @@ class Test_Parser:
 
     @patch("cloudai._core.system_parser.SystemParser.parse")
     @patch("cloudai._core.test_parser.TestParser.parse_all")
-    def test_no_scenario(self, m_tp, m_sp, parser: Parser):
+    def test_no_scenario(self, test_parser: Mock, _, parser: Parser):
         tests_dir = parser.system_config_path.parent / "tests"
         tests_dir.mkdir()
         fake_tests = []
         for i in range(3):
             fake_tests.append(Mock())
             fake_tests[-1].name = f"test-{i}"
-        m_tp.return_value = fake_tests
+        test_parser.return_value = fake_tests
         fake_scenario = Mock()
         fake_scenario.tests = [Mock()]
         fake_scenario.tests[0].name = "test-1"
@@ -37,17 +37,17 @@ class Test_Parser:
     @patch("cloudai._core.system_parser.SystemParser.parse")
     @patch("cloudai._core.test_parser.TestParser.parse_all")
     @patch("cloudai._core.test_scenario_parser.TestScenarioParser.parse")
-    def test_scenario_filters_tests(self, m_tsp, m_tp, m_sp, parser: Parser):
+    def test_scenario_filters_tests(self, test_scenario_parser: Mock, test_parser: Mock, _, parser: Parser):
         tests_dir = parser.system_config_path.parent / "tests"
         tests_dir.mkdir()
         fake_tests = []
         for i in range(3):
             fake_tests.append(Mock())
             fake_tests[-1].name = f"test-{i}"
-        m_tp.return_value = fake_tests
+        test_parser.return_value = fake_tests
         fake_scenario = Mock()
         fake_scenario.tests = [Mock()]
         fake_scenario.tests[0].name = "test-1"
-        m_tsp.return_value = fake_scenario
+        test_scenario_parser.return_value = fake_scenario
         _, tests, _ = parser.parse(tests_dir, Path())
         assert len(tests) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+from cloudai import Parser
+from cloudai._core.test_parser import TestParser
+
+
+class Test_Parser:
+    @pytest.fixture()
+    def parser(self, tmp_path: Path) -> Parser:
+        system = tmp_path / "system.toml"
+        templates_dir = tmp_path / "templates"
+        return Parser(system, templates_dir)
+
+    def test_no_scenario_file(self, parser: Parser):
+        scenario = parser.system_config_path.parent / "scenario.toml"
+        tests_dir = parser.system_config_path.parent / "tests"
+        with pytest.raises(FileNotFoundError) as exc_info:
+            parser.parse(tests_dir, scenario)
+        assert "Test scenario path" in str(exc_info.value)
+
+    def test_no_tests_dir(self, parser: Parser):
+        scenario = parser.system_config_path.parent / "scenario.toml"
+        scenario.touch()
+        tests_dir = parser.system_config_path.parent / "tests"
+        with pytest.raises(FileNotFoundError) as exc_info:
+            parser.parse(tests_dir, scenario)
+        assert "Test path" in str(exc_info.value)
+
+
+class TestTestParser:
+    @pytest.fixture()
+    def test_parser(self, tmp_path: Path) -> TestParser:
+        return TestParser(tmp_path / "tests", {})
+
+    def test_no_dir(self, test_parser: TestParser):
+        with pytest.raises(FileNotFoundError) as exc_info:
+            test_parser.load_test_names()
+        assert "Test path" in str(exc_info.value)
+
+    def test_not_a_dir(self, test_parser: TestParser):
+        test_parser.directory_path.touch()
+        with pytest.raises(NotADirectoryError) as exc_info:
+            test_parser.load_test_names()
+        assert "Test path" in str(exc_info.value)
+
+    def test_one_config(self, test_parser: TestParser):
+        test_parser.directory_path.mkdir()
+        (test_parser.directory_path / "test1.toml").write_text("name = 'test1'")
+        assert test_parser.load_test_names() == {"test1"}
+
+    def test_many_configs(self, test_parser: TestParser):
+        test_parser.directory_path.mkdir()
+        (test_parser.directory_path / "test1.toml").write_text("name = 'test1'")
+        (test_parser.directory_path / "test2.toml").write_text("name = 'test2'")
+        assert test_parser.load_test_names() == {"test1", "test2"}


### PR DESCRIPTION
## Summary
1. Update CLI args to highlight where we need a directory or just a file. Replaced underscores with dashes as it seems to be nowadays' standard.
2. Use `TestScenario` for filtering tests and test templates used for installation.

## Test Plan
CI

## Additional Notes
—
