### PR TITLE
Add job_status_check flag to disable checks for specific tests

### DIFF
--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -26,20 +26,23 @@ class TestScenario:
     Attributes
         name (str): Unique name of the test scenario.
         tests (List[Test]): Tests in the scenario.
+        job_status_check (bool): Flag indicating whether to check the job status or not.
     """
 
     __test__ = False
 
-    def __init__(self, name: str, tests: List[Test]) -> None:
+    def __init__(self, name: str, tests: List[Test], job_status_check: bool = True) -> None:
         """
         Initialize a TestScenario instance.
 
         Args:
             name (str): Name of the test scenario.
             tests (List[Test]): List of tests in the scenario.
+            job_status_check (bool): Flag indicating whether to check the job status or not.
         """
         self.name = name
         self.tests = tests
+        self.job_status_check = job_status_check
 
     def __repr__(self) -> str:
         """

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -71,6 +71,7 @@ class TestScenarioParser:
         if "name" not in data:
             raise KeyError("The 'name' field is missing from the data.")
         test_scenario_name = data["name"]
+        job_status_check = data.get("job_status_check", True)
         raw_tests_data = data.get("Tests", {})
         tests_data = {f"Tests.{k}": v for k, v in raw_tests_data.items()}
 
@@ -101,7 +102,9 @@ class TestScenarioParser:
             if "time_limit" in test_info:
                 test.time_limit = test_info["time_limit"]
 
-        return TestScenario(name=test_scenario_name, tests=list(section_tests.values()))
+        return TestScenario(
+            name=test_scenario_name, tests=list(section_tests.values()), job_status_check=job_status_check
+        )
 
     def _create_section_test(self, section: str, test_info: Dict[str, Any]) -> Test:
         """


### PR DESCRIPTION
## Summary
Add the job_status_check flag to the test scenario schema to ignore checking the job status. The flag is applied globally. Currently, if a test is killed or fails in the middle and does not produce a proper result, it is considered a job failure by the status-checking logic. As a result, all tests are terminated, and reports are not generated. This PR introduces a new flag, job_status_check, to the test scenario schema so that users can optionally enable or disable the job status check. By default, it is set to True, and it can be set to False if users wish. The flag is applied to all tests in the test scenario; you cannot optionally turn the check on or off for each test individually.

## Test Plan
example_test.toml
```
name = "nccl-test"
job_status_check = false

[Tests.1]
  name = "nccl_test_all_reduce"
  num_nodes = "1"
  time_limit = "00:20:00"

[Tests.2]
  name = "nccl_test_all_gather"
  num_nodes = "1"
  time_limit = "00:20:00"
```
When job_status_check is set to true, if nccl_test_all_reduce is killed midway, nccl_test_all_gather is also terminated. When it is set to false, if nccl_test_all_reduce is killed midway, nccl_test_all_gather is not affected.