### PR TITLE
Fix bug in generating NeMo launcher command

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -88,7 +88,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         cmd_args_str = self._generate_cmd_args_str(self.final_cmd_args, nodes)
 
-        full_cmd = f"./venv/bin/python {launcher_path}/launcher_scripts/main.py {cmd_args_str}"
+        full_cmd = f"python {launcher_path}/launcher_scripts/main.py {cmd_args_str}"
 
         if extra_cmd_args:
             full_cmd += " " + extra_cmd_args


### PR DESCRIPTION
## Summary
Fix the bug in generating the NeMo launcher command. Daria encountered the error "FileNotFoundError: [Errno 2] No such file or directory: .../run/results/nemo_log_globalrank-127_localrank-7.txt" in log-nemo-megatron-run_*.err. I found that the keyword venv/bin/python was causing the issue. The intention was to call venv/bin/python to run Python in the virtual environment, not the global Python. Directly calling Python fixed the issue, as it could identify the correct Python binary anyway.

## Test Plan
```
$ python ./cloudaix.py --mode run --system-config conf/v0.6/general/system/... --test-templates-dir conf/v0.6/general/test_template/ --tests-dir conf/v0.6/general/test/ --test-scenario conf/v0.6/general/test_scenario/gpt/gpt.toml
...
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: .../results/2024-07-03_21-20-25
[INFO] All test scenario execution attempts are complete. Please review the 'debug.log' file to confirm successful completion or to identify any issues.

$ tail ...../log-nemo-megatron-run_186185.out
Epoch 0: :  93%|█████████▎| 371/400 [12:39<00:59, v_num=, reduced_train_loss=4.490, global_step=370.0, c
Epoch 0: :  93%|█████████▎| 372/400 [12:41<00:57, v_num=, reduced_train_loss=4.490, global_step=370.0, c
Epoch 0: :  93%|█████████▎| 372/400 [12:41<00:57, v_num=, reduced_train_loss=4.280, global_step=371.0, c
Epoch 0: :  93%|█████████▎| 373/400 [12:43<00:55, v_num=, reduced_train_loss=4.280, global_step=371.0, c
Epoch 0: :  93%|█████████▎| 373/400 [12:43<00:55, v_num=, reduced_train_loss=4.470, global_step=372.0, c
Epoch 0: :  94%|█████████▎| 374/400 [12:45<00:53, v_num=, reduced_train_loss=4.470, global_step=372.0, c
Epoch 0: :  94%|█████████▎| 374/400 [12:45<00:53, v_num=, reduced_train_loss=4.330, global_step=373.0, c
Epoch 0: :  94%|█████████▍| 375/400 [12:47<00:51, v_num=, reduced_train_loss=4.330, global_step=373.0, c
Epoch 0: :  94%|█████████▍| 375/400 [12:47<00:51, v_num=, reduced_train_loss=4.420, global_step=374.0, c
Epoch 0: :  94%|█████████▍| 376/400 [12:49<00:49, v_num=, reduced_train_loss=4.420, global_step=374.0, c
Epoch 0: :  94%|█████████▍| 376/400 [12:49<00:49, v_num=, reduced_train_loss=4.680, global_step=375.0, c
Epoch 0: :  94%|█████████▍| 377/400 [12:51<00:47, v_num=, reduced_train_loss=4.680, global_step=375.0, c
Epoch 0: :  94%|█████████▍| 377/400 [12:51<00:47, v_num=, reduced_train_loss=4.440, global_step=376.0, c
Epoch 0: :  94%|█████████▍| 378/400 [12:53<00:44, v_num=, reduced_train_loss=4.440, global_step=376.0, c
Epoch 0: :  94%|█████████▍| 378/400 [12:53<00:44, v_num=, reduced_train_loss=4.390, global_step=377.0, c
Epoch 0: :  95%|█████████▍| 379/400 [12:54<00:42, v_num=, reduced_train_loss=4.390, global_step=377.0, c
Epoch 0: :  95%|█████████▍| 379/400 [12:54<00:42, v_num=, reduced_train_loss=4.480, global_step=378.0, c
Epoch 0: :  95%|█████████▌| 380/400 [12:56<00:40, v_num=, reduced_train_loss=4.480, global_step=378.0, c
Epoch 0: :  95%|█████████▌| 380/400 [12:56<00:40, v_num=, reduced_train_loss=4.510, global_step=379.0, c
Epoch 0: :  95%|█████████▌| 381/400 [12:58<00:38, v_num=, reduced_train_loss=4.510, global_step=379.0, c
Epoch 0: :  95%|█████████▌| 381/400 [12:58<00:38, v_num=, reduced_train_loss=4.310, global_step=380.0, c
Epoch 0: :  96%|█████████▌| 382/400 [13:00<00:36, v_num=, reduced_train_loss=4.310, global_step=380.0, c
Epoch 0: :  96%|█████████▌| 382/400 [13:00<00:36, v_num=, reduced_train_loss=4.500, global_step=381.0, c
Epoch 0: :  96%|█████████▌| 383/400 [13:02<00:34, v_num=, reduced_train_loss=4.500, global_step=381.0, c
Epoch 0: :  96%|█████████▌| 383/400 [13:02<00:34, v_num=, reduced_train_loss=4.380, global_step=382.0, c
Epoch 0: :  96%|█████████▌| 384/400 [13:04<00:32, v_num=, reduced_train_loss=4.380, global_step=382.0, c
Epoch 0: :  96%|█████████▌| 384/400 [13:04<00:32, v_num=, reduced_train_loss=4.550, global_step=383.0, c
Epoch 0: :  96%|█████████▋| 385/400 [13:06<00:30, v_num=, reduced_train_loss=4.550, global_step=383.0, c
```