### PR TITLE
add gpt3 175B test file

### DIFF
--- a/conf/test/gpt_175B.toml
+++ b/conf/test/gpt_175B.toml
@@ -1,0 +1,12 @@
+name = "gpt_175B"
+description = "gpt"
+test_template_name = "NeMoLauncher"
+extra_cmd_args = "training.exp_manager.resume_if_exists=false training.model.nsys_profile.enabled=True training.model.nsys_profile.start_step=45 training.model.nsys_profile.end_step=50 training.model.nsys_profile.gen_shape=False training.model.nsys_profile.ranks=[0] training.model.nsys_profile.trace=[nvtx,cuda]"
+
+[cmd_args]
+"training" = "gpt3/175b_fp8"
+"training.model.global_batch_size" = "192"
+"training.trainer.max_steps" = "100"
+"training.model.micro_batch_size" = "1"
+"training.model.pipeline_model_parallel_size" = "8"
+"training.model.tensor_model_parallel_size" = "4"

--- a/conf/test/gpt_175B.toml
+++ b/conf/test/gpt_175B.toml
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name = "gpt_175B"
 description = "gpt"
 test_template_name = "NeMoLauncher"

--- a/conf/test_template/nemo_launcher.toml
+++ b/conf/test_template/nemo_launcher.toml
@@ -7,11 +7,11 @@ name = "NeMoLauncher"
 
   [cmd_args.repository_commit_hash]
   type = "str"
-  default = "cf411a9ede3b466677df8ee672bcc6c396e71e1a"
+  default = "599ecfcbbd64fd2de02f2cc093b1610d73854022"
 
   [cmd_args.docker_image_url]
   type = "str"
-  default = "nvcr.io/nvidian/nemofw-training:24.01.01"
+  default = "nvcr.io/nvidia/nemo:24.05.01"
 
   [cmd_args.stages]
   type = "str"


### PR DESCRIPTION
Summary
This MR adds support to gpt3 175b. It adds the test file.

Test Plan
$ python ./cloudaix.py --mode run --system-config ... --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/gpt/gpt_175B.toml

...
Section Name: Tests.1
Test Name: gpt_175B
Description: gpt
No dependencies
[INFO] Initializing Runner
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
