### PR TITLE
Move parts of srun CLI generation into base class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 
 [project]
 name = "cloudai"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
     "bokeh==3.4.1",
     "pandas==2.2.1",

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -49,7 +49,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         job_name_prefix = "chakra_replay"
         slurm_args = self._parse_slurm_args(job_name_prefix, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _parse_slurm_args(
@@ -69,18 +69,10 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return base_args
 
-    def _generate_srun_command(
-        self,
-        slurm_args: Dict[str, Any],
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, str],
-        extra_cmd_args: str,
-    ) -> str:
+    def generate_test_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+    ) -> List[str]:
         srun_command_parts = [
-            "srun",
-            f"--mpi={slurm_args['mpi']}",
-            f'--container-image={slurm_args["image_path"]}',
-            f'--container-mounts={slurm_args["container_mounts"]}',
             "python /workspace/param/train/comms/pt/commsTraceReplay.py",
             f'--trace-type {cmd_args["trace_type"]}',
             f'--trace-path {cmd_args["trace_path"]}',
@@ -88,4 +80,4 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
             f'--device {cmd_args["device"]}',
             extra_cmd_args,
         ]
-        return " \\\n".join(srun_command_parts)
+        return srun_command_parts

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -138,7 +138,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         srun_command_parts = [
             "srun",
-            f"--mpi={slurm_args['mpi']}",
+            f"--mpi={self.slurm_system.mpi}",
             "--export=ALL",
             f"-o {slurm_args['output']}",
             f"-e {slurm_args['error']}",

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -52,7 +52,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = self._format_env_vars(final_env_vars)
 
         slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _format_xla_flags(self, cmd_args: Dict[str, str]) -> str:
@@ -131,12 +131,8 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return base_args
 
-    def _generate_srun_command(
-        self,
-        slurm_args: Dict[str, Any],
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, str],
-        extra_cmd_args: str,
+    def generate_full_srun_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
         self._create_run_script(slurm_args, env_vars, cmd_args, extra_cmd_args)
 

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -79,7 +79,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def generate_test_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
-        srun_command_parts = []
+        srun_command_parts = [f"/usr/local/bin/{cmd_args['subtest_name']}"]
         nccl_test_args = [
             "nthreads",
             "ngpus",

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -45,7 +45,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             raise KeyError("Subtest name not specified or unsupported.")
 
         slurm_args = self._parse_slurm_args(subtest_name, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _parse_slurm_args(
@@ -76,24 +76,10 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return base_args
 
-    def _generate_srun_command(
-        self,
-        slurm_args: Dict[str, Any],
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, str],
-        extra_cmd_args: str,
-    ) -> str:
-        srun_command_parts = [
-            "srun",
-            f"--mpi={slurm_args['mpi']}",
-            f"--container-image={slurm_args['image_path']}",
-        ]
-
-        if slurm_args.get("container_mounts"):
-            srun_command_parts.append(f"--container-mounts={slurm_args['container_mounts']}")
-
-        srun_command_parts.append(f"/usr/local/bin/{cmd_args['subtest_name']}")
-
+    def generate_test_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+    ) -> List[str]:
+        srun_command_parts = []
         nccl_test_args = [
             "nthreads",
             "ngpus",
@@ -119,4 +105,4 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if extra_cmd_args:
             srun_command_parts.append(extra_cmd_args)
 
-        return " \\\n".join(srun_command_parts)
+        return srun_command_parts

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -37,20 +37,13 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = self._format_env_vars(final_env_vars)
 
         slurm_args = self._parse_slurm_args("sleep", final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
-    def _generate_srun_command(
-        self,
-        slurm_args: Dict[str, Any],
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, str],
-        extra_cmd_args: str,
+    def generate_full_srun_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
-        srun_command_parts = [
-            "srun",
-            f"--mpi={slurm_args['mpi']}",
-        ]
+        srun_command_parts = ["srun", f"--mpi={slurm_args['mpi']}"]
 
         sec = cmd_args["seconds"]
         srun_command_parts.append(f"sleep {sec}")

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -43,7 +43,7 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def generate_full_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
-        srun_command_parts = ["srun", f"--mpi={slurm_args['mpi']}"]
+        srun_command_parts = ["srun", f"--mpi={self.slurm_system.mpi}"]
 
         sec = cmd_args["seconds"]
         srun_command_parts.append(f"sleep {sec}")

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -44,7 +44,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             raise KeyError("Collective name not specified or unsupported.")
 
         slurm_args = self._parse_slurm_args(collective, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self._generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _parse_slurm_args(
@@ -69,19 +69,10 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return base_args
 
-    def _generate_srun_command(
-        self,
-        slurm_args: Dict[str, Any],
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, str],
-        extra_cmd_args: str,
-    ) -> str:
-        srun_command_parts = [
-            "srun",
-            f"--mpi={slurm_args['mpi']}",
-            f"--container-image={slurm_args['image_path']}",
-            "/opt/hpcx/ucc/bin/ucc_perftest",
-        ]
+    def generate_test_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+    ) -> List[str]:
+        srun_command_parts = ["/opt/hpcx/ucc/bin/ucc_perftest"]
 
         # Add collective, minimum bytes, and maximum bytes options if available
         if "collective" in cmd_args:
@@ -99,4 +90,4 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if extra_cmd_args:
             srun_command_parts.append(extra_cmd_args)
 
-        return " \\\n".join(srun_command_parts)
+        return srun_command_parts

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -140,9 +140,9 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         srun_command_parts = ["srun", f"--mpi={self.slurm_system.mpi}"]
-        if "image_path" in slurm_args:
+        if slurm_args.get("image_path"):
             srun_command_parts.append(f'--container-image={slurm_args["image_path"]}')
-            if "container_mounts" in slurm_args:
+            if slurm_args.get("container_mounts"):
                 srun_command_parts.append(f'--container-mounts={slurm_args["container_mounts"]}')
 
         return srun_command_parts

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -31,12 +31,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             properties and methods.
     """
 
-    def __init__(
-        self,
-        system: SlurmSystem,
-        env_vars: Dict[str, Any],
-        cmd_args: Dict[str, Any],
-    ) -> None:
+    def __init__(self, system: SlurmSystem, env_vars: Dict[str, Any], cmd_args: Dict[str, Any]) -> None:
         """
         Initialize a new SlurmCommandGenStrategy instance.
 
@@ -136,27 +131,28 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         return slurm_args
 
-    def _generate_srun_command(
-        self,
-        slurm_args: Dict[str, Any],
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, str],
-        extra_cmd_args: str,
+    def generate_full_srun_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
-        """
-        Generate the srun command string for executing the test.
+        srun_command_parts = self.generate_srun_command(slurm_args, env_vars, cmd_args, extra_cmd_args)
+        test_command_parts = self.generate_test_command(slurm_args, env_vars, cmd_args, extra_cmd_args)
+        return " \\\n".join(srun_command_parts + test_command_parts)
 
-        Args:
-            slurm_args (Dict[str, Any]): Arguments containing Slurm job settings including image path and container
-                mounts.
-            env_vars (Dict[str, str]): Environment variables.
-            cmd_args (Dict[str, str]): Command-line arguments.
-            extra_cmd_args (str): Additional command-line arguments to be included in the srun command.
+    def generate_srun_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+    ) -> List[str]:
+        srun_command_parts = ["srun", f"--mpi={self.slurm_system.mpi}"]
+        if "image_path" in slurm_args:
+            srun_command_parts.append(f'--container-image={slurm_args["image_path"]}')
+            if "container_mounts" in slurm_args:
+                srun_command_parts.append(f'--container-mounts={slurm_args["container_mounts"]}')
 
-        Returns:
-            str: The complete srun command to execute the test.
-        """
-        return ""
+        return srun_command_parts
+
+    def generate_test_command(
+        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+    ) -> List[str]:
+        return []
 
     def _write_sbatch_script(self, args: Dict[str, Any], env_vars_str: str, srun_command: str, output_path: str) -> str:
         """

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -120,8 +120,6 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             slurm_args["account"] = self.slurm_system.account
         if self.slurm_system.distribution:
             slurm_args["distribution"] = self.slurm_system.distribution
-        if self.slurm_system.mpi:
-            slurm_args["mpi"] = self.slurm_system.mpi
         if self.slurm_system.gpus_per_node:
             slurm_args["gpus_per_node"] = self.slurm_system.gpus_per_node
         if self.slurm_system.ntasks_per_node:

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -143,8 +143,8 @@ class TestGenerateSrunCommand__CmdGeneration:
         ]
 
     def test_generate_full_srun_command(self, strategy_fixture: SlurmCommandGenStrategy):
-        strategy_fixture.generate_srun_command = lambda *args, **kwargs: ["srun", "--test", "test_arg"]
-        strategy_fixture.generate_test_command = lambda *args, **kwargs: ["test_command"]
+        strategy_fixture.generate_srun_command = lambda *_, **__: ["srun", "--test", "test_arg"]
+        strategy_fixture.generate_test_command = lambda *_, **__: ["test_command"]
 
         full_srun_command = strategy_fixture.generate_full_srun_command({}, {}, {}, "")
         assert full_srun_command == " \\\n".join(["srun", "--test", "test_arg", "test_command"])


### PR DESCRIPTION
## Summary
Updated `SlurmCommandGenStrategy` implementation:
1. Renamed `_generate_srun_command` to `generate_full_srun_command`.
2. Added two new functions to be called as part of it: `generate_srun_command` and `generate_test_command`.
3. Use `self.slurm_system.mpi` directly instead of of extra `slurm_args`.

## Test Plan
1. CI
2. Ran the following test templates with the dry-run mode and compared the generated command and sbatch script between the main branch and the am/slurm-common branch
    * Sleep (success)
    * NcclTest (success)
    * UccTest (success)
    * JaxToolbox (success)
    * NeMoLauncher (success)

## Additional Notes
—
