### PR TITLE
Raise descriptive exceptions when strategies are missing

### DIFF
--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -149,7 +149,11 @@ class TestTemplate:
         """
         if not nodes:
             nodes = []
-        assert self.command_gen_strategy is not None
+        if self.command_gen_strategy is None:
+            raise ValueError(
+                "command_gen_strategy is missing. Ensure the strategy is registered in src/cloudai/__init__.py "
+                "by calling the appropriate registration function for the system type."
+            )
         return self.command_gen_strategy.gen_exec_command(
             env_vars,
             cmd_args,
@@ -171,7 +175,11 @@ class TestTemplate:
         Returns:
             Optional[int]: The retrieved job ID, or None if not found.
         """
-        assert self.job_id_retrieval_strategy is not None
+        if self.job_id_retrieval_strategy is None:
+            raise ValueError(
+                "job_id_retrieval_strategy is missing. Ensure the strategy is registered in src/cloudai/__init__.py "
+                "by calling the appropriate registration function for the system type."
+            )
         return self.job_id_retrieval_strategy.get_job_id(stdout, stderr)
 
     def get_job_status(self, output_path: str) -> JobStatusResult:
@@ -184,7 +192,11 @@ class TestTemplate:
         Returns:
             JobStatusResult: The result containing the job status and an optional error message.
         """
-        assert self.job_status_retrieval_strategy is not None
+        if self.job_status_retrieval_strategy is None:
+            raise ValueError(
+                "job_status_retrieval_strategy is missing. Ensure the strategy is registered in "
+                "src/cloudai/__init__.py by calling the appropriate registration function for the system type."
+            )
         return self.job_status_retrieval_strategy.get_job_status(output_path)
 
     def can_handle_directory(self, directory_path: str) -> bool:

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -151,7 +151,7 @@ class TestTemplate:
             nodes = []
         if self.command_gen_strategy is None:
             raise ValueError(
-                "command_gen_strategy is missing. Ensure the strategy is registered in src/cloudai/__init__.py "
+                "command_gen_strategy is missing. Ensure the strategy is registered in the Registry "
                 "by calling the appropriate registration function for the system type."
             )
         return self.command_gen_strategy.gen_exec_command(
@@ -177,7 +177,7 @@ class TestTemplate:
         """
         if self.job_id_retrieval_strategy is None:
             raise ValueError(
-                "job_id_retrieval_strategy is missing. Ensure the strategy is registered in src/cloudai/__init__.py "
+                "job_id_retrieval_strategy is missing. Ensure the strategy is registered in the Registry "
                 "by calling the appropriate registration function for the system type."
             )
         return self.job_id_retrieval_strategy.get_job_id(stdout, stderr)
@@ -195,7 +195,7 @@ class TestTemplate:
         if self.job_status_retrieval_strategy is None:
             raise ValueError(
                 "job_status_retrieval_strategy is missing. Ensure the strategy is registered in "
-                "src/cloudai/__init__.py by calling the appropriate registration function for the system type."
+                "the Registry by calling the appropriate registration function for the system type."
             )
         return self.job_status_retrieval_strategy.get_job_status(output_path)
 


### PR DESCRIPTION
## Summary
Raise descriptive exceptions when strategies are missing

## Test Plan
```
$ python ./cloudaix.py --mode run --system-config conf/v0.6/general/system/[SYSTEM_1].toml --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/sleep.toml 
[INFO] System configuration file: conf/v0.6/general/system/[SYSTEM_1].toml
[INFO] Test templates directory: conf/v0.6/general/test_template
[INFO] Tests directory: conf/v0.6/general/test
[INFO] Test scenario file: conf/v0.6/general/test_scenario/sleep.toml
[INFO] Output directory: None
[WARNING] No JobIdRetrievalStrategy found for TestTemplateParser and SlurmSystem
[WARNING] No JobStatusRetrievalStrategy found for TestTemplateParser and SlurmSystem
[INFO] System Name: [SYSTEM_1]
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: test_scenario_example
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: test_scenario_example

Section Name: Tests.1
  Test Name: sleep_10
  Description: sleep_10
  No dependencies
Section Name: Tests.2
  Test Name: sleep_5
  Description: sleep_5
  Start Post Init: Tests.1, Time: 5 seconds
Section Name: Tests.3
  Test Name: sleep_5
  Description: sleep_5
  Start Post Comp: Tests.1, Time: 0 seconds
Section Name: Tests.4
  Test Name: sleep_20
  Description: sleep_20
  End Post Comp: Tests.1, Time: 5 seconds
[INFO] Initializing Runner
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Executing command for test Tests.1: sleep 10
Traceback (most recent call last):
  File "[PATH]/cloudaix.py", line 140, in <module>
    main()
  File "[PATH]/cloudaix.py", line 131, in main
    handle_dry_run_and_run(args.mode, system, tests, test_scenario)
  File "[PATH]/cloudai-theo/src/cloudai/__main__.py", line 231, in handle_dry_run_and_run
    asyncio.run(runner.run())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "[PATH]/cloudai-theo/src/cloudai/_core/runner.py", line 75, in run
    await self.runner.run()
  File "[PATH]/cloudai-theo/src/cloudai/_core/base_runner.py", line 154, in run
    await self.submit_test(test)
  File "[PATH]/cloudai-theo/src/cloudai/_core/base_runner.py", line 170, in submit_test
    job = self._submit_test(test)
  File "[PATH]/cloudai-theo/src/cloudai/runner/slurm/slurm_runner.py", line 70, in _submit_test
    job_id = test.get_job_id(stdout, stderr)
  File "[PATH]/cloudai-theo/src/cloudai/_core/test.py", line 162, in get_job_id
    return self.test_template.get_job_id(stdout, stderr)
  File "[PATH]/cloudai-theo/src/cloudai/_core/test_template.py", line 179, in get_job_id
    raise ValueError(
ValueError: job_id_retrieval_strategy is missing. Ensure the strategy is registered in src/cloudai/__init__.py by calling the appropriate registration function for the system type.

```