### PR TITLE
Pass all env vars to final command in NeMo launcher test template

### DIFF
--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import pytest
 from cloudai.schema.test_template.nemo_launcher.slurm_command_gen_strategy import (
-    REQUIRE_ENV_VARS,
     NeMoLauncherSlurmCommandGenStrategy,
 )
 from cloudai.systems import SlurmSystem
@@ -121,15 +120,8 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
         strategy = NeMoLauncherSlurmCommandGenStrategy(slurm_system, env_vars, cmd_args)
         return strategy
 
-    def test_raises_if_required_env_var_missed(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
-        with pytest.raises(KeyError) as exc_info:
-            nemo_cmd_gen.gen_exec_command(
-                env_vars={}, cmd_args={}, extra_env_vars={}, extra_cmd_args="", output_path="", num_nodes=1, nodes=[]
-            )
-        assert REQUIRE_ENV_VARS[0] in str(exc_info.value)
-
     def test_extra_env_vars_added(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
-        extra_env_vars = {v: "fake" for v in REQUIRE_ENV_VARS}
+        extra_env_vars = {"TEST_VAR_1": "value1", "TEST_VAR_2": "value2"}
         cmd_args = {
             "docker_image_url": "fake",
             "repository_url": "fake",
@@ -148,8 +140,27 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
         for k, v in extra_env_vars.items():
             assert f"{k}={v}" in cmd
 
+    def test_env_var_escaping(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
+        extra_env_vars = {"TEST_VAR": "value,with,commas"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+        }
+        cmd = nemo_cmd_gen.gen_exec_command(
+            env_vars={},
+            cmd_args=cmd_args,
+            extra_env_vars=extra_env_vars,
+            extra_cmd_args="",
+            output_path="",
+            num_nodes=1,
+            nodes=[],
+        )
+
+        assert "TEST_VAR=\\'value,with,commas\\'" in cmd
+
     def test_tokenizer_handled(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
-        extra_env_vars = {v: "fake" for v in REQUIRE_ENV_VARS}
+        extra_env_vars = {"TEST_VAR_1": "value1"}
         cmd_args = {
             "docker_image_url": "fake",
             "repository_url": "fake",


### PR DESCRIPTION
## Summary
Pass all env vars to final command in NeMo launcher test template

## Test Plan
1. Updated unit tests, and CI passes
2. Ran on a server
```
$ python ./cloudaix.py --mode run --system-config ... --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/gpt/gpt.toml 
...
```