### PR TITLE
Update logging to use dynamic log file name from args.log_file in run mode

### DIFF
--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -196,7 +196,9 @@ def handle_install_and_uninstall(mode: str, system: System, tests: List[Test]) -
             sys.exit(1)
 
 
-def handle_dry_run_and_run(mode: str, system: System, tests: List[Test], test_scenario: TestScenario) -> None:
+def handle_dry_run_and_run(
+    mode: str, log_file: str, system: System, tests: List[Test], test_scenario: TestScenario
+) -> None:
     """
     Execute the dry-run or run modes for CloudAI.
 
@@ -204,10 +206,10 @@ def handle_dry_run_and_run(mode: str, system: System, tests: List[Test], test_sc
 
     Args:
         mode (str): The operating mode.
+        log_file (str): The name of the log file.
         system (System): The system object.
         tests (List[Test]): The list of test objects.
         test_scenario (TestScenario): The test scenario object.
-        output_dir (Optional[Path]): The path to the output directory.
     """
     logging.info(f"System Name: {system.name}")
     logging.info(f"Scheduler: {system.scheduler}")
@@ -236,7 +238,7 @@ def handle_dry_run_and_run(mode: str, system: System, tests: List[Test], test_sc
     if mode == "run":
         logging.info(
             "All test scenario execution attempts are complete. Please review"
-            " the 'debug.log' file to confirm successful completion or to"
+            f" the '{log_file}' file to confirm successful completion or to"
             " identify any issues."
         )
 
@@ -291,7 +293,7 @@ def main() -> None:
             exit(1)
 
         elif args.mode in ["dry-run", "run"]:
-            handle_dry_run_and_run(args.mode, system, tests, test_scenario)
+            handle_dry_run_and_run(args.mode, args.log_file, system, tests, test_scenario)
         elif args.mode == "generate-report":
             if not output_dir:
                 logging.error("Error: --output-dir is required when mode is generate-report.")

--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -196,9 +196,7 @@ def handle_install_and_uninstall(mode: str, system: System, tests: List[Test]) -
             sys.exit(1)
 
 
-def handle_dry_run_and_run(
-    mode: str, log_file: str, system: System, tests: List[Test], test_scenario: TestScenario
-) -> None:
+def handle_dry_run_and_run(mode: str, system: System, tests: List[Test], test_scenario: TestScenario) -> None:
     """
     Execute the dry-run or run modes for CloudAI.
 
@@ -206,7 +204,6 @@ def handle_dry_run_and_run(
 
     Args:
         mode (str): The operating mode.
-        log_file (str): The name of the log file.
         system (System): The system object.
         tests (List[Test]): The list of test objects.
         test_scenario (TestScenario): The test scenario object.
@@ -236,12 +233,6 @@ def handle_dry_run_and_run(
     logging.info(f"All test scenario results stored at: {runner.runner.output_path}")
 
     if mode == "run":
-        logging.info(
-            "All test scenario execution attempts are complete. Please review"
-            f" the '{log_file}' file to confirm successful completion or to"
-            " identify any issues."
-        )
-
         generator = ReportGenerator(runner.runner.output_path)
         generator.generate_report(test_scenario)
 
@@ -293,7 +284,13 @@ def main() -> None:
             exit(1)
 
         elif args.mode in ["dry-run", "run"]:
-            handle_dry_run_and_run(args.mode, args.log_file, system, tests, test_scenario)
+            handle_dry_run_and_run(args.mode, system, tests, test_scenario)
+            if args.mode == "run":
+                logging.info(
+                    "All test scenario execution attempts are complete. Please review"
+                    f" the '{args.log_file}' file to confirm successful completion or to"
+                    " identify any issues."
+                )
         elif args.mode == "generate-report":
             if not output_dir:
                 logging.error("Error: --output-dir is required when mode is generate-report.")

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -20,20 +20,14 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from cloudai import InstallStatusResult, Parser, TestTemplate
-from cloudai.__main__ import handle_dry_run_and_run
+from cloudai.__main__ import handle_dry_run_and_run, setup_logging
 from cloudai._core.base_installer import BaseInstaller
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm import SlurmNode, SlurmNodeState
 
 SLURM_TEST_SCENARIOS = [
-    {
-        "path": Path("conf/test_scenario/sleep.toml"),
-        "expected_dirs_number": 3,
-    },
-    {
-        "path": Path("conf/test_scenario/ucc_test.toml"),
-        "expected_dirs_number": 1,
-    },
+    {"path": Path("conf/test_scenario/sleep.toml"), "expected_dirs_number": 3, "log_file": "sleep_debug.log"},
+    {"path": Path("conf/test_scenario/ucc_test.toml"), "expected_dirs_number": 1, "log_file": "ucc_test_debug.log"},
 ]
 
 
@@ -41,14 +35,23 @@ SLURM_TEST_SCENARIOS = [
 def test_slurm(tmp_path: Path, scenario: Dict):
     test_scenario_path = scenario["path"]
     expected_dirs_number = scenario.get("expected_dirs_number")
+    log_file = scenario.get("log_file")
+    log_file_path = tmp_path / str(log_file)
 
     parser = Parser(Path("conf/system/example_slurm_cluster.toml"), Path("conf/test_template"))
     system, tests, test_scenario = parser.parse(Path("conf/test"), test_scenario_path)
     system.output_path = str(tmp_path)
     assert test_scenario is not None, "Test scenario is None"
-    handle_dry_run_and_run("dry-run", system, tests, test_scenario)
+    setup_logging(str(log_file_path), "DEBUG")
+    handle_dry_run_and_run("dry-run", str(log_file_path), system, tests, test_scenario)
 
-    results_output = list(tmp_path.glob("*"))[0]
+    # Find the directory that was created for the test results
+    results_output_dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+
+    # Assuming there's only one result directory created
+    assert len(results_output_dirs) == 1, "No result directory found or multiple directories found."
+    results_output = results_output_dirs[0]
+
     test_dirs = list(results_output.iterdir())
 
     if expected_dirs_number is not None:
@@ -57,6 +60,8 @@ def test_slurm(tmp_path: Path, scenario: Dict):
     for td in test_dirs:
         assert td.is_dir(), "Invalid test directory"
         assert "Tests." in td.name, "Invalid test directory name"
+
+    assert log_file_path.exists(), f"Log file {log_file_path} does not exist"
 
 
 @pytest.fixture

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -43,7 +43,7 @@ def test_slurm(tmp_path: Path, scenario: Dict):
     system.output_path = str(tmp_path)
     assert test_scenario is not None, "Test scenario is None"
     setup_logging(str(log_file_path), "DEBUG")
-    handle_dry_run_and_run("dry-run", str(log_file_path), system, tests, test_scenario)
+    handle_dry_run_and_run("dry-run", system, tests, test_scenario)
 
     # Find the directory that was created for the test results
     results_output_dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
@@ -61,7 +61,7 @@ def test_slurm(tmp_path: Path, scenario: Dict):
         assert td.is_dir(), "Invalid test directory"
         assert "Tests." in td.name, "Invalid test directory name"
 
-    assert log_file_path.exists(), f"Log file {log_file_path} does not exist"
+    assert log_file_path.exists(), f"Log file {log_file_path} was not created"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Update logging to use dynamic log file name from args.log_file in run mode

## Test Plan
1. Updated unit tests, and CI pipelines pass
2. Ran it on my laptop
```
$ cloudai --mode run --system-config conf/system/standalone_system.toml --test-scenario conf/test_scenario/sleep.toml --test-templates-dir conf/test_template --tests-dir conf/test
[INFO] System configuration file: conf/system/standalone_system.toml
[INFO] Test templates directory: conf/test_template
[INFO] Tests directory: conf/test
[INFO] Test scenario file: conf/test_scenario/sleep.toml
[INFO] Output directory: None
...
[INFO] Job completed: Tests.2
[INFO] Job completed: Tests.4
[INFO] Job completed: Tests.3
[INFO] All test scenario results stored at: /Users/theo/cloudai/results/test_scenario_example_2024-07-09_07-24-57
...
[INFO] All test scenario execution attempts are complete. Please review the 'debug.log' file to confirm successful completion or to identify any issues.
```