### PR TITLE
Add support for Sleep on Slurm systems

### DIFF
--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -72,6 +72,7 @@ from .schema.test_template.nemo_launcher.slurm_job_id_retrieval_strategy import 
 from .schema.test_template.nemo_launcher.template import NeMoLauncher
 from .schema.test_template.sleep.grading_strategy import SleepGradingStrategy
 from .schema.test_template.sleep.report_generation_strategy import SleepReportGenerationStrategy
+from .schema.test_template.sleep.slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from .schema.test_template.sleep.standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
 from .schema.test_template.sleep.standalone_install_strategy import SleepStandaloneInstallStrategy
 from .schema.test_template.sleep.template import Sleep
@@ -92,7 +93,8 @@ Registry().add_runner("standalone", StandaloneRunner)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NcclTest], NcclTestSlurmInstallStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NeMoLauncher], NeMoLauncherSlurmInstallStrategy)
 Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [NcclTest], NcclTestReportGenerationStrategy)
-Registry().add_strategy(CommandGenStrategy, [StandaloneSystem, SlurmSystem], [Sleep], SleepStandaloneCommandGenStrategy)
+Registry().add_strategy(CommandGenStrategy, [StandaloneSystem], [Sleep], SleepStandaloneCommandGenStrategy)
+Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [Sleep], SleepSlurmCommandGenStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxSlurmInstallStrategy)
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [NcclTest], NcclTestGradingStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmInstallStrategy)
@@ -112,7 +114,10 @@ Registry().add_strategy(GradingStrategy, [SlurmSystem], [JaxToolbox], JaxToolbox
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [UCCTest], UCCTestGradingStrategy)
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxSlurmCommandGenStrategy)
 Registry().add_strategy(
-    JobIdRetrievalStrategy, [SlurmSystem], [ChakraReplay, JaxToolbox, NcclTest, UCCTest], SlurmJobIdRetrievalStrategy
+    JobIdRetrievalStrategy,
+    [SlurmSystem],
+    [ChakraReplay, JaxToolbox, NcclTest, UCCTest, Sleep],
+    SlurmJobIdRetrievalStrategy,
 )
 Registry().add_strategy(JobIdRetrievalStrategy, [StandaloneSystem], [Sleep], StandaloneJobIdRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [StandaloneSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
@@ -121,7 +126,7 @@ Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [JaxToolbox],
 Registry().add_strategy(
     JobStatusRetrievalStrategy,
     [SlurmSystem],
-    [ChakraReplay, UCCTest, NeMoLauncher],
+    [ChakraReplay, UCCTest, NeMoLauncher, Sleep],
     DefaultJobStatusRetrievalStrategy,
 )
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmCommandGenStrategy)

--- a/src/cloudai/schema/test_template/sleep/__init__.py
+++ b/src/cloudai/schema/test_template/sleep/__init__.py
@@ -15,6 +15,7 @@
 
 from .grading_strategy import SleepGradingStrategy
 from .report_generation_strategy import SleepReportGenerationStrategy
+from .slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from .standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
 from .standalone_install_strategy import SleepStandaloneInstallStrategy
 from .template import Sleep
@@ -23,6 +24,7 @@ __all__ = [
     "Sleep",
     "SleepStandaloneInstallStrategy",
     "SleepStandaloneCommandGenStrategy",
+    "SleepSlurmCommandGenStrategy",
     "SleepReportGenerationStrategy",
     "SleepGradingStrategy",
 ]

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List
+
+from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
+
+
+class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
+    """Command generation strategy for Sleep on Slurm systems."""
+
+    def gen_exec_command(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> str:
+        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
+        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+        env_vars_str = self._format_env_vars(final_env_vars)
+
+        slurm_args = self._parse_slurm_args("sleep", final_env_vars, final_cmd_args, num_nodes, nodes)
+        srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
+
+    def _generate_srun_command(
+        self,
+        slurm_args: Dict[str, Any],
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_cmd_args: str,
+    ) -> str:
+        srun_command_parts = [
+            "srun",
+            f"--mpi={slurm_args['mpi']}",
+        ]
+
+        sec = cmd_args["seconds"]
+        srun_command_parts.append(f"sleep {sec}")
+
+        return " \\\n".join(srun_command_parts)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -51,6 +51,7 @@ from cloudai.schema.test_template.nemo_launcher.slurm_job_id_retrieval_strategy 
 from cloudai.schema.test_template.nemo_launcher.template import NeMoLauncher
 from cloudai.schema.test_template.sleep.grading_strategy import SleepGradingStrategy
 from cloudai.schema.test_template.sleep.report_generation_strategy import SleepReportGenerationStrategy
+from cloudai.schema.test_template.sleep.slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from cloudai.schema.test_template.sleep.standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
 from cloudai.schema.test_template.sleep.standalone_install_strategy import SleepStandaloneInstallStrategy
 from cloudai.schema.test_template.sleep.template import Sleep
@@ -84,7 +85,7 @@ def test_runners():
         ((CommandGenStrategy, SlurmSystem, JaxToolbox), JaxToolboxSlurmCommandGenStrategy),
         ((CommandGenStrategy, SlurmSystem, NcclTest), NcclTestSlurmCommandGenStrategy),
         ((CommandGenStrategy, SlurmSystem, NeMoLauncher), NeMoLauncherSlurmCommandGenStrategy),
-        ((CommandGenStrategy, SlurmSystem, Sleep), SleepStandaloneCommandGenStrategy),
+        ((CommandGenStrategy, SlurmSystem, Sleep), SleepSlurmCommandGenStrategy),
         ((CommandGenStrategy, SlurmSystem, UCCTest), UCCTestSlurmCommandGenStrategy),
         ((CommandGenStrategy, StandaloneSystem, Sleep), SleepStandaloneCommandGenStrategy),
         ((GradingStrategy, SlurmSystem, ChakraReplay), ChakraReplayGradingStrategy),


### PR DESCRIPTION
## Summary
Add support for Sleep on Slurm systems

The main branch fails with the following error.
```
$ cloudai --mode run --system-config conf/v0.6/general/system/system_1.toml --test-scenario conf/v0.6/general/test_scenario/sleep.toml --tests-dir conf/v0.6/general/test/ --test-templates-dir conf/v0.6/general/test_template/
[INFO] System configuration file: conf/v0.6/general/system/system_1.toml
[INFO] Test templates directory: conf/v0.6/general/test_template
[INFO] Tests directory: conf/v0.6/general/test
[INFO] Test scenario file: conf/v0.6/general/test_scenario/sleep.toml
[INFO] Output directory: None
[WARNING] No JobIdRetrievalStrategy found for TestTemplateParser and SlurmSystem
[WARNING] No JobStatusRetrievalStrategy found for TestTemplateParser and SlurmSystem
[INFO] System Name: system_1
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: test_scenario_example
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: test_scenario_example

Section Name: Tests.1
  Test Name: sleep_10
  Description: sleep_10
  No dependencies
Section Name: Tests.2
  Test Name: sleep_5
  Description: sleep_5
  Start Post Init: Tests.1, Time: 5 seconds
Section Name: Tests.3
  Test Name: sleep_5
  Description: sleep_5
  Start Post Comp: Tests.1, Time: 0 seconds
Section Name: Tests.4
  Test Name: sleep_20
  Description: sleep_20
  End Post Comp: Tests.1, Time: 5 seconds
[INFO] Initializing Runner
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Executing command for test Tests.1: sleep 10
Traceback (most recent call last):
  File "/path/to/cloudai/bin/cloudai", line 8, in <module>
    sys.exit(main())
  File "/path/to/cloudai/src/cloudai/__main__.py", line 294, in main
    handle_dry_run_and_run(args.mode, system, tests, test_scenario)
  File "/path/to/cloudai/src/cloudai/__main__.py", line 232, in handle_dry_run_and_run
    asyncio.run(runner.run())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/path/to/cloudai/src/cloudai/_core/runner.py", line 75, in run
    await self.runner.run()
  File "/path/to/cloudai/src/cloudai/_core/base_runner.py", line 155, in run
    await self.submit_test(test)
  File "/path/to/cloudai/src/cloudai/_core/base_runner.py", line 171, in submit_test
    job = self._submit_test(test)
  File "/path/to/cloudai/src/cloudai/runner/slurm/slurm_runner.py", line 70, in _submit_test
    job_id = test.get_job_id(stdout, stderr)
  File "/path/to/cloudai/src/cloudai/_core/test.py", line 162, in get_job_id
    return self.test_template.get_job_id(stdout, stderr)
  File "/path/to/cloudai/src/cloudai/_core/test_template.py", line 174, in get_job_id
    assert self.job_id_retrieval_strategy is not None
AssertionError
```

## Test Plan
```
$ python ./cloudaix.py --mode run --system-config ... --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/sleep.toml 
...
[INFO] Scheduling termination of job 199235 after 5 seconds.
[INFO] Job completed: Tests.2
[INFO] Job completed: Tests.3
[INFO] Job completed: Tests.4
[INFO] All test scenario results stored at:
...
```
