### PR TITLE
Fix bug in NeMo launcher report generation

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/report_generation_strategy.py
@@ -37,7 +37,7 @@ class NeMoLauncherReportGenerationStrategy(ReportGenerationStrategy):
         return False
 
     def generate_report(self, test_name: str, directory_path: str, sol: Optional[float] = None) -> None:
-        tags = ["train_step_timing"]
+        tags = ["train_step_timing in s"]
         data_reader = TensorBoardDataReader(directory_path)
         report_tool = BokehReportTool(directory_path)
 


### PR DESCRIPTION
## Summary
Fix bug in NeMo launcher report generation. The tag name has been updated from 'train_step_timing' to 'train_step_timing in s'

## Test Plan
```
$ python3 cloudaix.py --system-config ... --output-dir ... --mode generate-report --test-scenario ...
```
[Report Generated]