### PR TITLE
Add mpi field to SlurmSystem and allow different MPI options in schema

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -103,6 +103,7 @@ output_path = "./results"
 cache_docker_images_locally = "True"
 default_partition = "<YOUR PARTITION NAME>"
 
+mpi = "pmix"
 gpus_per_node = 8
 ntasks_per_node = 8
 
@@ -210,6 +211,7 @@ install_path = "./install"
 output_path = "./results"
 default_partition = "partition_1"
 
+mpi = "pmix"
 gpus_per_node = 8
 ntasks_per_node = 8
 
@@ -260,6 +262,7 @@ cache_docker_images_locally = true
 - **default_partition**: Specifies the default partition where jobs are scheduled.
 - **partitions**: Describes the available partitions and nodes within those partitions.
   - **groups**: Within the same partition, users can define groups of nodes. This is a logical grouping that does not overlap between groups. The group concept can be used to allocate nodes from specific groups in a test scenario schema.
+- **mpi**: Indicates the Process Management Interface (PMI) implementation to be used for inter-process communication.
 - **gpus_per_node** and **ntasks_per_node**: These are Slurm arguments passed to the `sbatch` script and `srun`.
 - **cache_docker_images_locally**: Specifies whether CloudAI should cache remote Docker images locally during installation. If set to `true`, CloudAI will cache the Docker images, enabling local access without needing to download them each time a test template is run. This approach saves network bandwidth but requires more disk capacity. If set to `false`, CloudAI will allow Slurm to download the Docker images as needed when they are not cached locally by Slurm.
 - **global_env_vars**: Lists all global environment variables that will be applied globally whenever tests are run.

--- a/conf/system/example_slurm_cluster.toml
+++ b/conf/system/example_slurm_cluster.toml
@@ -20,6 +20,7 @@ install_path = "./install"
 output_path = "./results"
 default_partition = "partition_1"
 
+mpi = "pmix"
 gpus_per_node = 8
 ntasks_per_node = 8
 

--- a/src/cloudai/parser/system_parser/slurm_system_parser.py
+++ b/src/cloudai/parser/system_parser/slurm_system_parser.py
@@ -81,6 +81,7 @@ class SlurmSystemParser(BaseSystemParser):
         account = data.get("account")
         distribution = data.get("distribution")
 
+        mpi = data.get("mpi", "pmix")
         gpus_per_node = safe_int(data.get("gpus_per_node"))
         ntasks_per_node = safe_int(data.get("ntasks_per_node"))
 
@@ -150,6 +151,7 @@ class SlurmSystemParser(BaseSystemParser):
             partitions=updated_partitions,
             account=account,
             distribution=distribution,
+            mpi=mpi,
             gpus_per_node=gpus_per_node,
             ntasks_per_node=ntasks_per_node,
             cache_docker_images_locally=cache_docker_images_locally,

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -78,7 +78,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
     ) -> str:
         srun_command_parts = [
             "srun",
-            "--mpi=pmix",
+            f"--mpi={slurm_args['mpi']}",
             f'--container-image={slurm_args["image_path"]}',
             f'--container-mounts={slurm_args["container_mounts"]}',
             "python /workspace/param/train/comms/pt/commsTraceReplay.py",

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -136,7 +136,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         srun_command_parts = [
             "srun",
-            "--mpi=pmix",
+            f"--mpi={slurm_args['mpi']}",
             "--export=ALL",
             f"-o {slurm_args['output']}",
             f"-e {slurm_args['error']}",

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -85,7 +85,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     ) -> str:
         srun_command_parts = [
             "srun",
-            "--mpi=pmix",
+            f"--mpi={slurm_args['mpi']}",
             f"--container-image={slurm_args['image_path']}",
         ]
 

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -78,7 +78,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     ) -> str:
         srun_command_parts = [
             "srun",
-            "--mpi=pmix",
+            f"--mpi={slurm_args['mpi']}",
             f"--container-image={slurm_args['image_path']}",
             "/opt/hpcx/ucc/bin/ucc_perftest",
         ]

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -36,6 +36,8 @@ class SlurmSystem(System):
         partitions (Dict[str, List[SlurmNode]]): Mapping of partition names to lists of SlurmNodes.
         account (Optional[str]): Account name for charging resources used by this job.
         distribution (Optional[str]): Specifies alternate distribution methods for remote processes.
+        mpi (Optional[str]): Indicates the Process Management Interface (PMI) implementation to be used for
+            inter-process communication.
         gpus_per_node (Optional[int]): Specifies the number of GPUs available per node.
         ntasks_per_node (Optional[int]): Specifies the number of tasks that can run concurrently on a single node.
         cache_docker_images_locally (bool): Whether to cache Docker images locally for the Slurm system.
@@ -182,6 +184,7 @@ class SlurmSystem(System):
         partitions: Dict[str, List[SlurmNode]],
         account: Optional[str] = None,
         distribution: Optional[str] = None,
+        mpi: Optional[str] = None,
         gpus_per_node: Optional[int] = None,
         ntasks_per_node: Optional[int] = None,
         cache_docker_images_locally: bool = False,
@@ -199,6 +202,8 @@ class SlurmSystem(System):
             partitions (Dict[str, List[SlurmNode]]): Partitions in the system.
             account (Optional[str]): Account name for charging resources used by this job.
             distribution (Optional[str]): Specifies alternate distribution methods for remote processes.
+            mpi (Optional[str]): Indicates the Process Management Interface (PMI) implementation to be used for
+                inter-process communication.
             gpus_per_node (Optional[int]): Specifies the number of GPUs available per node.
             ntasks_per_node (Optional[int]): Specifies the number of tasks that can run concurrently on a single node.
             cache_docker_images_locally (bool): Whether to cache Docker images locally for the Slurm system.
@@ -214,6 +219,7 @@ class SlurmSystem(System):
         self.partitions = partitions
         self.account = account
         self.distribution = distribution
+        self.mpi = mpi
         self.gpus_per_node = gpus_per_node
         self.ntasks_per_node = ntasks_per_node
         self.cache_docker_images_locally = cache_docker_images_locally

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -125,6 +125,8 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             slurm_args["account"] = self.slurm_system.account
         if self.slurm_system.distribution:
             slurm_args["distribution"] = self.slurm_system.distribution
+        if self.slurm_system.mpi:
+            slurm_args["mpi"] = self.slurm_system.mpi
         if self.slurm_system.gpus_per_node:
             slurm_args["gpus_per_node"] = self.slurm_system.gpus_per_node
         if self.slurm_system.ntasks_per_node:

--- a/tests/test_slurm_system_parser.py
+++ b/tests/test_slurm_system_parser.py
@@ -43,7 +43,18 @@ def example_data() -> Dict[str, Any]:
     }
 
 
-def test_parse_slurm_system_parser(example_data):
+@pytest.mark.parametrize(
+    "mpi_value, expected_mpi",
+    [
+        ("pmix", "pmix"),
+        ("pmi2", "pmi2"),
+        ("", "pmix"),
+    ],
+)
+def test_parse_slurm_system_parser_with_mpi(example_data, mpi_value, expected_mpi):
+    if mpi_value:
+        example_data["mpi"] = mpi_value
+
     parser = SlurmSystemParser()
     slurm_system = parser.parse(example_data)
 
@@ -57,6 +68,7 @@ def test_parse_slurm_system_parser(example_data):
     assert "backup" in slurm_system.partitions
     assert "group1" in slurm_system.groups["main"]
     assert "group2" in slurm_system.groups["backup"]
+    assert slurm_system.mpi == expected_mpi
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Add mpi field to SlurmSystem and allow different MPI options in schema

## Test Plan
1. Added unit tests for SlurmSystemParser
2. Ran CloudAI with the dry-run mode
Chakra Replay
```
$ python cloudaix.py --mode dry-run --system-config conf/v0.6/general/system/... --test-scenario conf/v0.6/general/test_scenario/chakra_replay.toml                          
```
```
srun \
--mpi=pmi2 \
...
```
NCCL Test
```
$ python cloudaix.py --mode dry-run --system-config conf/v0.6/general/system/... --test-scenario conf/v0.6/general/test_scenario/nccl_test.toml                 
```
```
srun \
--mpi=pmi2 \
...
```
UCC Test
```
$ python cloudaix.py --mode dry-run --system-config conf/v0.6/general/system/... --test-scenario conf/v0.6/general/test_scenario/ucc_test.toml                 
```
```
srun \
--mpi=pmi2 \
...
```