### PR TITLE
Forbid accessing _core directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,24 @@ pythonpath = ["src"]
 root_package = "cloudai"
 
 [[tool.importlinter.contracts]]
-name = "_core does not higher level layers"
+name = "_core does not depends on higher level layers"
 type = "layers"
 layers = [
     "installer : parser : report_generator : runner : schema : util",
     "_core",
 ]
 containers = ["cloudai"]
+
+[[tool.importlinter.contracts]]
+name = "_core is not accessed directly"
+type = "forbidden"
+forbidden_modules = ["cloudai._core"]
+allow_indirect_imports = true # this is to allow "from cloudai import ..."
+source_modules = [
+    "cloudai.installer",
+    "cloudai.parser",
+    "cloudai.report_generator",
+    "cloudai.runner",
+    "cloudai.schema",
+    "cloudai.util",
+]

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ._core.base_installer import BaseInstaller, InstallStatusResult
+from ._core.base_job import BaseJob
+from ._core.base_runner import BaseRunner
 from ._core.command_gen_strategy import CommandGenStrategy
+from ._core.exceptions import JobIdRetrievalError
 from ._core.grader import Grader
 from ._core.grading_strategy import GradingStrategy
 from ._core.install_strategy import InstallStrategy
 from ._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
+from ._core.job_status_result import JobStatusResult
 from ._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from ._core.parser import Parser
 from ._core.registry import Registry

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -15,6 +15,7 @@
 from ._core.base_installer import BaseInstaller, InstallStatusResult
 from ._core.base_job import BaseJob
 from ._core.base_runner import BaseRunner
+from ._core.base_system_parser import BaseSystemParser
 from ._core.command_gen_strategy import CommandGenStrategy
 from ._core.exceptions import JobIdRetrievalError
 from ._core.grader import Grader

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -140,11 +140,18 @@ Registry().add_installer("slurm", SlurmInstaller)
 Registry().add_installer("standalone", StandaloneInstaller)
 
 __all__ = [
+    "BaseInstaller",
+    "BaseJob",
+    "BaseRunner",
+    "BaseSystemParser",
     "CommandGenStrategy",
     "Grader",
     "GradingStrategy",
     "Installer",
+    "InstallStatusResult",
     "InstallStrategy",
+    "JobIdRetrievalError",
+    "JobStatusResult",
     "Parser",
     "ReportGenerationStrategy",
     "ReportGenerator",

--- a/src/cloudai/installer/installer.py
+++ b/src/cloudai/installer/installer.py
@@ -15,10 +15,7 @@
 import logging
 from typing import Iterable
 
-from cloudai._core.install_status_result import InstallStatusResult
-from cloudai._core.registry import Registry
-from cloudai._core.system import System
-from cloudai._core.test import Test
+from cloudai import InstallStatusResult, Registry, System, Test
 
 
 class Installer:

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -20,10 +20,7 @@ from typing import Iterable, cast
 
 import toml
 
-from cloudai._core.base_installer import BaseInstaller
-from cloudai._core.install_status_result import InstallStatusResult
-from cloudai._core.system import System
-from cloudai._core.test import Test
+from cloudai import BaseInstaller, InstallStatusResult, System, Test
 from cloudai.systems import SlurmSystem
 
 

--- a/src/cloudai/installer/standalone_installer.py
+++ b/src/cloudai/installer/standalone_installer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.base_installer import BaseInstaller, InstallStatusResult
+from cloudai import BaseInstaller, InstallStatusResult
 
 
 class StandaloneInstaller(BaseInstaller):

--- a/src/cloudai/parser/system_parser/__init__.py
+++ b/src/cloudai/parser/system_parser/__init__.py
@@ -11,11 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from ..standalone.standalone_job import StandaloneJob
-from ..standalone.standalone_runner import StandaloneRunner
-
-__all__ = [
-    "StandaloneRunner",
-    "StandaloneJob",
-]

--- a/src/cloudai/parser/system_parser/slurm_system_parser.py
+++ b/src/cloudai/parser/system_parser/slurm_system_parser.py
@@ -15,7 +15,7 @@
 import os
 from typing import Any, Dict, List
 
-from cloudai._core.base_system_parser import BaseSystemParser
+from cloudai import BaseSystemParser
 from cloudai.systems.slurm import SlurmNode, SlurmNodeState, SlurmSystem
 
 

--- a/src/cloudai/parser/system_parser/standalone_system_parser.py
+++ b/src/cloudai/parser/system_parser/standalone_system_parser.py
@@ -15,7 +15,7 @@
 import os
 from typing import Any, Dict
 
-from cloudai._core.base_system_parser import BaseSystemParser
+from cloudai import BaseSystemParser
 from cloudai.systems import StandaloneSystem
 
 

--- a/src/cloudai/report_generator/report_generator.py
+++ b/src/cloudai/report_generator/report_generator.py
@@ -15,8 +15,7 @@
 import logging
 import os
 
-from cloudai._core.test import Test
-from cloudai._core.test_scenario import TestScenario
+from cloudai import Test, TestScenario
 
 
 class ReportGenerator:

--- a/src/cloudai/runner/slurm/__init__.py
+++ b/src/cloudai/runner/slurm/__init__.py
@@ -11,11 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from ..standalone.standalone_job import StandaloneJob
-from ..standalone.standalone_runner import StandaloneRunner
-
-__all__ = [
-    "StandaloneRunner",
-    "StandaloneJob",
-]

--- a/src/cloudai/runner/slurm/slurm_job.py
+++ b/src/cloudai/runner/slurm/slurm_job.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.base_job import BaseJob
+from cloudai import BaseJob
 
 
 class SlurmJob(BaseJob):

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -15,10 +15,10 @@
 import logging
 from typing import cast
 
+from cloudai import System
 from cloudai._core.base_job import BaseJob
 from cloudai._core.base_runner import BaseRunner
 from cloudai._core.exceptions import JobIdRetrievalError
-from cloudai._core.system import System
 from cloudai._core.test import Test
 from cloudai._core.test_scenario import TestScenario
 from cloudai.systems import SlurmSystem

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -15,12 +15,7 @@
 import logging
 from typing import cast
 
-from cloudai import System
-from cloudai._core.base_job import BaseJob
-from cloudai._core.base_runner import BaseRunner
-from cloudai._core.exceptions import JobIdRetrievalError
-from cloudai._core.test import Test
-from cloudai._core.test_scenario import TestScenario
+from cloudai import BaseJob, BaseRunner, JobIdRetrievalError, System, Test, TestScenario
 from cloudai.systems import SlurmSystem
 from cloudai.util import CommandShell
 

--- a/src/cloudai/runner/standalone/standalone_job.py
+++ b/src/cloudai/runner/standalone/standalone_job.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.base_job import BaseJob
+from cloudai import BaseJob
 
 
 class StandaloneJob(BaseJob):

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -15,12 +15,7 @@
 import logging
 from typing import cast
 
-from cloudai._core.base_job import BaseJob
-from cloudai._core.base_runner import BaseRunner
-from cloudai._core.exceptions import JobIdRetrievalError
-from cloudai._core.system import System
-from cloudai._core.test import Test
-from cloudai._core.test_scenario import TestScenario
+from cloudai import BaseJob, BaseRunner, JobIdRetrievalError, System, Test, TestScenario
 from cloudai.util import CommandShell
 
 from .standalone_job import StandaloneJob

--- a/src/cloudai/schema/test_template/__init__.py
+++ b/src/cloudai/schema/test_template/__init__.py
@@ -11,11 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from ..standalone.standalone_job import StandaloneJob
-from ..standalone.standalone_runner import StandaloneRunner
-
-__all__ = [
-    "StandaloneRunner",
-    "StandaloneJob",
-]

--- a/src/cloudai/schema/test_template/chakra_replay/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/report_generation_strategy.py
@@ -23,7 +23,7 @@ from bokeh.models import ColumnDataSource, DataTable, Div, TableColumn, Title
 from bokeh.palettes import Turbo256
 from bokeh.plotting import figure, output_file, save
 from bokeh.transform import cumsum
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
+from cloudai import ReportGenerationStrategy
 
 
 class ChakraReplayReportGenerationStrategy(ReportGenerationStrategy):

--- a/src/cloudai/schema/test_template/chakra_replay/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/report_generation_strategy.py
@@ -23,6 +23,7 @@ from bokeh.models import ColumnDataSource, DataTable, Div, TableColumn, Title
 from bokeh.palettes import Turbo256
 from bokeh.plotting import figure, output_file, save
 from bokeh.transform import cumsum
+
 from cloudai import ReportGenerationStrategy
 
 

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_install_strategy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.install_status_result import InstallStatusResult
+from cloudai import InstallStatusResult
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 
 

--- a/src/cloudai/schema/test_template/chakra_replay/template.py
+++ b/src/cloudai/schema/test_template/chakra_replay/template.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.test_template import TestTemplate
+from cloudai import TestTemplate
 
 
 class ChakraReplay(TestTemplate):

--- a/src/cloudai/schema/test_template/common/default_job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/common/default_job_status_retrieval_strategy.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-from cloudai._core.job_status_result import JobStatusResult
-from cloudai._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
+from cloudai import JobStatusResult, JobStatusRetrievalStrategy
 
 
 class DefaultJobStatusRetrievalStrategy(JobStatusRetrievalStrategy):

--- a/src/cloudai/schema/test_template/common/slurm_job_id_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/common/slurm_job_id_retrieval_strategy.py
@@ -15,7 +15,7 @@
 import re
 from typing import Optional
 
-from cloudai._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
+from cloudai import JobIdRetrievalStrategy
 
 
 class SlurmJobIdRetrievalStrategy(JobIdRetrievalStrategy):

--- a/src/cloudai/schema/test_template/common/standalone_job_id_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/common/standalone_job_id_retrieval_strategy.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from cloudai._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
+from cloudai import JobIdRetrievalStrategy
 
 
 class StandaloneJobIdRetrievalStrategy(JobIdRetrievalStrategy):

--- a/src/cloudai/schema/test_template/jax_toolbox/job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/job_status_retrieval_strategy.py
@@ -15,8 +15,7 @@
 import os
 from pathlib import Path
 
-from cloudai._core.job_status_result import JobStatusResult
-from cloudai._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
+from cloudai import JobStatusResult, JobStatusRetrievalStrategy
 
 
 class JaxToolboxJobStatusRetrievalStrategy(JobStatusRetrievalStrategy):

--- a/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
@@ -17,7 +17,7 @@ import os
 import statistics
 from typing import List, Optional
 
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
+from cloudai import ReportGenerationStrategy
 
 
 class JaxToolboxReportGenerationStrategy(ReportGenerationStrategy):

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_install_strategy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.install_status_result import InstallStatusResult
+from cloudai import InstallStatusResult
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 
 

--- a/src/cloudai/schema/test_template/jax_toolbox/template.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/template.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.test_template import TestTemplate
+from cloudai import TestTemplate
 
 
 class JaxToolbox(TestTemplate):

--- a/src/cloudai/schema/test_template/nccl_test/job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/job_status_retrieval_strategy.py
@@ -14,8 +14,7 @@
 
 import os
 
-from cloudai._core.job_status_result import JobStatusResult
-from cloudai._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
+from cloudai import JobStatusResult, JobStatusRetrievalStrategy
 
 
 class NcclTestJobStatusRetrievalStrategy(JobStatusRetrievalStrategy):

--- a/src/cloudai/schema/test_template/nccl_test/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/report_generation_strategy.py
@@ -17,7 +17,8 @@ import re
 from typing import List, Optional, Tuple
 
 import pandas as pd
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
+
+from cloudai import ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.tool.csv_report_tool import CSVReportTool
 from cloudai.report_generator.util import add_human_readable_sizes

--- a/src/cloudai/schema/test_template/nccl_test/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_install_strategy.py
@@ -14,7 +14,7 @@
 
 import os
 
-from cloudai._core.install_status_result import InstallStatusResult
+from cloudai import InstallStatusResult
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 
 

--- a/src/cloudai/schema/test_template/nccl_test/template.py
+++ b/src/cloudai/schema/test_template/nccl_test/template.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.test_template import TestTemplate
+from cloudai import TestTemplate
 
 
 class NcclTest(TestTemplate):

--- a/src/cloudai/schema/test_template/nemo_launcher/grading_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/grading_strategy.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+
 from cloudai import GradingStrategy
 from cloudai.report_generator.tool import TensorBoardDataReader
 

--- a/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
@@ -16,7 +16,7 @@ import os
 from typing import Optional
 
 import pandas as pd
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
+from cloudai import ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.tool.tensorboard_data_reader import TensorBoardDataReader
 

--- a/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
@@ -16,6 +16,7 @@ import os
 from typing import Optional
 
 import pandas as pd
+
 from cloudai import ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.tool.tensorboard_data_reader import TensorBoardDataReader

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -18,8 +18,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List
 
-from cloudai._core.install_status_result import InstallStatusResult
-from cloudai._core.system import System
+from cloudai import InstallStatusResult, System
 from cloudai.systems.slurm import SlurmNodeState
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_job_id_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_job_id_retrieval_strategy.py
@@ -15,7 +15,7 @@
 import re
 from typing import Optional
 
-from cloudai._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
+from cloudai import JobIdRetrievalStrategy
 
 
 class NeMoLauncherSlurmJobIdRetrievalStrategy(JobIdRetrievalStrategy):

--- a/src/cloudai/schema/test_template/nemo_launcher/template.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/template.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.test_template import TestTemplate
+from cloudai import TestTemplate
 
 
 class NeMoLauncher(TestTemplate):

--- a/src/cloudai/schema/test_template/sleep/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/report_generation_strategy.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
+from cloudai import ReportGenerationStrategy
 
 
 class SleepReportGenerationStrategy(ReportGenerationStrategy):

--- a/src/cloudai/schema/test_template/sleep/standalone_install_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/standalone_install_strategy.py
@@ -14,8 +14,7 @@
 
 import shutil
 
-from cloudai import InstallStrategy
-from cloudai._core.install_status_result import InstallStatusResult
+from cloudai import InstallStatusResult, InstallStrategy
 
 
 class SleepStandaloneInstallStrategy(InstallStrategy):

--- a/src/cloudai/schema/test_template/sleep/template.py
+++ b/src/cloudai/schema/test_template/sleep/template.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.test_template import TestTemplate
+from cloudai import TestTemplate
 
 
 class Sleep(TestTemplate):

--- a/src/cloudai/schema/test_template/ucc_test/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/report_generation_strategy.py
@@ -17,7 +17,7 @@ import re
 from typing import List, Optional
 
 import pandas as pd
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
+from cloudai import ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.util import add_human_readable_sizes
 

--- a/src/cloudai/schema/test_template/ucc_test/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/report_generation_strategy.py
@@ -17,6 +17,7 @@ import re
 from typing import List, Optional
 
 import pandas as pd
+
 from cloudai import ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.util import add_human_readable_sizes

--- a/src/cloudai/schema/test_template/ucc_test/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_install_strategy.py
@@ -14,7 +14,7 @@
 
 import os
 
-from cloudai._core.install_status_result import InstallStatusResult
+from cloudai import InstallStatusResult
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 
 

--- a/src/cloudai/schema/test_template/ucc_test/template.py
+++ b/src/cloudai/schema/test_template/ucc_test/template.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.test_template import TestTemplate
+from cloudai import TestTemplate
 
 
 class UCCTest(TestTemplate):

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -17,7 +17,7 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from cloudai._core.system import System
+from cloudai import System
 from cloudai.util import CommandShell
 
 from .slurm_node import SlurmNode, SlurmNodeState

--- a/src/cloudai/systems/standalone_system.py
+++ b/src/cloudai/systems/standalone_system.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudai._core.system import System
+from cloudai import System
 
 
 class StandaloneSystem(System):

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -16,10 +16,9 @@ from concurrent.futures import Future
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from cloudai import InstallStatusResult, TestTemplate
 from cloudai._core.base_installer import BaseInstaller
-from cloudai._core.install_status_result import InstallStatusResult
 from cloudai._core.test import Test
-from cloudai._core.test_template import TestTemplate
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm import SlurmNode, SlurmNodeState
 

--- a/tests/test_job_submission_error.py
+++ b/tests/test_job_submission_error.py
@@ -16,10 +16,10 @@ import subprocess
 from unittest.mock import MagicMock, Mock
 
 import pytest
+from cloudai import TestTemplate
 from cloudai._core.exceptions import JobIdRetrievalError
 from cloudai._core.test import Test
 from cloudai._core.test_scenario import TestScenario
-from cloudai._core.test_template import TestTemplate
 from cloudai.runner.slurm.slurm_runner import SlurmRunner
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm import SlurmNode, SlurmNodeState

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 
 import pytest
+from cloudai import JobIdRetrievalStrategy, JobStatusRetrievalStrategy, ReportGenerationStrategy, System, TestTemplate
 from cloudai._core.base_installer import BaseInstaller
 from cloudai._core.base_runner import BaseRunner
 from cloudai._core.base_system_parser import BaseSystemParser
-from cloudai._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
-from cloudai._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from cloudai._core.registry import Registry
-from cloudai._core.report_generation_strategy import ReportGenerationStrategy
-from cloudai._core.system import System
-from cloudai._core.test_template import TestTemplate
 from cloudai._core.test_template_strategy import TestTemplateStrategy
 
 

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from cloudai._core.install_status_result import InstallStatusResult
+from cloudai import InstallStatusResult
 from cloudai.schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
 from cloudai.schema.test_template.nemo_launcher.slurm_install_strategy import (
     DatasetCheckResult,


### PR DESCRIPTION
## Summary
Forbid accessing _core directly. This helps ensuring that all symbols needed for extending Core functionality are available.

## Test Plan
CI

## Additional Notes
—
