### PR TITLE
Simplify slurm system

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import getpass
 import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple


### PR DESCRIPTION
## Summary
Remove fetching for allocated nodes when looking for available nodes as it is useless.

## Test Plan
Tested with a scenario with 2 consecutive tests such as :
name = "llama_2"

[Tests]
  [Tests.1]
    name = "llama"
    nodes = ["cluster_name-[042,045,047-049,051,059-060]"]

  [Tests.2]
    name = "llama"
    nodes = ["cluster_name-[042,045,047-049,051,059-060]"]
    [Tests.2.dependencies]
      start_post_comp = { name = "Tests.1", time = 0 }
