### PR TITLE
Remove subtest name check in NcclTestSlurmCommandGenStrategy

### DIFF
--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, List
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
 from .slurm_install_strategy import NcclTestSlurmInstallStrategy
-from .template import NcclTest
 
 
 class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
@@ -41,8 +40,14 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = self._format_env_vars(final_env_vars)
 
         subtest_name = final_cmd_args.get("subtest_name")
-        if subtest_name not in NcclTest.SUPPORTED_SUBTESTS:
-            raise KeyError("Subtest name not specified or unsupported.")
+        if subtest_name is None:
+            raise ValueError(
+                "The NCCL test's 'subtest_name' is not provided. Please ensure 'subtest_name' "
+                "is included in the test template schema or the test schema. Valid subtest names "
+                "include: all_reduce_perf_mpi, all_gather_perf_mpi, alltoall_perf_mpi, "
+                "broadcast_perf_mpi, gather_perf_mpi, hypercube_perf_mpi, reduce_perf_mpi, "
+                "reduce_scatter_perf_mpi, scatter_perf_mpi, and sendrecv_perf_mpi."
+            )
 
         slurm_args = self._parse_slurm_args(subtest_name, final_env_vars, final_cmd_args, num_nodes, nodes)
         srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)

--- a/src/cloudai/schema/test_template/nccl_test/template.py
+++ b/src/cloudai/schema/test_template/nccl_test/template.py
@@ -17,23 +17,4 @@ from cloudai import TestTemplate
 
 
 class NcclTest(TestTemplate):
-    """
-    Test template for NCCL tests.
-
-    Attributes
-        SUPPORTED_SUBTESTS (List[str]): List of supported subtests for NCCL,
-            including all_reduce_perf_mpi, all_gather_perf_mpi, and others.
-    """
-
-    SUPPORTED_SUBTESTS = [
-        "all_reduce_perf_mpi",
-        "all_gather_perf_mpi",
-        "alltoall_perf_mpi",
-        "broadcast_perf_mpi",
-        "gather_perf_mpi",
-        "hypercube_perf_mpi",
-        "reduce_perf_mpi",
-        "reduce_scatter_perf_mpi",
-        "scatter_perf_mpi",
-        "sendrecv_perf_mpi",
-    ]
+    """Test template for NCCL tests."""


### PR DESCRIPTION
## Summary
Remove subtest name check in NcclTestSlurmCommandGenStrategy. CloudAI will check the subtest name field to ensure the value is within the predefined values in the test template schema. Therefore, the values do not need to be kept in the schema. This will allow CloudAI to support bisection_perf_mpi as well. This idea was proposed by Eyal Chocron.

## Test Plan
CI passes