### PR TITLE
Add warning for insufficient epochs in JaxToolbox report generation

### DIFF
--- a/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/report_generation_strategy.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import glob
+import logging
 import os
 import statistics
 from typing import List, Optional
@@ -77,6 +78,13 @@ class JaxToolboxReportGenerationStrategy(ReportGenerationStrategy):
                                 continue  # Skip any lines where conversion fails
 
             times.extend(file_times)
+
+        if len(times) == 0:
+            logging.warning(
+                "JaxToolbox: The number of epochs is not sufficient to generate a report. "
+                "At least 11 epochs are required to ensure accurate performance metrics, "
+                "as the first 10 epochs are ignored due to overhead. Please run the tests for more than 10 epochs."
+            )
 
         return times
 


### PR DESCRIPTION
## Summary
Add warning for insufficient epochs in JaxToolbox report generation. Proposed by Srivatsan Krishna.

## Test Plan
CI passes
