### PR TITLE
add support for NeMo Launcher in the reservation

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -60,7 +60,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         self.final_cmd_args["cluster.partition"] = self.slurm_system.default_partition
         reservation_key = "--reservation "
         if self.slurm_system.extra_srun_args and reservation_key in self.slurm_system.extra_srun_args:
-            reservation = extra_cmd_args.split(reservation_key, 1)[1].split(" ", 1)[0]
+            reservation = self.slurm_system.extra_srun_args.split(reservation_key, 1)[1].split(" ", 1)[0]
             self.final_cmd_args["+cluster.reservation"] = reservation
         nodes = self.slurm_system.parse_nodes(nodes)
         if nodes:

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -58,6 +58,10 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         for key, value in final_env_vars.items():
             self.final_cmd_args[f"env_vars.{key}"] = value
         self.final_cmd_args["cluster.partition"] = self.slurm_system.default_partition
+        reservation_key = "--reservation "
+        if self.slurm_system.extra_srun_args and reservation_key in self.slurm_system.extra_srun_args:
+            reservation = extra_cmd_args.split(reservation_key, 1)[1].split(" ", 1)[0]
+            self.final_cmd_args["+cluster.reservation"] = reservation
         nodes = self.slurm_system.parse_nodes(nodes)
         if nodes:
             self.final_cmd_args["training.trainer.num_nodes"] = str(len(nodes))

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -242,8 +242,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "repository_url": "fake",
             "repository_commit_hash": "fake",
         }
-        nemo_cmd_gen.system.extra_srun_args = "--reservation my-reservation"
-
+        nemo_cmd_gen.slurm_system.extra_srun_args = "--reservation my-reservation"
         cmd = nemo_cmd_gen.gen_exec_command(
             env_vars={},
             cmd_args=cmd_args,

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -234,6 +234,27 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
 
         assert f"container_mounts=[{tokenizer_path}:{tokenizer_path}]" in cmd
 
+    def test_reservation_handled(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
+        extra_env_vars = {"TEST_VAR_1": "value1"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+        }
+        nemo_cmd_gen.system.extra_srun_args = "--reservation my-reservation"
+
+        cmd = nemo_cmd_gen.gen_exec_command(
+            env_vars={},
+            cmd_args=cmd_args,
+            extra_cmd_args="",
+            extra_env_vars=extra_env_vars,
+            output_path="",
+            num_nodes=1,
+            nodes=[],
+        )
+
+        assert f"+cluster.reservation=my-reservation" in cmd
+
     def test_invalid_tokenizer_path(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
         extra_env_vars = {"TEST_VAR_1": "value1"}
         cmd_args = {

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -253,7 +253,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             nodes=[],
         )
 
-        assert f"+cluster.reservation=my-reservation" in cmd
+        assert "+cluster.reservation=my-reservation" in cmd
 
     def test_invalid_tokenizer_path(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
         extra_env_vars = {"TEST_VAR_1": "value1"}

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -33,6 +33,7 @@ def slurm_system(tmp_path: Path) -> SlurmSystem:
         install_path=str(tmp_path / "install"),
         output_path=str(tmp_path / "output"),
         default_partition="main",
+        extra_srun_args="",
         partitions={
             "main": [
                 SlurmNode(name="node1", partition="main", state=SlurmNodeState.IDLE),


### PR DESCRIPTION
## Summary
This PR is based on andrei's : https://github.com/NVIDIA/cloudai/pull/160
It enables reservation flag to be transmitted to NeMoLauncher

## Test Plan

system.toml

```
extra_srun_args = "--reservation my-reservation"
``` 

command 

```
$ python ./cloudaix.py --mode run --system-config ... --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/llama/llama3_70B.toml
...

Section Name: Tests.1
Test Name: llama3_70B
Description: llama
No dependencies
[INFO] Initializing Runner
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
...
```
