### PR TITLE
Improve overall performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["I", "B", "E", "D", "F", "SIM", "W", "C90", "EXE"]
+select = ["I", "B", "E", "D", "F", "SIM", "W", "C90", "EXE", "ERA"]
 ignore = [
     "D407", # Missing dashed underline after section
     "D203", # conflicts with D211

--- a/src/cloudai/report_generator/tool/tensorboard_data_reader.py
+++ b/src/cloudai/report_generator/tool/tensorboard_data_reader.py
@@ -15,8 +15,6 @@
 import os
 from typing import List, Tuple
 
-from tbparse import SummaryReader
-
 
 class TensorBoardDataReader:
     """
@@ -39,6 +37,8 @@ class TensorBoardDataReader:
         Returns:
             List[Tuple[int, float]]: A list of (step, value) tuples.
         """
+        from tbparse import SummaryReader  # lazy import to improve overall performance
+
         data = []
         for root, _, files in os.walk(self.directory_path):
             for file in files:


### PR DESCRIPTION
## Summary
1. `tbparse` import takes long time, made it a lazy import. This improves the very basic operations like showing help. On my host time reduced from 3 to 1 sec.
2. Added [`ERA`](https://docs.astral.sh/ruff/rules/#eradicate-era) linter to report commented code.

## Test Plan
CI

## Additional Notes
—
