### PR TITLE
[Draft] support k8s cluster

### DIFF
--- a/conf/system/kubernetes_cluster.toml
+++ b/conf/system/kubernetes_cluster.toml
@@ -14,20 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .grading_strategy import SleepGradingStrategy
-from .report_generation_strategy import SleepReportGenerationStrategy
-from .slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
-from .standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
-from .kubernetes_json_gen_strategy import SleepKubernetesJobJsonGenStrategy
-from .standalone_install_strategy import SleepStandaloneInstallStrategy
-from .template import Sleep
+name = "kubernetes-cluster"
+scheduler = "kubernetes"
+kube_config_path = ""
 
-__all__ = [
-    "Sleep",
-    "SleepStandaloneInstallStrategy",
-    "SleepStandaloneCommandGenStrategy",
-    "SleepKubernetesJobJsonGenStrategy",
-    "SleepSlurmCommandGenStrategy",
-    "SleepReportGenerationStrategy",
-    "SleepGradingStrategy",
-]
+# Job/Task configurations
+
+install_path = "./install"
+output_path = "./results"
+default_image = "ubuntu:22.04"
+default_namespace = "default"
+
+[global_env_vars]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bokeh==3.4.1
 pandas==2.2.1
 tbparse==0.0.8
 toml==0.10.2
+kubernetes==30.1.0

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -19,6 +19,7 @@ from ._core.base_job import BaseJob
 from ._core.base_runner import BaseRunner
 from ._core.base_system_parser import BaseSystemParser
 from ._core.command_gen_strategy import CommandGenStrategy
+from ._core.json_gen_strategy import JsonGenStrategy
 from ._core.exceptions import JobIdRetrievalError
 from ._core.grader import Grader
 from ._core.grading_strategy import GradingStrategy
@@ -38,10 +39,13 @@ from ._core.test_template_strategy import TestTemplateStrategy
 from .installer.installer import Installer
 from .installer.slurm_installer import SlurmInstaller
 from .installer.standalone_installer import StandaloneInstaller
+from .installer.kubernetes_installer import KubernetesInstaller
 from .parser.system_parser.slurm_system_parser import SlurmSystemParser
+from .parser.system_parser.kubernetes_system_parser import KubernetesSystemParser
 from .parser.system_parser.standalone_system_parser import StandaloneSystemParser
 from .report_generator import ReportGenerator
 from .runner.slurm.slurm_runner import SlurmRunner
+from .runner.kubernetes.kubernetes_runner import KubernetesRunner
 from .runner.standalone.standalone_runner import StandaloneRunner
 from .schema.test_template.chakra_replay.grading_strategy import ChakraReplayGradingStrategy
 from .schema.test_template.chakra_replay.report_generation_strategy import ChakraReplayReportGenerationStrategy
@@ -74,6 +78,7 @@ from .schema.test_template.nemo_launcher.template import NeMoLauncher
 from .schema.test_template.sleep.grading_strategy import SleepGradingStrategy
 from .schema.test_template.sleep.report_generation_strategy import SleepReportGenerationStrategy
 from .schema.test_template.sleep.slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
+from .schema.test_template.sleep.kubernetes_json_gen_strategy import SleepKubernetesJobJsonGenStrategy
 from .schema.test_template.sleep.standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
 from .schema.test_template.sleep.standalone_install_strategy import SleepStandaloneInstallStrategy
 from .schema.test_template.sleep.template import Sleep
@@ -84,11 +89,14 @@ from .schema.test_template.ucc_test.slurm_install_strategy import UCCTestSlurmIn
 from .schema.test_template.ucc_test.template import UCCTest
 from .systems.slurm.slurm_system import SlurmSystem
 from .systems.standalone_system import StandaloneSystem
+from .systems.kubernetes.kubernetes_system import KubernetesSystem
 
 Registry().add_system_parser("standalone", StandaloneSystemParser)
 Registry().add_system_parser("slurm", SlurmSystemParser)
+Registry().add_system_parser("kubernetes", KubernetesSystemParser)
 
 Registry().add_runner("slurm", SlurmRunner)
+Registry().add_runner("kubernetes", KubernetesRunner)
 Registry().add_runner("standalone", StandaloneRunner)
 
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NcclTest], NcclTestSlurmInstallStrategy)
@@ -96,6 +104,7 @@ Registry().add_strategy(InstallStrategy, [SlurmSystem], [NeMoLauncher], NeMoLaun
 Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [NcclTest], NcclTestReportGenerationStrategy)
 Registry().add_strategy(CommandGenStrategy, [StandaloneSystem], [Sleep], SleepStandaloneCommandGenStrategy)
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [Sleep], SleepSlurmCommandGenStrategy)
+Registry().add_strategy(JsonGenStrategy, [KubernetesSystem], [Sleep], SleepKubernetesJobJsonGenStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxSlurmInstallStrategy)
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [NcclTest], NcclTestGradingStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmInstallStrategy)
@@ -122,6 +131,7 @@ Registry().add_strategy(
 )
 Registry().add_strategy(JobIdRetrievalStrategy, [StandaloneSystem], [Sleep], StandaloneJobIdRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [StandaloneSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
+Registry().add_strategy(JobStatusRetrievalStrategy, [KubernetesSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [NcclTest], NcclTestJobStatusRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxJobStatusRetrievalStrategy)
 Registry().add_strategy(
@@ -145,6 +155,7 @@ Registry().add_test_template("UCCTest", UCCTest)
 
 Registry().add_installer("slurm", SlurmInstaller)
 Registry().add_installer("standalone", StandaloneInstaller)
+Registry().add_installer("kubernetes", KubernetesInstaller)
 
 __all__ = [
     "BaseInstaller",
@@ -152,6 +163,7 @@ __all__ = [
     "BaseRunner",
     "BaseSystemParser",
     "CommandGenStrategy",
+    "JsonGenStrategy",
     "Grader",
     "GradingStrategy",
     "Installer",

--- a/src/cloudai/_core/json_gen_strategy.py
+++ b/src/cloudai/_core/json_gen_strategy.py
@@ -20,15 +20,14 @@ from typing import Dict, List
 from .test_template_strategy import TestTemplateStrategy
 
 
-class CommandGenStrategy(TestTemplateStrategy):
+class JsonGenStrategy(TestTemplateStrategy):
     """
     Abstract base class defining the interface for command generation strategies across different system environments.
-
-    It specifies how to generate execution commands or json string based on system and test parameters.
+    It specifies how to generate execution commands based on system and test parameters.
     """
 
     @abstractmethod
-    def gen_exec_command(
+    def generate_job_json(
         self,
         env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
@@ -40,7 +39,6 @@ class CommandGenStrategy(TestTemplateStrategy):
     ) -> str:
         """
         Generate the execution command for a test based on the given parameters.
-
         Args:
             env_vars (Dict[str, str]): Environment variables for the test.
             cmd_args (Dict[str, str]): Command-line arguments for the test.
@@ -49,7 +47,6 @@ class CommandGenStrategy(TestTemplateStrategy):
             output_path (str): Path to the output directory.
             num_nodes (int): The number of nodes to be used for the test execution.
             nodes (List[str]): List of nodes for test execution, optional.
-
         Returns:
             str: The generated execution command.
         """

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -149,6 +149,30 @@ class Test:
             self.nodes,
         )
 
+    def gen_json_string(self, output_path: str, job_name: str) -> str:
+        """
+        Generate the command to run this specific test.
+
+        Args:
+            output_path (str): Path to the output directory.
+
+        Returns:
+            str: The command string.
+        """
+        if self.time_limit is not None:
+            self.cmd_args["time_limit"] = self.time_limit
+
+        return self.test_template.gen_json_string(
+            self.env_vars,
+            self.cmd_args,
+            self.extra_env_vars,
+            self.extra_cmd_args,
+            output_path,
+            job_name,
+            self.num_nodes,
+            self.nodes,
+        )
+
     def get_job_id(self, stdout: str, stderr: str) -> Optional[int]:
         """
         Retrieve the job ID using the test template's method.

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -17,6 +17,7 @@
 from typing import Any, Dict, List, Optional
 
 from .command_gen_strategy import CommandGenStrategy
+from .json_gen_strategy import JsonGenStrategy
 from .grading_strategy import GradingStrategy
 from .install_status_result import InstallStatusResult
 from .install_strategy import InstallStrategy
@@ -41,6 +42,7 @@ class TestTemplate:
         logger (logging.Logger): Logger for the test template.
         install_strategy (InstallStrategy): Strategy for installing test prerequisites.
         command_gen_strategy (CommandGenStrategy): Strategy for generating execution commands.
+        json_gen_strategy (JsonGenStrategy): Strategy for generating json string.
         job_id_retrieval_strategy (JobIdRetrievalStrategy): Strategy for retrieving job IDs.
         report_generation_strategy (ReportGenerationStrategy): Strategy for generating reports.
         grading_strategy (GradingStrategy): Strategy for grading performance based on test outcomes.
@@ -63,7 +65,7 @@ class TestTemplate:
             system (System): System configuration for the test template.
             name (str): Name of the test template.
             env_vars (Dict[str, Any]): Environment variables.
-            cmd_args (Dict[str, Any]): Command-line arguments.
+            cmd_args (Dict[str, Any]): Command-line arguments.json_gen_strategy
         """
         self.system = system
         self.name = name
@@ -71,6 +73,7 @@ class TestTemplate:
         self.cmd_args = cmd_args
         self.install_strategy: Optional[InstallStrategy] = None
         self.command_gen_strategy: Optional[CommandGenStrategy] = None
+        self.json_gen_strategy: Optional[JsonGenStrategy] = None
         self.job_id_retrieval_strategy: Optional[JobIdRetrievalStrategy] = None
         self.job_status_retrieval_strategy: Optional[JobStatusRetrievalStrategy] = None
         self.report_generation_strategy: Optional[ReportGenerationStrategy] = None
@@ -161,6 +164,52 @@ class TestTemplate:
             extra_env_vars,
             extra_cmd_args,
             output_path,
+            num_nodes,
+            nodes,
+        )
+
+    def gen_json_string(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: str,
+        job_name: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> str:
+        """
+        Generate an execution command for a test using this template.
+
+        This method must be implemented by subclasses.
+
+        Args:
+            env_vars (Dict[str, str]): Environment variables for the test.
+            cmd_args (Dict[str, str]): Command-line arguments for the test.
+            extra_env_vars (Dict[str, str]): Extra environment variables.
+            extra_cmd_args (str): Extra command-line arguments.
+            output_path (str): Path to the output directory.
+            num_nodes (int): The number of nodes to be used for the test execution.
+            nodes (List[str]): A list of nodes where the test will be executed.
+
+        Returns:
+            str: The generated execution command.
+        """
+        if not nodes:
+            nodes = []
+        if self.json_gen_strategy is None:
+            raise ValueError(
+                "json_gen_strategy is missing. Ensure the strategy is registered in the Registry "
+                "by calling the appropriate registration function for the system type."
+            )
+        return self.json_gen_strategy.gen_json_string(
+            env_vars,
+            cmd_args,
+            extra_env_vars,
+            extra_cmd_args,
+            output_path,
+            job_name,
             num_nodes,
             nodes,
         )

--- a/src/cloudai/_core/test_template_parser.py
+++ b/src/cloudai/_core/test_template_parser.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Optional, Type, Union, cast
 
 from .base_multi_file_parser import BaseMultiFileParser
 from .command_gen_strategy import CommandGenStrategy
+from .json_gen_strategy import JsonGenStrategy
 from .grading_strategy import GradingStrategy
 from .install_strategy import InstallStrategy
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
@@ -126,6 +127,10 @@ class TestTemplateParser(BaseMultiFileParser):
         obj.command_gen_strategy = cast(
             CommandGenStrategy,
             self._fetch_strategy(CommandGenStrategy, type(obj.system), type(obj), env_vars, cmd_args),
+        )
+        obj.json_gen_strategy = cast(
+            JsonGenStrategy,
+            self._fetch_strategy(JsonGenStrategy, type(obj.system), type(obj), env_vars, cmd_args),
         )
         obj.job_id_retrieval_strategy = cast(
             JobIdRetrievalStrategy,

--- a/src/cloudai/installer/kubernetes_installer.py
+++ b/src/cloudai/installer/kubernetes_installer.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudai import BaseInstaller, InstallStatusResult
+
+
+class KubernetesInstaller(BaseInstaller):
+    """
+    Installer for systems that do not use a scheduler (kubernetes systems).
+
+    Handles the installation of benchmarks or test templates for kubernetes systems.
+    """
+
+    PREREQUISITES = ["kubectl"]
+
+    def _check_prerequisites(self) -> InstallStatusResult:
+        """Check for the presence of required binaries, returning an error status if any are missing."""
+        super()._check_prerequisites()  # TODO: if fails, print out missing prerequisites
+        missing_binaries = []
+        for binary in self.PREREQUISITES:
+            if not self._is_binary_installed(binary):
+                missing_binaries.append(binary)
+
+        if missing_binaries:
+            missing_str = ", ".join(missing_binaries)
+            return InstallStatusResult(False, f"Required binaries not installed: {missing_str}.")
+
+        return InstallStatusResult(True)

--- a/src/cloudai/parser/system_parser/kubernetes_system_parser.py
+++ b/src/cloudai/parser/system_parser/kubernetes_system_parser.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Any, Dict, List
+
+from cloudai import BaseSystemParser
+from cloudai.systems.kubernetes import KubernetesSystem
+
+
+class KubernetesSystemParser(BaseSystemParser):
+    """Parser for parsing Slurm system configurations."""
+
+    def parse(self, data: Dict[str, Any]) -> KubernetesSystem:  # noqa: C901
+        """
+        Parse the Slurm system configuration.
+
+        Args:
+            data (Dict[str, Any]): The loaded configuration data.
+
+        Returns:
+            KubernetesSystem: The parsed kubernetes system object.
+
+        Raises:
+            ValueError: If 'name' is missing from the data or if there are node list parsing issues
+            or group membership conflicts.
+        """
+
+        def safe_int(value):
+            try:
+                return int(value) if value is not None else None
+            except ValueError:
+                return None
+
+        def str_to_bool(value: Any) -> bool:
+            if isinstance(value, bool):
+                return value
+            return value.lower() in ("true", "1", "yes")
+
+        name = data.get("name")
+        if not name:
+            raise ValueError("Missing mandatory field: 'name'")
+
+        install_path = data.get("install_path")
+        if not install_path:
+            raise ValueError("Field 'install_path' is required.")
+        install_path = os.path.abspath(install_path)
+
+        output_path = data.get("output_path")
+        if not output_path:
+            raise ValueError("Field 'output_path' is required.")
+        output_path = os.path.abspath(output_path)
+
+        default_image = data.get("default_image")
+        if not default_image:
+            raise ValueError("Field 'default_image' is required.")
+
+        kube_config_path = data.get("kube_config_path")
+        if not kube_config_path or len(kube_config_path) == 0 or kube_config_path.isspace():
+            home_directory = os.path.expanduser('~')
+            kube_config_path = os.path.join(home_directory, '.kube', 'config')
+
+        default_namespace = data.get("default_namespace")
+        if not default_namespace:
+            raise ValueError("Field 'default_namespace' is required.")
+
+        global_env_vars = data.get("global_env_vars", {})
+        
+        return KubernetesSystem(
+            name=name,
+            install_path=install_path,
+            output_path=output_path,
+            default_image=default_image,
+            kube_config_path=kube_config_path,
+            default_namespace=default_namespace,
+            global_env_vars = global_env_vars,
+        )

--- a/src/cloudai/runner/kubernetes/__init__.py
+++ b/src/cloudai/runner/kubernetes/__init__.py
@@ -13,21 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .grading_strategy import SleepGradingStrategy
-from .report_generation_strategy import SleepReportGenerationStrategy
-from .slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
-from .standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
-from .kubernetes_json_gen_strategy import SleepKubernetesJobJsonGenStrategy
-from .standalone_install_strategy import SleepStandaloneInstallStrategy
-from .template import Sleep
-
-__all__ = [
-    "Sleep",
-    "SleepStandaloneInstallStrategy",
-    "SleepStandaloneCommandGenStrategy",
-    "SleepKubernetesJobJsonGenStrategy",
-    "SleepSlurmCommandGenStrategy",
-    "SleepReportGenerationStrategy",
-    "SleepGradingStrategy",
-]

--- a/src/cloudai/runner/kubernetes/kubernetes_job.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_job.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudai import BaseJob
+from cloudai._core.test import Test
+
+class KubernetesJob(BaseJob):
+    """
+    A class for representing a kubernetes job created by executing a test.
+
+    Attributes
+        name (str): The name of the job.
+        namespace (str): The namespace of the job.
+        test (Test): The test instance associated with this job.
+    """
+
+    def __init__(self, job_id: int, test: Test, output_path: str, name: str, namespace: str):
+        """
+        Initialize a Kubernetes Job instance.
+
+        Args:
+            name (str): The name of the job.
+            namespace (str): The namespace of the job.
+            test (Test): The test instance associated with this job.
+        """
+        super().__init__(job_id, test, output_path)
+        self.namespace = namespace
+        self.name = name
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the kubernetes Job instance.
+
+        Returns
+            str: String representation of the kubernetes job.
+        """
+        return f"BaseJob(name={self.name}, namespace={self.namespace}, test={self.test.name}, )"

--- a/src/cloudai/runner/kubernetes/kubernetes_runner.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_runner.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import cast
+
+from cloudai import BaseJob, BaseRunner, JobIdRetrievalError, System, Test, TestScenario
+from cloudai.systems import KubernetesSystem
+from cloudai.util.kubernetes import KubernetesJobClient
+
+from .kubernetes_job import KubernetesJob
+
+
+class KubernetesRunner(BaseRunner):
+    """
+    Implementation of the Runner for a system using Slurm.
+
+    This class is responsible for executing and managing tests in a Slurm environment. It extends the BaseRunner class,
+    implementing the abstract methods to work with Slurm jobs.
+
+    Attributes
+        slurm_system (SlurmSystem): This attribute is a casted version of the `system` attribute to `SlurmSystem` type,
+            ensuring that Slurm-specific properties and methods are accessible.
+        cmd_shell (CommandShell): An instance of CommandShell for executing system commands.
+        Inherits all other attributes from the BaseRunner class.
+    """
+
+    def __init__(self, mode: str, system: System, test_scenario: TestScenario) -> None:
+        """
+        Initialize the SlurmRunner.
+
+        Args:
+            mode (str): The operation mode ('dry-run', 'run').
+            system (System): The system configuration.
+            test_scenario (TestScenario): The test scenario to run.
+        """
+        super().__init__(mode, system, test_scenario)
+        self.kubernetes_system: KubernetesSystem = cast(KubernetesSystem, system)
+        self.k8sJobClient = KubernetesJobClient(self.kubernetes_system.kube_config_path)
+
+    def _submit_test(self, test: Test) -> KubernetesJob:
+        """
+        Submit a test for execution on Slurm and returns a SlurmJob.
+
+        Args:
+            test (Test): The test to be executed.
+
+        Returns:
+            SlurmJob: A SlurmJob object
+        """
+        logging.info(f"Running test: {test.section_name}")
+        job_output_path = self.get_job_output_path(test)
+        job_name = test.section_name.replace('.', '-').lower()
+        job_spec = test.gen_json_string(job_output_path, job_name)
+        logging.info(f"Json string for test {test.section_name}: {job_spec}")
+        job_id = 0
+        job_namespace = ""  
+        if self.mode == "run":
+            job_name, job_namespace = self.k8sJobClient.create_job(job_spec, self.kubernetes_system.default_namespace)
+
+        return KubernetesJob(job_id, test, job_output_path, job_name, job_namespace)
+
+    def is_job_running(self, job: BaseJob) -> bool:
+        """
+        Check if the specified job is currently running.
+
+        Args:
+            job (BaseJob): The job to check.
+
+        Returns:
+            bool: True if the job is running, False otherwise.
+        """
+        if self.mode == "dry-run":
+            return True
+        k_job = cast(KubernetesJob, job)
+        return self.k8sJobClient.is_job_running(k_job.name, k_job.namespace)
+
+    def is_job_completed(self, job: BaseJob) -> bool:
+        """
+        Check if a Slurm job is completed.
+
+        Args:
+            job (BaseJob): The job to check.
+
+        Returns:
+            bool: True if the job is completed, False otherwise.
+        """
+        if self.mode == "dry-run":
+            return True
+        k_job = cast(KubernetesJob, job)
+        return self.k8sJobClient.is_job_completed(k_job.name, k_job.namespace)
+
+    def kill_job(self, job: BaseJob) -> None:
+        """
+        Terminate a Slurm job.
+
+        Args:
+            job (BaseJob): The job to be terminated.
+        """
+        pass

--- a/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, cast
+
+from cloudai import JsonGenStrategy
+from cloudai.systems import KubernetesSystem
+
+
+class SleepKubernetesJobJsonGenStrategy(JsonGenStrategy):
+    """
+    Command generation strategy for the Sleep test on kubernetes systems.
+
+    This strategy generates a command to execute a sleep operation with specified duration on kubernetes systems.
+    """
+
+    def gen_json_string(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: str,
+        job_name: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> dict:
+        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+        sec = self.final_cmd_args["seconds"]
+
+        kubernetes_system = cast(KubernetesSystem, self.system)
+
+        job_spec = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name":  job_name,
+                "namespace": kubernetes_system.default_namespace
+            },
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "args": [
+                                    "sleep " + sec
+                                ],
+                                "command": [
+                                    "/bin/bash",
+                                    "-c"
+                                ],
+                                "image": kubernetes_system.default_image,
+                                "name": "task"
+                            }
+                        ],
+                        "restartPolicy": "Never"
+                    }
+                }
+            }
+        }
+        
+        return job_spec
+

--- a/src/cloudai/systems/__init__.py
+++ b/src/cloudai/systems/__init__.py
@@ -16,8 +16,10 @@
 
 from .slurm.slurm_system import SlurmSystem
 from .standalone_system import StandaloneSystem
+from .kubernetes.kubernetes_system import KubernetesSystem
 
 __all__ = [
     "SlurmSystem",
     "StandaloneSystem",
+    "KubernetesSystem",
 ]

--- a/src/cloudai/systems/kubernetes/__init__.py
+++ b/src/cloudai/systems/kubernetes/__init__.py
@@ -14,20 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .grading_strategy import SleepGradingStrategy
-from .report_generation_strategy import SleepReportGenerationStrategy
-from .slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
-from .standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
-from .kubernetes_json_gen_strategy import SleepKubernetesJobJsonGenStrategy
-from .standalone_install_strategy import SleepStandaloneInstallStrategy
-from .template import Sleep
+from .kubernetes_system import KubernetesSystem
 
 __all__ = [
-    "Sleep",
-    "SleepStandaloneInstallStrategy",
-    "SleepStandaloneCommandGenStrategy",
-    "SleepKubernetesJobJsonGenStrategy",
-    "SleepSlurmCommandGenStrategy",
-    "SleepReportGenerationStrategy",
-    "SleepGradingStrategy",
+    "KubernetesSystem",
 ]

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import getpass
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from cloudai import System
+
+class KubernetesSystem(System):
+    """
+    Represents a Slurm system, encapsulating the system's configuration.
+
+    Attributes
+        name (str): The name of the Slurm system.
+        install_path (str): Installation path of CloudAI software.
+        output_path (str): Directory path for output files.
+        default_image (str): Default image.
+        global_env_vars (Optional[Dict[str, Any]]): Dictionary containing additional configuration settings for the
+            system.
+    """
+
+    def update(self) -> None:
+        """
+        Update the system object for a SLURM system.
+
+        This method updates the system object by querying the current state of each node using the 'sinfo' and 'squeue'
+        commands, and correlating this information to determine the state of each node and the user running jobs on
+        each node.
+        """
+        pass
+
+    def __init__(
+        self,
+        name: str,
+        install_path: str,
+        output_path: str,
+        default_image: str,
+        kube_config_path: str,
+        default_namespace: str,
+        global_env_vars: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Initialize a KubernetesSystem instance.
+
+        Args:
+            name (str): Name of the Slurm system.
+            install_path (str): The installation path of CloudAI.
+            output_path (str): Path to the output directory.
+            default_image (str): Default image.
+            kube_config_path(str): Kube config file path.
+            global_env_vars (Optional[Dict[str, Any]]): Dictionary containing additional configuration settings for
+                the system.
+        """
+        super().__init__(name, "kubernetes", output_path)
+        self.install_path = install_path
+        self.default_image = default_image
+        self.kube_config_path = kube_config_path
+        self.default_namespace = default_namespace
+        self.global_env_vars = global_env_vars if global_env_vars is not None else {}
+        logging.debug(f"{self.__class__.__name__} initialized")
+
+    def __repr__(self) -> str:
+        """
+        Provide a structured string representation of the system.
+        """
+        header = f"System Name: {self.name}\nScheduler Type: {self.scheduler}"
+        return header

--- a/src/cloudai/util/kubernetes/__init__.py
+++ b/src/cloudai/util/kubernetes/__init__.py
@@ -14,20 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .grading_strategy import SleepGradingStrategy
-from .report_generation_strategy import SleepReportGenerationStrategy
-from .slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
-from .standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
-from .kubernetes_json_gen_strategy import SleepKubernetesJobJsonGenStrategy
-from .standalone_install_strategy import SleepStandaloneInstallStrategy
-from .template import Sleep
+from .kubernetes_job import KubernetesJobClient
 
 __all__ = [
-    "Sleep",
-    "SleepStandaloneInstallStrategy",
-    "SleepStandaloneCommandGenStrategy",
-    "SleepKubernetesJobJsonGenStrategy",
-    "SleepSlurmCommandGenStrategy",
-    "SleepReportGenerationStrategy",
-    "SleepGradingStrategy",
+    "KubernetesJobClient",
 ]

--- a/src/cloudai/util/kubernetes/kubernetes_job.py
+++ b/src/cloudai/util/kubernetes/kubernetes_job.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from time import sleep
+from typing import List
+from kubernetes import config, client
+
+class KubernetesJobClient:
+    """
+    A class responsible for submit job to kubernetes cluster.
+
+    Attributes
+        kube_config_path (str): The kube config file path.
+    """
+
+    def __init__(self, kube_config_path: str):
+        """
+        Initialize the KubernetesJobClient.
+
+        Args:
+            kube_config_path (str): The kube config file path. Defaults to "~/.kube/config".
+
+        Raises:
+            FileNotFoundError: If the specified kube config file does not exist.
+        """
+        if not os.path.exists(kube_config_path):
+            raise FileNotFoundError(f"kube config file '{kube_config_path}' not found.")
+        self.kube_config_path = kube_config_path
+        config.load_kube_config(config_file = self.kube_config_path)
+        self.core_v1 = client.CoreV1Api()
+        self.batch_v1 = client.BatchV1Api()
+
+    def create_node_group(self, name: str, node_list: List[str]):
+        for node in node_list:
+            body = {
+                "metadata": {
+                    "labels": { "cloudai/node-group": name }
+                }
+            }
+            self.core_v1.patch_node(node, body)
+
+    """
+    def create_job_object(self, job_name: str, image: str, args: List[str]):
+        containers = client.V1Container(
+            name = "task",
+            image = image,
+            command = ["/bin/bash", "-c"],
+            args = args)
+        # Create and configure a spec section
+        template = client.V1PodTemplateSpec(
+            metadata=client.V1ObjectMeta(),
+            spec=client.V1PodSpec(restart_policy = "Never", containers = [containers]))
+        # Create the specification of deployment
+        spec = client.V1JobSpec(
+            template = template,
+            backoff_limit = 4)
+        # Instantiate the job object
+        job = client.V1Job(
+            api_version = "batch/v1",
+            kind = "Job",
+            metadata = client.V1ObjectMeta(name=job_name),
+            spec = spec)
+
+        return job
+    """
+
+    def create_job(self, job_spec, namespace) -> tuple[str, str]:
+        api_response = self.batch_v1.create_namespaced_job(
+            body = job_spec,
+            namespace = namespace)
+        print(f"Job created. status='{str(api_response.status)}'")
+        return api_response.metadata.name, api_response.metadata.namespace
+
+    def is_job_running(self, job_name, namespace) -> bool:
+        k8s_job = self.batch_v1.read_namespaced_job_status(name=job_name, namespace=namespace)
+        if k8s_job.status.completion_time:
+            return False
+        else:
+            return True
+
+    def is_job_completed(self, job_name, namespace) -> bool:
+        return not self.is_job_running(job_name, namespace)
+
+    def get_job_status(self, job_name, namespace):
+        job_completed = False
+        while not job_completed:
+            api_response = self.batch_v1.read_namespaced_job_status(
+                name = job_name,
+                namespace = namespace)
+            if api_response.status.succeeded is not None or \
+                    api_response.status.failed is not None:
+                job_completed = True
+            sleep(1)
+            print(f"Job status='{str(api_response.status)}'")
+
+    def delete_job(self, job_name, namespace):
+        api_response = self.batch_v1.delete_namespaced_job(
+            name = job_name,
+            namespace = namespace,
+            body = client.V1DeleteOptions(
+                propagation_policy = 'Foreground',
+                grace_period_seconds = 5))
+        print(f"Job deleted. status='{str(api_response.status)}'")
+
+    def list_job(self, namespace):
+        return self.batch_v1.list_namespaced_job(namespace = namespace)
+
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@
 import pytest
 from cloudai import (
     CommandGenStrategy,
+    JsonGenStrategy,
     GradingStrategy,
     InstallStrategy,
     JobIdRetrievalStrategy,
@@ -25,6 +26,7 @@ from cloudai import (
 )
 from cloudai.installer.slurm_installer import SlurmInstaller
 from cloudai.installer.standalone_installer import StandaloneInstaller
+from cloudai.installer.kubernetes_installer import KubernetesInstaller
 from cloudai.schema.test_template.chakra_replay.grading_strategy import ChakraReplayGradingStrategy
 from cloudai.schema.test_template.chakra_replay.report_generation_strategy import ChakraReplayReportGenerationStrategy
 from cloudai.schema.test_template.chakra_replay.slurm_command_gen_strategy import ChakraReplaySlurmCommandGenStrategy
@@ -54,6 +56,7 @@ from cloudai.schema.test_template.sleep.grading_strategy import SleepGradingStra
 from cloudai.schema.test_template.sleep.report_generation_strategy import SleepReportGenerationStrategy
 from cloudai.schema.test_template.sleep.slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from cloudai.schema.test_template.sleep.standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
+from cloudai.schema.test_template.sleep.kubernetes_json_gen_strategy import SleepKubernetesJobJsonGenStrategy
 from cloudai.schema.test_template.sleep.standalone_install_strategy import SleepStandaloneInstallStrategy
 from cloudai.schema.test_template.sleep.template import Sleep
 from cloudai.schema.test_template.ucc_test.grading_strategy import UCCTestGradingStrategy
@@ -63,6 +66,7 @@ from cloudai.schema.test_template.ucc_test.slurm_install_strategy import UCCTest
 from cloudai.schema.test_template.ucc_test.template import UCCTest
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.systems.standalone_system import StandaloneSystem
+from cloudai.systems.kubernetes.kubernetes_system import KubernetesSystem
 
 
 def test_system_parsers():
@@ -89,6 +93,7 @@ def test_runners():
         ((CommandGenStrategy, SlurmSystem, Sleep), SleepSlurmCommandGenStrategy),
         ((CommandGenStrategy, SlurmSystem, UCCTest), UCCTestSlurmCommandGenStrategy),
         ((CommandGenStrategy, StandaloneSystem, Sleep), SleepStandaloneCommandGenStrategy),
+        ((JsonGenStrategy, KubernetesSystem, Sleep), SleepKubernetesJobJsonGenStrategy),
         ((GradingStrategy, SlurmSystem, ChakraReplay), ChakraReplayGradingStrategy),
         ((GradingStrategy, SlurmSystem, JaxToolbox), JaxToolboxGradingStrategy),
         ((GradingStrategy, SlurmSystem, NcclTest), NcclTestGradingStrategy),
@@ -135,6 +140,7 @@ def test_test_templates():
 
 def test_installers():
     installers = Registry().installers_map
-    assert len(installers) == 2
+    assert len(installers) == 3
     assert installers["standalone"] == StandaloneInstaller
     assert installers["slurm"] == SlurmInstaller
+    assert installers["kubernetes"] == KubernetesInstaller


### PR DESCRIPTION
## Summary
Support K8s system.

## Test Plan
Submit sleep job:
```
cloudai    --mode run    --system-config conf/system/kubernetes_cluster.toml    --test-templates-dir conf/test_template 
   --tests-dir conf/test    --test-scenario conf/test_scenario/sleep.toml
```

Check jobs in k8s cluster:
```
kubectl get job
NAME      COMPLETIONS   DURATION   AGE
tests-1   1/1           13s        18s
tests-2   1/1           8s         13s
tests-3   1/1           8s         13s
tests-4   0/1           18s        18s
```

## Additional Notes
Some configuration is hard code and there some functions that have not been implemented(such as getting job status and running time, etc). 
