### PR TITLE
Reduce logs for stdout

### DIFF
--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -171,13 +171,13 @@ def handle_install_and_uninstall(mode: str, system: System, tests: List[Test]) -
         for template in unique_test_templates:
             if not installer.is_installed([template]):
                 all_installed = False
-                logging.info(f"Test template {template.name} is not installed.")
+                logging.debug(f"Test template {template.name} is not installed.")
                 break
 
         if all_installed:
             logging.info("CloudAI is already installed.")
         else:
-            logging.info("Not all components are ready, preparing")
+            logging.info("Not all components are ready")
             result = installer.install(list(unique_test_templates))
             if result.success:
                 logging.info("Installation successful.")

--- a/src/cloudai/installer/installer.py
+++ b/src/cloudai/installer/installer.py
@@ -52,7 +52,7 @@ class Installer:
         Returns:
             InstallStatusResult: Result containing the installation status and error message if not installed.
         """
-        logging.info("Checking installation status of test templates.")
+        logging.debug("Checking installation status of test templates.")
         return self.installer.is_installed(test_templates)
 
     def install(self, test_templates: Iterable[TestTemplate]) -> InstallStatusResult:

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -217,7 +217,7 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         idle_nodes = [node.name for node in partition_nodes if node.state == SlurmNodeState.IDLE]
 
         if not idle_nodes:
-            logging.info(
+            logging.warning(
                 "There are no idle nodes in the default partition to check. "
                 "Skipping NeMo-Launcher dataset verification."
             )
@@ -280,15 +280,15 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         repo_path = os.path.join(subdir_path, self.REPOSITORY_NAME)
 
         if os.path.exists(repo_path):
-            logging.info("Repository already exists at %s, clone skipped", repo_path)
+            logging.warning("Repository already exists at %s, clone skipped", repo_path)
         else:
-            logging.info("Cloning NeMo-Launcher repository into %s", repo_path)
+            logging.debug("Cloning NeMo-Launcher repository into %s", repo_path)
             clone_cmd = ["git", "clone", self.repository_url, repo_path]
             result = subprocess.run(clone_cmd, capture_output=True, text=True)
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to clone repository: {result.stderr}")
 
-        logging.info("Checking out specific commit %s in repository", self.repository_commit_hash)
+        logging.debug("Checking out specific commit %s in repository", self.repository_commit_hash)
         checkout_cmd = ["git", "checkout", self.repository_commit_hash]
         result = subprocess.run(checkout_cmd, cwd=repo_path, capture_output=True, text=True)
         if result.returncode != 0:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -177,25 +177,25 @@ class DockerImageCacheManager:
 
         # Check if the cache file exists
         if not os.path.exists(self.install_path):
-            error_message = f"Install path {self.install_path} does not exist."
-            logging.error(error_message)
-            return DockerImageCacheResult(False, "", error_message)
+            message = f"Install path {self.install_path} does not exist."
+            logging.debug(message)
+            return DockerImageCacheResult(False, "", message)
 
         subdir_path = os.path.join(self.install_path, subdir_name)
         if not os.path.exists(subdir_path):
-            error_message = f"Subdirectory path {subdir_path} does not exist."
-            logging.error(error_message)
-            return DockerImageCacheResult(False, "", error_message)
+            message = f"Subdirectory path {subdir_path} does not exist."
+            logging.debug(message)
+            return DockerImageCacheResult(False, "", message)
 
         docker_image_path = os.path.join(subdir_path, docker_image_filename)
         if os.path.isfile(docker_image_path) and os.path.exists(docker_image_path):
-            success_message = f"Cached Docker image already exists at {docker_image_path}."
-            logging.info(success_message)
-            return DockerImageCacheResult(True, docker_image_path, success_message)
+            message = f"Cached Docker image already exists at {docker_image_path}."
+            logging.debug(message)
+            return DockerImageCacheResult(True, docker_image_path, message)
 
-        error_message = f"Docker image does not exist at the specified path: {docker_image_path}."
-        logging.info(error_message)
-        return DockerImageCacheResult(False, "", error_message)
+        message = f"Docker image does not exist at the specified path: {docker_image_path}."
+        logging.debug(message)
+        return DockerImageCacheResult(False, "", message)
 
     def cache_docker_image(
         self, docker_image_url: str, subdir_name: str, docker_image_filename: str
@@ -249,9 +249,10 @@ class DockerImageCacheManager:
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
 
         try:
-            subprocess.run(enroot_import_cmd, shell=True, check=True)
+            p = subprocess.run(enroot_import_cmd, shell=True, check=True, capture_output=True)
             success_message = f"Docker image cached successfully at {docker_image_path}."
-            logging.info(success_message)
+            logging.debug(success_message)
+            logging.debug(f"Command used: {enroot_import_cmd}, stdout: {p.stdout}, stderr: {p.stderr}")
             return DockerImageCacheResult(True, docker_image_path, success_message)
         except subprocess.CalledProcessError as e:
             error_message = (

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -94,6 +94,7 @@ def test_cache_docker_image(mock_check_prerequisites, mock_run, mock_makedirs, m
         "srun --export=ALL --partition=default enroot import -o /fake/install/path/subdir/image.tar.gz docker://docker.io/hello-world",
         shell=True,
         check=True,
+        capture_output=True,
     )
     assert result.success
     assert result.message == "Docker image cached successfully at /fake/install/path/subdir/image.tar.gz."


### PR DESCRIPTION
## Summary
Reduce stdout logging by default, track only main progress and errors. Keep all details in the file by default.

```bash
$ cloudai --mode install --system-config system.toml --test-templates-dir test_template/ --tests-dir test/
[INFO] System configuration file: ...
[INFO] Test templates directory: ...
[INFO] Tests directory: ...
[INFO] Test scenario file: None
[INFO] Output directory: None
[WARNING] No JobIdRetrievalStrategy found for TestTemplateParser and SlurmSystem
[WARNING] No JobStatusRetrievalStrategy found for TestTemplateParser and SlurmSystem
[INFO] System Name: ...
[INFO] Scheduler: slurm
[INFO] Not all components are ready
[INFO] Installing test templates.
[INFO] 1/5 Installation for ChakraReplay finished with status: OK
[INFO] 2/5 Installation for Sleep finished with status: OK
[INFO] 3/5 Installation for UCCTest finished with status: OK
[INFO] 4/5 Installation for NcclTest finished with status: OK
[INFO] 5/5 Installation for NeMoLauncher finished with status: OK
[INFO] Installation successful.
```

## Test Plan
CI

## Additional Notes
—
