### PR TITLE
Refactor handle_install_and_uninstall to identify unique test templates

### DIFF
--- a/src/cloudai/installer/installer.py
+++ b/src/cloudai/installer/installer.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Iterable
 
-from cloudai import InstallStatusResult, Registry, System, Test
+from cloudai import InstallStatusResult, Registry, System, TestTemplate
 
 
 class Installer:
@@ -42,41 +42,41 @@ class Installer:
             raise NotImplementedError(f"No installer available for scheduler: {scheduler_type}")
         self.installer = installer_class(system)
 
-    def is_installed(self, tests: Iterable[Test]) -> InstallStatusResult:
+    def is_installed(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
         """
         Check if the necessary components for the provided test templates are already installed.
 
         Args:
-            tests (Iterable[Test]): The list of test templates to check.
+            test_templates (Iterable[TestTemplate]): The list of test templates to check.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        logging.info("Checking installation status of components.")
-        return self.installer.is_installed(tests)
+        logging.info("Checking installation status of test templates.")
+        return self.installer.is_installed(test_templates)
 
-    def install(self, tests: Iterable[Test]) -> InstallStatusResult:
+    def install(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
         """
-        Check if the necessary components are installed and install them if not using the instantiated installer.
+        Install the necessary components using the instantiated installer.
 
         Args:
-            tests (Iterable[Test]): The list of test templates to install.
+            test_templates (Iterable[TestTemplate]): The list of test templates to install.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
         logging.info("Installing test templates.")
-        return self.installer.install(tests)
+        return self.installer.install(test_templates)
 
-    def uninstall(self, tests: Iterable[Test]) -> InstallStatusResult:
+    def uninstall(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:
         """
         Uninstall the benchmarks or test templates using the instantiated installer.
 
         Args:
-            tests (Iterable[Test]): The list of test templates to uninstall.
+            test_templates (Iterable[TestTemplate]): The list of test templates to uninstall.
 
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
         logging.info("Uninstalling test templates.")
-        return self.installer.uninstall(tests)
+        return self.installer.uninstall(test_templates)

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Dict
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from cloudai import Parser
+from cloudai import InstallStatusResult, Parser, TestTemplate
 from cloudai.__main__ import handle_dry_run_and_run
+from cloudai._core.base_installer import BaseInstaller
+from cloudai.systems import SlurmSystem
+from cloudai.systems.slurm import SlurmNode, SlurmNodeState
 
 SLURM_TEST_SCENARIOS = [
     {
@@ -51,3 +56,107 @@ def test_slurm(tmp_path: Path, scenario: Dict):
     for td in test_dirs:
         assert td.is_dir(), "Invalid test directory"
         assert "Tests." in td.name, "Invalid test directory name"
+
+
+@pytest.fixture
+def slurm_system() -> SlurmSystem:
+    nodes = [SlurmNode(name=f"node-0{i}", partition="main", state=SlurmNodeState.UNKNOWN_STATE) for i in range(33, 65)]
+    backup_nodes = [
+        SlurmNode(name=f"node0{i}", partition="backup", state=SlurmNodeState.UNKNOWN_STATE) for i in range(1, 9)
+    ]
+
+    system = SlurmSystem(
+        name="test_system",
+        install_path="/fake/path",
+        output_path="/fake/output",
+        default_partition="main",
+        partitions={"main": nodes, "backup": backup_nodes},
+    )
+    return system
+
+
+@pytest.fixture
+def test_template_success() -> TestTemplate:
+    template = MagicMock(spec=TestTemplate)
+    template.name = "test_template_success"
+    template.install.return_value = InstallStatusResult(success=True)
+    template.uninstall.return_value = InstallStatusResult(success=True)
+    return template
+
+
+@pytest.fixture
+def test_template_failure() -> TestTemplate:
+    template = MagicMock(spec=TestTemplate)
+    template.name = "test_template_failure"
+    template.install.return_value = InstallStatusResult(success=False, message="Installation failed")
+    template.uninstall.return_value = InstallStatusResult(success=False, message="Uninstallation failed")
+    return template
+
+
+def create_real_future(result):
+    future = Future()
+    future.set_result(result)
+    return future
+
+
+def extract_unique_test_templates(test_templates):
+    unique_test_templates = {}
+    for test_template in test_templates:
+        template_name = test_template.name
+        if template_name not in unique_test_templates:
+            unique_test_templates[template_name] = test_template
+    return list(unique_test_templates.values())
+
+
+@patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
+def test_install_success(mock_executor: Mock, slurm_system: SlurmSystem, test_template_success: Mock):
+    installer = BaseInstaller(slurm_system)
+    mock_future = create_real_future(test_template_success.install.return_value)
+    mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
+
+    result = installer.install([test_template_success])
+
+    assert result.success
+    assert result.message == "All test templates installed successfully."
+
+    # Check if the template is installed
+    assert installer.is_installed([test_template_success])
+
+
+@patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
+def test_install_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_template_failure: Mock):
+    installer = BaseInstaller(slurm_system)
+    mock_future = create_real_future(test_template_failure.install.return_value)
+    mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
+
+    result = installer.install([test_template_failure])
+
+    assert not result.success
+    assert result.message == "Some test templates failed to install."
+
+
+@patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
+def test_uninstall_success(mock_executor: Mock, slurm_system: SlurmSystem, test_template_success: Mock):
+    installer = BaseInstaller(slurm_system)
+    mock_future = create_real_future(test_template_success.uninstall.return_value)
+    mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
+
+    result = installer.uninstall([test_template_success])
+
+    assert result.success
+    assert result.message == "All test templates uninstalled successfully."
+
+
+@patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
+def test_uninstall_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_template_failure: Mock):
+    installer = BaseInstaller(slurm_system)
+    mock_future = create_real_future(test_template_failure.uninstall.return_value)
+    mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
+
+    result = installer.uninstall([test_template_failure])
+
+    assert not result.success
+    assert result.message == "Some test templates failed to uninstall."
+
+    # Check if the template is still installed
+    assert installer.is_installed([test_template_failure])

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -46,9 +46,7 @@ def test_success() -> Test:
     template.name = "test_template_success"
     template.install.return_value = InstallStatusResult(success=True)
     template.uninstall.return_value = InstallStatusResult(success=True)
-    test = Mock(spec=Test)
-    test.test_template = template
-    return test
+    return template
 
 
 @pytest.fixture
@@ -57,9 +55,7 @@ def test_failure() -> Test:
     template.name = "test_template_failure"
     template.install.return_value = InstallStatusResult(success=False, message="Installation failed")
     template.uninstall.return_value = InstallStatusResult(success=False, message="Uninstallation failed")
-    test = Mock(spec=Test)
-    test.test_template = template
-    return test
+    return template
 
 
 def create_real_future(result):
@@ -71,7 +67,7 @@ def create_real_future(result):
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
 def test_install_success(mock_executor: Mock, slurm_system: SlurmSystem, test_success: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_success.test_template.install.return_value)
+    mock_future = create_real_future(test_success.install.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
     result = installer.install([test_success])
@@ -83,7 +79,7 @@ def test_install_success(mock_executor: Mock, slurm_system: SlurmSystem, test_su
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
 def test_install_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_failure: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_failure.test_template.install.return_value)
+    mock_future = create_real_future(test_failure.install.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
     result = installer.install([test_failure])
@@ -95,7 +91,7 @@ def test_install_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_fa
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
 def test_uninstall_success(mock_executor: Mock, slurm_system: SlurmSystem, test_success: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_success.test_template.uninstall.return_value)
+    mock_future = create_real_future(test_success.uninstall.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
     result = installer.uninstall([test_success])
@@ -107,7 +103,7 @@ def test_uninstall_success(mock_executor: Mock, slurm_system: SlurmSystem, test_
 @patch("cloudai._core.base_installer.ThreadPoolExecutor", autospec=True)
 def test_uninstall_failure(mock_executor: Mock, slurm_system: SlurmSystem, test_failure: Mock):
     installer = BaseInstaller(slurm_system)
-    mock_future = create_real_future(test_failure.test_template.uninstall.return_value)
+    mock_future = create_real_future(test_failure.uninstall.return_value)
     mock_executor.return_value.__enter__.return_value.submit.return_value = mock_future
 
     result = installer.uninstall([test_failure])


### PR DESCRIPTION
## Summary
Refactor installer for TestTemplate iterables in Slurm and base classes. Currently, all tests in a test scenario directory are passed to `is_installed`, `install`, and `uninstall`, which is inefficient. This approach triggers multiple processes for installation and uninstallation. This pull request now uniquely identifies test templates within the directory before passing them to the respective methods.

## Test Plan
**1. CI passes.
2. Ran on a system**
```
$ python ./cloudaix.py --mode install --system-config ...
[INFO] Scheduler: slurm                                                     
[INFO] Checking installation status of components.                          
[INFO] Verifying installation status of test templates.                     
[INFO] Test template NcclTest is not installed.
[INFO] Not all components are ready, preparing
...
```