### PR TITLE
Defer docker image URL accessibility check to srun when not caching locally

### DIFF
--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -160,16 +160,9 @@ class DockerImageCacheManager:
             f"cache_docker_images_locally={self.cache_docker_images_locally}"
         )
 
-        # If not caching locally, check URL accessibility
+        # If not caching locally, return True. Defer checking URL accessibility to srun.
         if not self.cache_docker_images_locally:
-            accessibility_check = self._check_docker_image_accessibility(docker_image_url)
-            if accessibility_check.success:
-                return DockerImageCacheResult(True, docker_image_url, accessibility_check.message)
-            logging.error(
-                f"Accessibility check failed for Docker image URL: {docker_image_url}. "
-                f"Error: {accessibility_check.message}"
-            )
-            return DockerImageCacheResult(False, "", accessibility_check.message)
+            return DockerImageCacheResult(True, docker_image_url, "")
 
         # Check if docker_image_url is a file path and exists
         if os.path.isfile(docker_image_url) and os.path.exists(docker_image_url):


### PR DESCRIPTION
## Summary
Defer docker image URL accessibility check to srun when not caching locally. This PR is created to fix a bug reported by @srivatsankrishnan. CloudAI has an install mode to install test templates. In the install stage, docker images are cached locally when a user sets cache_docker_images_locally to true. Even if cache_docker_images_locally is set to false, the accessibility of the given docker image URL is tested. The problem arises when the head node does not have enroot. In install mode, CloudAI calls DockerImageCacheManager's `check_docker_image_exists`. `check_docker_image_exists` uses enroot, and when the head node does not have enroot, it fails to check and then reports an unknown error as shown below.
```
[ERROR] Accessibility check failed for Docker image URL: .... Error: Failed to access Docker image URL: .... Unknown error.
```
While DockerImageCacheManager has `_check_prerequisites` to check prerequisites like enroot and srun, it is only called in `cache_docker_image` and not in `check_docker_image_exists`. Therefore, if `check_docker_image_exists` is called directly, `_check_prerequisites` is not called, and it fails to check the accessibility of the URL. This PR fixes the error by always returning True in `check_docker_image_exists`. This is the rationale: if a docker image URL is not accessible, it will be identified by the actual sbatch or srun command. Therefore, DockerImageCacheManager does not need to check it.

## Test Plan
* CI passes
* Install: https://nvidia.slack.com/archives/C076DHMN402/p1722365382659189?thread_ts=1722362106.248499&cid=C076DHMN402
* NCCL-test run: https://nvidia.slack.com/archives/C076DHMN402/p1722366327291599?thread_ts=1722362106.248499&cid=C076DHMN402