### PR TITLE
Allow extra srun args set in system config

### DIFF
--- a/src/cloudai/parser/system_parser/slurm_system_parser.py
+++ b/src/cloudai/parser/system_parser/slurm_system_parser.py
@@ -158,4 +158,5 @@ class SlurmSystemParser(BaseSystemParser):
             cache_docker_images_locally=cache_docker_images_locally,
             groups=updated_groups,
             global_env_vars=global_env_vars,
+            extra_srun_args=data.get("extra_srun_args"),
         )

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -140,6 +140,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         srun_command_parts = [
             "srun",
             f"--mpi={self.slurm_system.mpi}",
+            f"{self.slurm_system.extra_srun_args if self.slurm_system.extra_srun_args else ''}",
             "--export=ALL",
             f"-o {slurm_args['output']}",
             f"-e {slurm_args['error']}",

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -44,7 +44,11 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def generate_full_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
-        srun_command_parts = ["srun", f"--mpi={self.slurm_system.mpi}"]
+        srun_command_parts = [
+            "srun",
+            f"--mpi={self.slurm_system.mpi}",
+            f"{self.slurm_system.extra_srun_args if self.slurm_system.extra_srun_args else ''}",
+        ]
 
         sec = cmd_args["seconds"]
         srun_command_parts.append(f"sleep {sec}")

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -191,6 +191,7 @@ class SlurmSystem(System):
         cache_docker_images_locally: bool = False,
         groups: Optional[Dict[str, Dict[str, List[SlurmNode]]]] = None,
         global_env_vars: Optional[Dict[str, Any]] = None,
+        extra_srun_args: Optional[str] = None,
     ) -> None:
         """
         Initialize a SlurmSystem instance.
@@ -213,6 +214,7 @@ class SlurmSystem(System):
                 empty dictionary if not provided.
             global_env_vars (Optional[Dict[str, Any]]): Dictionary containing additional configuration settings for
                 the system.
+            extra_srun_args (Optional[str]): Additional arguments to be passed to the srun command.
         """
         super().__init__(name, "slurm", output_path)
         self.install_path = install_path
@@ -226,6 +228,7 @@ class SlurmSystem(System):
         self.cache_docker_images_locally = cache_docker_images_locally
         self.groups = groups if groups is not None else {}
         self.global_env_vars = global_env_vars if global_env_vars is not None else {}
+        self.extra_srun_args = extra_srun_args
         self.cmd_shell = CommandShell()
         logging.debug(f"{self.__class__.__name__} initialized")
 

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -146,6 +146,9 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             if slurm_args.get("container_mounts"):
                 srun_command_parts.append(f'--container-mounts={slurm_args["container_mounts"]}')
 
+        if self.slurm_system.extra_srun_args:
+            srun_command_parts.append(self.slurm_system.extra_srun_args)
+
         return srun_command_parts
 
     def generate_test_command(

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -124,6 +124,11 @@ class TestGenerateSrunCommand__CmdGeneration:
         srun_command = strategy_fixture.generate_srun_command({}, {}, {}, "")
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}"]
 
+    def test_generate_srun_command_with_extra_args(self, strategy_fixture: SlurmCommandGenStrategy):
+        strategy_fixture.slurm_system.extra_srun_args = "--extra-args value"
+        srun_command = strategy_fixture.generate_srun_command({}, {}, {}, "")
+        assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}", "--extra-args value"]
+
     def test_generate_srun_command_with_container_image(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "fake_image_path"}
         srun_command = strategy_fixture.generate_srun_command(slurm_args, {}, {}, "")


### PR DESCRIPTION
## Summary
Allow extra `srun` args set in system config.

## Test Plan
CI

## Additional Notes
—
