### PR TITLE
Allow local docker image caching for JaxToolbox

### DIFF
--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List
 
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
+from .slurm_install_strategy import JaxToolboxSlurmInstallStrategy
+
 
 class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for JaxToolbox tests on Slurm systems."""
@@ -107,7 +109,11 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, num_nodes, nodes)
 
-        image_path = cmd_args["docker_image_url"]
+        image_path = self.docker_image_cache_manager.ensure_docker_image(
+            self.docker_image_url,
+            JaxToolboxSlurmInstallStrategy.SUBDIR_PATH,
+            JaxToolboxSlurmInstallStrategy.DOCKER_IMAGE_FILENAME,
+        ).docker_image_path
 
         local_workspace_dir = os.path.abspath(cmd_args["output_path"])
         docker_workspace_dir = cmd_args["docker_workspace_dir"]

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_install_strategy.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from cloudai import InstallStatusResult
 from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 
@@ -20,5 +22,63 @@ from cloudai.systems.slurm.strategy import SlurmInstallStrategy
 class JaxToolboxSlurmInstallStrategy(SlurmInstallStrategy):
     """Install strategy for JaxToolbox on Slurm systems."""
 
+    SUBDIR_PATH = "jax-toolbox"
+    DOCKER_IMAGE_FILENAME = "jax_toolbox.sqsh"
+
     def is_installed(self) -> InstallStatusResult:
+        docker_image_result = self.docker_image_cache_manager.check_docker_image_exists(
+            self.docker_image_url, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+        )
+        if docker_image_result.success:
+            return InstallStatusResult(success=True)
+        else:
+            if self.docker_image_cache_manager.cache_docker_images_locally:
+                expected_docker_image_path = os.path.join(
+                    self.docker_image_cache_manager.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+                )
+                return InstallStatusResult(
+                    success=False,
+                    message=(
+                        f"Docker image for JaxToolbox is not installed.\n"
+                        f"    - Expected path: {expected_docker_image_path}.\n"
+                        f"    - Error: {docker_image_result.message}"
+                    ),
+                )
+            else:
+                return InstallStatusResult(
+                    success=False,
+                    message=(
+                        f"Docker image for JaxToolbox is not accessible.\n    - Error: {docker_image_result.message}"
+                    ),
+                )
+
+    def install(self) -> InstallStatusResult:
+        install_status = self.is_installed()
+        if install_status.success:
+            return InstallStatusResult(success=True)
+
+        docker_image_result = self.docker_image_cache_manager.ensure_docker_image(
+            self.docker_image_url, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+        )
+        if not docker_image_result.success:
+            return InstallStatusResult(
+                success=False,
+                message=(
+                    "Failed to download and import the Docker image for JaxToolbox. "
+                    f"Error: {docker_image_result.message}"
+                ),
+            )
+
+        return InstallStatusResult(success=True)
+
+    def uninstall(self) -> InstallStatusResult:
+        docker_image_result = self.docker_image_cache_manager.uninstall_cached_image(
+            self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+        )
+        if not docker_image_result.success:
+            return InstallStatusResult(
+                success=False,
+                message=("Failed to remove the Docker image for JaxToolbox. Error: {docker_image_result.message}"),
+            )
+
         return InstallStatusResult(success=True)


### PR DESCRIPTION
## Summary
Allow local docker image caching for JaxToolbox

## Test Plan
```
$ python ./cloudaix.py --mode run --system-config conf/v0.6/general/system/... --log-level DEBUG
 --test-templates-dir conf/internal/jax_toolbox/test_template/ --tests-dir conf/internal/jax_toolbox/test --test-scenario conf/internal/jax_toolbox/test_scenario/grok_proxy/test_scenario_...toml     
[INFO] All test scenario results stored at:...
[INFO] All test scenario execution attempts are complete. Please review the 'debug.log' file to confirm successful completion or to identify any issues.                                                                    
```