### PR TITLE
fix required args in slurm_command_gen_strategy of NeMo_Launcher

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -52,6 +52,10 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     ) -> str:
         # Ensure required environment variables are included
         for key in REQUIRE_ENV_VARS:
+            if key not in self.slurm_system.global_env_vars:
+                raise KeyError(f"key : {key} wasn't specified in the system file while it's required for NeMo_Launcher")
+
+        for key in self.slurm_system.global_env_vars:
             if key not in extra_env_vars:
                 extra_env_vars[key] = self.slurm_system.global_env_vars[key]
 


### PR DESCRIPTION
## Summary
Problem : In the NeMo Launcher command, we didn't see some of the vars of the system file appear.
This was caused by the fact that only REQUIRE_ENV_VARS were passed to the command.

I changed the code so that first, we check if all the vars in the REQUIRE_ENV_VARS can be found in the system toml.
And second, so that all of the vars in the system toml are indeed passed to the command regardless if they are required or not.

## Test Plan
python ./cloudaix.py --mode run --system-config ... --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/gpt/gpt_MOE.toml 
...

Section Name: Tests.1
  Test Name: gpt_MOE
  Description: gpt
  No dependencies
[INFO] Initializing Runner
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
...