### PR TITLE
Update NCCL Test Templates and Introduce Kubernetes-Specific Strategies (No Shared Dir / Mixin / Sep 3rd)

### DIFF
--- a/conf/common/system/kubernetes_cluster.toml
+++ b/conf/common/system/kubernetes_cluster.toml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = "kubernetes-cluster"
+scheduler = "kubernetes"
+kube_config_path = ""
+
+install_path = "./install"
+output_path = "./results"
+default_image = "ubuntu:22.04"
+default_namespace = "default"
+
+[global_env_vars]
+NCCL_IB_GID_INDEX = "3"
+NCCL_SOCKET_IFNAME = "ib0"
+NCCL_IB_HCA = "mlx5_0"
+UCX_NET_DEVICES = "mlx5_0:1"
+NCCL_P2P_LEVEL = "PIX"
+UCX_TLS = "rc_x,sm,cuda_copy"
+NCCL_IB_TC = "96"

--- a/conf/common/test/nccl_test_all_gather.toml
+++ b/conf/common/test/nccl_test_all_gather.toml
@@ -20,7 +20,7 @@ test_template_name = "NcclTest"
 extra_cmd_args = "--stepfactor 2"
 
 [cmd_args]
-"subtest_name" = "all_gather_perf_mpi"
+"subtest_name" = "all_gather_perf"
 "ngpus" = "1"
 "minbytes" = "128"
 "maxbytes" = "4G"

--- a/conf/common/test/nccl_test_all_reduce.toml
+++ b/conf/common/test/nccl_test_all_reduce.toml
@@ -20,7 +20,7 @@ test_template_name = "NcclTest"
 extra_cmd_args = "--stepfactor 2"
 
 [cmd_args]
-"subtest_name" = "all_reduce_perf_mpi"
+"subtest_name" = "all_reduce_perf"
 "ngpus" = "1"
 "minbytes" = "128"
 "maxbytes" = "16G"

--- a/conf/common/test/nccl_test_alltoall.toml
+++ b/conf/common/test/nccl_test_alltoall.toml
@@ -20,7 +20,7 @@ test_template_name = "NcclTest"
 extra_cmd_args = "--stepfactor 2"
 
 [cmd_args]
-"subtest_name" = "alltoall_perf_mpi"
+"subtest_name" = "alltoall_perf"
 "ngpus" = "1"
 "minbytes" = "128"
 "maxbytes" = "4G"

--- a/conf/common/test/nccl_test_broadcast.toml
+++ b/conf/common/test/nccl_test_broadcast.toml
@@ -19,4 +19,4 @@ description = "broadcast"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"subtest_name" = "broadcast_perf_mpi"
+"subtest_name" = "broadcast_perf"

--- a/conf/common/test/nccl_test_gather.toml
+++ b/conf/common/test/nccl_test_gather.toml
@@ -19,4 +19,4 @@ description = "gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"subtest_name" = "gather_perf_mpi"
+"subtest_name" = "gather_perf"

--- a/conf/common/test/nccl_test_hypercube.toml
+++ b/conf/common/test/nccl_test_hypercube.toml
@@ -19,4 +19,4 @@ description = "hypercube"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"subtest_name" = "hypercube_perf_mpi"
+"subtest_name" = "hypercube_perf"

--- a/conf/common/test/nccl_test_reduce.toml
+++ b/conf/common/test/nccl_test_reduce.toml
@@ -19,4 +19,4 @@ description = "reduce"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"subtest_name" = "reduce_perf_mpi"
+"subtest_name" = "reduce_perf"

--- a/conf/common/test/nccl_test_reduce_scatter.toml
+++ b/conf/common/test/nccl_test_reduce_scatter.toml
@@ -20,7 +20,7 @@ test_template_name = "NcclTest"
 extra_cmd_args = "--stepfactor 2"
 
 [cmd_args]
-"subtest_name" = "reduce_scatter_perf_mpi"
+"subtest_name" = "reduce_scatter_perf"
 "ngpus" = "1"
 "minbytes" = "128"
 "maxbytes" = "4G"

--- a/conf/common/test/nccl_test_scatter.toml
+++ b/conf/common/test/nccl_test_scatter.toml
@@ -19,4 +19,4 @@ description = "scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"subtest_name" = "scatter_perf_mpi"
+"subtest_name" = "scatter_perf"

--- a/conf/common/test/nccl_test_sendrecv.toml
+++ b/conf/common/test/nccl_test_sendrecv.toml
@@ -19,4 +19,4 @@ description = "sendrecv"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"subtest_name" = "sendrecv_perf_mpi"
+"subtest_name" = "sendrecv_perf"

--- a/conf/common/test_template/nccl_test.toml
+++ b/conf/common/test_template/nccl_test.toml
@@ -19,23 +19,23 @@ name = "NcclTest"
 [cmd_args]
   [cmd_args.docker_image_url]
   type = "str"
-  default = "nvcr.io/nvidia/pytorch:24.02-py3"
+  default = "ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-85f9143"
 
   [cmd_args.subtest_name]
   type = "preset"
   values = [
-    "all_reduce_perf_mpi",
-    "all_gather_perf_mpi",
-    "alltoall_perf_mpi",
-    "broadcast_perf_mpi",
-    "gather_perf_mpi",
-    "hypercube_perf_mpi",
-    "reduce_perf_mpi",
-    "reduce_scatter_perf_mpi",
-    "scatter_perf_mpi",
-    "sendrecv_perf_mpi",
+    "all_reduce_perf",
+    "all_gather_perf",
+    "alltoall_perf",
+    "broadcast_perf",
+    "gather_perf",
+    "hypercube_perf",
+    "reduce_perf",
+    "reduce_scatter_perf",
+    "scatter_perf",
+    "sendrecv_perf",
   ]
-  default = "all_reduce_perf_mpi"
+  default = "all_reduce_perf"
 
   [cmd_args.nthreads]
   type = "int"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bokeh==3.4.1
 pandas==2.2.1
 tbparse==0.0.8
 toml==0.10.2
+kubernetes==30.1.0

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -61,12 +61,21 @@ from .schema.test_template.jax_toolbox.report_generation_strategy import JaxTool
 from .schema.test_template.jax_toolbox.slurm_command_gen_strategy import JaxToolboxSlurmCommandGenStrategy
 from .schema.test_template.jax_toolbox.slurm_install_strategy import JaxToolboxSlurmInstallStrategy
 from .schema.test_template.jax_toolbox.template import JaxToolbox
-from .schema.test_template.nccl_test.grading_strategy import NcclTestGradingStrategy
-from .schema.test_template.nccl_test.job_status_retrieval_strategy import NcclTestJobStatusRetrievalStrategy
+from .schema.test_template.nccl_test.kubernetes_grading_strategy import KubernetesNcclTestGradingStrategy
+from .schema.test_template.nccl_test.kubernetes_job_status_retrieval_strategy import (
+    KubernetesNcclTestJobStatusRetrievalStrategy,
+)
 from .schema.test_template.nccl_test.kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
-from .schema.test_template.nccl_test.report_generation_strategy import NcclTestReportGenerationStrategy
+from .schema.test_template.nccl_test.kubernetes_report_generation_strategy import (
+    KubernetesNcclTestReportGenerationStrategy,
+)
 from .schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
+from .schema.test_template.nccl_test.slurm_grading_strategy import SlurmNcclTestGradingStrategy
 from .schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
+from .schema.test_template.nccl_test.slurm_job_status_retrieval_strategy import (
+    SlurmNcclTestJobStatusRetrievalStrategy,
+)
+from .schema.test_template.nccl_test.slurm_report_generation_strategy import SlurmNcclTestReportGenerationStrategy
 from .schema.test_template.nccl_test.template import NcclTest
 from .schema.test_template.nemo_launcher.grading_strategy import NeMoLauncherGradingStrategy
 from .schema.test_template.nemo_launcher.report_generation_strategy import NeMoLauncherReportGenerationStrategy
@@ -103,13 +112,17 @@ Registry().add_runner("standalone", StandaloneRunner)
 
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NcclTest], NcclTestSlurmInstallStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NeMoLauncher], NeMoLauncherSlurmInstallStrategy)
-Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [NcclTest], NcclTestReportGenerationStrategy)
+Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [NcclTest], SlurmNcclTestReportGenerationStrategy)
+Registry().add_strategy(
+    ReportGenerationStrategy, [KubernetesSystem], [NcclTest], KubernetesNcclTestReportGenerationStrategy
+)
 Registry().add_strategy(CommandGenStrategy, [StandaloneSystem], [Sleep], SleepStandaloneCommandGenStrategy)
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [Sleep], SleepSlurmCommandGenStrategy)
 Registry().add_strategy(JsonGenStrategy, [KubernetesSystem], [Sleep], SleepKubernetesJsonGenStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxSlurmInstallStrategy)
 Registry().add_strategy(JsonGenStrategy, [KubernetesSystem], [NcclTest], NcclTestKubernetesJsonGenStrategy)
-Registry().add_strategy(GradingStrategy, [SlurmSystem], [NcclTest], NcclTestGradingStrategy)
+Registry().add_strategy(GradingStrategy, [KubernetesSystem], [NcclTest], KubernetesNcclTestGradingStrategy)
+Registry().add_strategy(GradingStrategy, [SlurmSystem], [NcclTest], SlurmNcclTestGradingStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmInstallStrategy)
 Registry().add_strategy(InstallStrategy, [StandaloneSystem, SlurmSystem], [Sleep], SleepStandaloneInstallStrategy)
 Registry().add_strategy(InstallStrategy, [KubernetesSystem], [Sleep], SleepKubernetesInstallStrategy)
@@ -135,10 +148,11 @@ Registry().add_strategy(
 )
 Registry().add_strategy(JobIdRetrievalStrategy, [StandaloneSystem], [Sleep], StandaloneJobIdRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [StandaloneSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
+Registry().add_strategy(JobStatusRetrievalStrategy, [KubernetesSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
+Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [NcclTest], SlurmNcclTestJobStatusRetrievalStrategy)
 Registry().add_strategy(
-    JobStatusRetrievalStrategy, [KubernetesSystem], [Sleep, NcclTest], DefaultJobStatusRetrievalStrategy
+    JobStatusRetrievalStrategy, [KubernetesSystem], [NcclTest], KubernetesNcclTestJobStatusRetrievalStrategy
 )
-Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [NcclTest], NcclTestJobStatusRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxJobStatusRetrievalStrategy)
 Registry().add_strategy(
     JobStatusRetrievalStrategy,

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -38,6 +38,7 @@ from ._core.test_template_strategy import TestTemplateStrategy
 from .installer.installer import Installer
 from .installer.slurm_installer import SlurmInstaller
 from .installer.standalone_installer import StandaloneInstaller
+from .parser.system_parser.kubernetes_system_parser import KubernetesSystemParser
 from .parser.system_parser.slurm_system_parser import SlurmSystemParser
 from .parser.system_parser.standalone_system_parser import StandaloneSystemParser
 from .report_generator import ReportGenerator
@@ -87,6 +88,7 @@ from .systems.standalone_system import StandaloneSystem
 
 Registry().add_system_parser("standalone", StandaloneSystemParser)
 Registry().add_system_parser("slurm", SlurmSystemParser)
+Registry().add_system_parser("kubernetes", KubernetesSystemParser)
 
 Registry().add_runner("slurm", SlurmRunner)
 Registry().add_runner("standalone", StandaloneRunner)

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -36,6 +36,7 @@ from ._core.test_scenario import TestScenario
 from ._core.test_template import TestTemplate
 from ._core.test_template_strategy import TestTemplateStrategy
 from .installer.installer import Installer
+from .installer.kubernetes_installer import KubernetesInstaller
 from .installer.slurm_installer import SlurmInstaller
 from .installer.standalone_installer import StandaloneInstaller
 from .parser.system_parser.kubernetes_system_parser import KubernetesSystemParser
@@ -147,6 +148,7 @@ Registry().add_test_template("UCCTest", UCCTest)
 
 Registry().add_installer("slurm", SlurmInstaller)
 Registry().add_installer("standalone", StandaloneInstaller)
+Registry().add_installer("kubernetes", KubernetesInstaller)
 
 __all__ = [
     "BaseInstaller",

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -63,6 +63,7 @@ from .schema.test_template.jax_toolbox.slurm_install_strategy import JaxToolboxS
 from .schema.test_template.jax_toolbox.template import JaxToolbox
 from .schema.test_template.nccl_test.grading_strategy import NcclTestGradingStrategy
 from .schema.test_template.nccl_test.job_status_retrieval_strategy import NcclTestJobStatusRetrievalStrategy
+from .schema.test_template.nccl_test.kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
 from .schema.test_template.nccl_test.report_generation_strategy import NcclTestReportGenerationStrategy
 from .schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 from .schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
@@ -107,6 +108,7 @@ Registry().add_strategy(CommandGenStrategy, [StandaloneSystem], [Sleep], SleepSt
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [Sleep], SleepSlurmCommandGenStrategy)
 Registry().add_strategy(JsonGenStrategy, [KubernetesSystem], [Sleep], SleepKubernetesJsonGenStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxSlurmInstallStrategy)
+Registry().add_strategy(JsonGenStrategy, [KubernetesSystem], [NcclTest], NcclTestKubernetesJsonGenStrategy)
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [NcclTest], NcclTestGradingStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmInstallStrategy)
 Registry().add_strategy(InstallStrategy, [StandaloneSystem, SlurmSystem], [Sleep], SleepStandaloneInstallStrategy)
@@ -133,7 +135,9 @@ Registry().add_strategy(
 )
 Registry().add_strategy(JobIdRetrievalStrategy, [StandaloneSystem], [Sleep], StandaloneJobIdRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [StandaloneSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
-Registry().add_strategy(JobStatusRetrievalStrategy, [KubernetesSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
+Registry().add_strategy(
+    JobStatusRetrievalStrategy, [KubernetesSystem], [Sleep, NcclTest], DefaultJobStatusRetrievalStrategy
+)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [NcclTest], NcclTestJobStatusRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxJobStatusRetrievalStrategy)
 Registry().add_strategy(

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -76,6 +76,8 @@ from .schema.test_template.nemo_launcher.slurm_job_id_retrieval_strategy import 
 )
 from .schema.test_template.nemo_launcher.template import NeMoLauncher
 from .schema.test_template.sleep.grading_strategy import SleepGradingStrategy
+from .schema.test_template.sleep.kubernetes_install_strategy import SleepKubernetesInstallStrategy
+from .schema.test_template.sleep.kubernetes_json_gen_strategy import SleepKubernetesJsonGenStrategy
 from .schema.test_template.sleep.report_generation_strategy import SleepReportGenerationStrategy
 from .schema.test_template.sleep.slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from .schema.test_template.sleep.standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
@@ -86,6 +88,7 @@ from .schema.test_template.ucc_test.report_generation_strategy import UCCTestRep
 from .schema.test_template.ucc_test.slurm_command_gen_strategy import UCCTestSlurmCommandGenStrategy
 from .schema.test_template.ucc_test.slurm_install_strategy import UCCTestSlurmInstallStrategy
 from .schema.test_template.ucc_test.template import UCCTest
+from .systems.kubernetes.kubernetes_system import KubernetesSystem
 from .systems.slurm.slurm_system import SlurmSystem
 from .systems.standalone_system import StandaloneSystem
 
@@ -102,10 +105,12 @@ Registry().add_strategy(InstallStrategy, [SlurmSystem], [NeMoLauncher], NeMoLaun
 Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [NcclTest], NcclTestReportGenerationStrategy)
 Registry().add_strategy(CommandGenStrategy, [StandaloneSystem], [Sleep], SleepStandaloneCommandGenStrategy)
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [Sleep], SleepSlurmCommandGenStrategy)
+Registry().add_strategy(JsonGenStrategy, [KubernetesSystem], [Sleep], SleepKubernetesJsonGenStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxSlurmInstallStrategy)
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [NcclTest], NcclTestGradingStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [UCCTest], UCCTestSlurmInstallStrategy)
 Registry().add_strategy(InstallStrategy, [StandaloneSystem, SlurmSystem], [Sleep], SleepStandaloneInstallStrategy)
+Registry().add_strategy(InstallStrategy, [KubernetesSystem], [Sleep], SleepKubernetesInstallStrategy)
 Registry().add_strategy(
     ReportGenerationStrategy, [StandaloneSystem, SlurmSystem], [Sleep], SleepReportGenerationStrategy
 )
@@ -128,6 +133,7 @@ Registry().add_strategy(
 )
 Registry().add_strategy(JobIdRetrievalStrategy, [StandaloneSystem], [Sleep], StandaloneJobIdRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [StandaloneSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
+Registry().add_strategy(JobStatusRetrievalStrategy, [KubernetesSystem], [Sleep], DefaultJobStatusRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [NcclTest], NcclTestJobStatusRetrievalStrategy)
 Registry().add_strategy(JobStatusRetrievalStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxJobStatusRetrievalStrategy)
 Registry().add_strategy(

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -26,6 +26,7 @@ from ._core.install_strategy import InstallStrategy
 from ._core.job_id_retrieval_strategy import JobIdRetrievalStrategy
 from ._core.job_status_result import JobStatusResult
 from ._core.job_status_retrieval_strategy import JobStatusRetrievalStrategy
+from ._core.json_gen_strategy import JsonGenStrategy
 from ._core.parser import Parser
 from ._core.registry import Registry
 from ._core.report_generation_strategy import ReportGenerationStrategy
@@ -43,6 +44,7 @@ from .parser.system_parser.kubernetes_system_parser import KubernetesSystemParse
 from .parser.system_parser.slurm_system_parser import SlurmSystemParser
 from .parser.system_parser.standalone_system_parser import StandaloneSystemParser
 from .report_generator import ReportGenerator
+from .runner.kubernetes.kubernetes_runner import KubernetesRunner
 from .runner.slurm.slurm_runner import SlurmRunner
 from .runner.standalone.standalone_runner import StandaloneRunner
 from .schema.test_template.chakra_replay.grading_strategy import ChakraReplayGradingStrategy
@@ -92,6 +94,7 @@ Registry().add_system_parser("slurm", SlurmSystemParser)
 Registry().add_system_parser("kubernetes", KubernetesSystemParser)
 
 Registry().add_runner("slurm", SlurmRunner)
+Registry().add_runner("kubernetes", KubernetesRunner)
 Registry().add_runner("standalone", StandaloneRunner)
 
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NcclTest], NcclTestSlurmInstallStrategy)
@@ -156,6 +159,7 @@ __all__ = [
     "BaseRunner",
     "BaseSystemParser",
     "CommandGenStrategy",
+    "JsonGenStrategy",
     "Grader",
     "GradingStrategy",
     "Installer",

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -282,6 +282,8 @@ class BaseRunner(ABC):
 
         for job in list(self.jobs):
             if job.is_completed():
+                await self.job_completion_callback(job)
+
                 if self.mode == "dry-run":
                     successful_jobs_count += 1
                     await self.handle_job_completion(job)
@@ -334,6 +336,7 @@ class BaseRunner(ABC):
             completed_job (BaseJob): The job that has just been completed.
         """
         logging.info(f"Job completed: {completed_job.test_run.test.section_name}")
+
         self.jobs.remove(completed_job)
         del self.test_to_job_map[completed_job.test_run.test]
         completed_job.increment_iteration()
@@ -343,6 +346,18 @@ class BaseRunner(ABC):
             await self.submit_test(completed_job.test_run)
         else:
             await self.handle_dependencies(completed_job)
+
+    async def job_completion_callback(self, job: BaseJob) -> None:
+        """
+        Call callback functions upon job completion.
+
+        This method can be overridden by subclasses to invoke custom actions or callback functions when a job
+        completes, such as storing logs or other processing.
+
+        Args:
+            job (BaseJob): The job that has completed and for which callback functions are being invoked.
+        """
+        pass
 
     async def handle_dependencies(self, completed_job: BaseJob) -> List[Task]:
         """

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -347,7 +347,7 @@ class BaseRunner(ABC):
         else:
             await self.handle_dependencies(completed_job)
 
-    async def job_completion_callback(self, job: BaseJob) -> None:
+    async def job_completion_callback(self, job: BaseJob) -> None:  # noqa: B027
         """
         Call callback functions upon job completion.
 

--- a/src/cloudai/_core/json_gen_strategy.py
+++ b/src/cloudai/_core/json_gen_strategy.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import abstractmethod
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .test_template_strategy import TestTemplateStrategy
+
+
+class JsonGenStrategy(TestTemplateStrategy):
+    """
+    Abstract base class for generating Kubernetes job specifications based on system and test parameters.
+
+    It specifies how to generate JSON job specifications based on system and test parameters.
+    """
+
+    @abstractmethod
+    def gen_json(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: Path,
+        job_name: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> Dict[Any, Any]:
+        """
+        Generate the Kubernetes job specification based on the given parameters.
+
+        Args:
+            env_vars (Dict[str, str]): Environment variables for the job.
+            cmd_args (Dict[str, str]): Command-line arguments for the job.
+            extra_env_vars (Dict[str, str]): Additional environment variables.
+            extra_cmd_args (str): Additional command-line arguments.
+            output_path (Path): Path to the output directory.
+            job_name (str): The name of the job.
+            num_nodes (int): The number of nodes to be used for job execution.
+            nodes (List[str]): List of nodes for job execution, optional.
+
+        Returns:
+            Dict[Any, Any]: The generated Kubernetes job specification in JSON format.
+        """
+        pass

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -120,7 +120,7 @@ class Test:
         Generate the command to run this specific test.
 
         Args:
-            output_path (str): Path to the output directory.
+            output_path (Path): Path to the output directory where logs and results will be stored.
             time_limit (Optional[str]): Time limit for the test execution.
             num_nodes (Optional[int]): Number of nodes to be used for the test execution.
             nodes (Optional[List[str]]): List of nodes involved in the test.
@@ -143,19 +143,31 @@ class Test:
             nodes,
         )
 
-    def gen_json(self, output_path: Path, job_name: str) -> Dict[Any, Any]:
+    def gen_json(
+        self,
+        output_path: Path,
+        job_name: str,
+        time_limit: Optional[str] = None,
+        num_nodes: int = 1,
+        nodes: Optional[List[str]] = None,
+    ) -> Dict[Any, Any]:
         """
-        Generate the JSON string for the Kubernetes job specification for this specific test.
+        Generate a JSON dictionary representing the Kubernetes job specification for this test.
 
         Args:
-            output_path (Path): Path to the output directory.
-            job_name (str): The name of the job.
+            output_path (Path): Path to the output directory where logs and results will be stored.
+            job_name (str): The name assigned to the Kubernetes job.
+            time_limit (Optional[str]): Time limit for the test execution.
+            num_nodes (Optional[int]): Number of nodes to be used for the test execution.
+            nodes (Optional[List[str]]): List of nodes involved in the test.
 
         Returns:
             Dict[Any, Any]: A dictionary representing the Kubernetes job specification.
         """
-        if self.time_limit is not None:
-            self.cmd_args["time_limit"] = self.time_limit
+        if time_limit is not None:
+            self.cmd_args["time_limit"] = time_limit
+        if not nodes:
+            nodes = []
 
         return self.test_template.gen_json(
             self.env_vars,
@@ -164,8 +176,8 @@ class Test:
             self.extra_cmd_args,
             output_path,
             job_name,
-            self.num_nodes,
-            self.nodes,
+            num_nodes,
+            nodes,
         )
 
     def get_job_id(self, stdout: str, stderr: str) -> Optional[int]:

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -16,7 +16,7 @@
 
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from .job_status_result import JobStatusResult
 from .test_template import TestTemplate
@@ -146,6 +146,31 @@ class Test:
             self.extra_env_vars,
             self.extra_cmd_args,
             output_path,
+            self.num_nodes,
+            self.nodes,
+        )
+
+    def gen_json(self, output_path: Path, job_name: str) -> Dict[Any, Any]:
+        """
+        Generate the JSON string for the Kubernetes job specification for this specific test.
+
+        Args:
+            output_path (Path): Path to the output directory.
+            job_name (str): The name of the job.
+
+        Returns:
+            Dict[Any, Any]: A dictionary representing the Kubernetes job specification.
+        """
+        if self.time_limit is not None:
+            self.cmd_args["time_limit"] = self.time_limit
+
+        return self.test_template.gen_json(
+            self.env_vars,
+            self.cmd_args,
+            self.extra_env_vars,
+            self.extra_cmd_args,
+            output_path,
+            job_name,
             self.num_nodes,
             self.nodes,
         )

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -24,6 +24,7 @@ from .install_strategy import InstallStrategy
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
 from .job_status_result import JobStatusResult
 from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
+from .json_gen_strategy import JsonGenStrategy
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
 
@@ -42,6 +43,7 @@ class TestTemplate:
         logger (logging.Logger): Logger for the test template.
         install_strategy (InstallStrategy): Strategy for installing test prerequisites.
         command_gen_strategy (CommandGenStrategy): Strategy for generating execution commands.
+        json_gen_strategy (JsonGenStrategy): Strategy for generating json string.
         job_id_retrieval_strategy (JobIdRetrievalStrategy): Strategy for retrieving job IDs.
         report_generation_strategy (ReportGenerationStrategy): Strategy for generating reports.
         grading_strategy (GradingStrategy): Strategy for grading performance based on test outcomes.
@@ -72,6 +74,7 @@ class TestTemplate:
         self.cmd_args = cmd_args
         self.install_strategy: Optional[InstallStrategy] = None
         self.command_gen_strategy: Optional[CommandGenStrategy] = None
+        self.json_gen_strategy: Optional[JsonGenStrategy] = None
         self.job_id_retrieval_strategy: Optional[JobIdRetrievalStrategy] = None
         self.job_status_retrieval_strategy: Optional[JobStatusRetrievalStrategy] = None
         self.report_generation_strategy: Optional[ReportGenerationStrategy] = None
@@ -162,6 +165,51 @@ class TestTemplate:
             extra_env_vars,
             extra_cmd_args,
             output_path,
+            num_nodes,
+            nodes,
+        )
+
+    def gen_json(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: Path,
+        job_name: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> Dict[Any, Any]:
+        """
+        Generate a JSON string representing the Kubernetes job specification for this test using this template.
+
+        Args:
+            env_vars (Dict[str, str]): Environment variables for the test.
+            cmd_args (Dict[str, str]): Command-line arguments for the test.
+            extra_env_vars (Dict[str, str]): Extra environment variables.
+            extra_cmd_args (str): Extra command-line arguments.
+            output_path (Path): Path to the output directory.
+            job_name (str): The name of the job.
+            num_nodes (int): The number of nodes to be used for the test execution.
+            nodes (List[str]): A list of nodes where the test will be executed.
+
+        Returns:
+            Dict[Any, Any]: A dictionary representing the Kubernetes job specification.
+        """
+        if not nodes:
+            nodes = []
+        if self.json_gen_strategy is None:
+            raise ValueError(
+                "json_gen_strategy is missing. Ensure the strategy is registered in the Registry "
+                "by calling the appropriate registration function for the system type."
+            )
+        return self.json_gen_strategy.gen_json(
+            env_vars,
+            cmd_args,
+            extra_env_vars,
+            extra_cmd_args,
+            output_path,
+            job_name,
             num_nodes,
             nodes,
         )

--- a/src/cloudai/_core/test_template_parser.py
+++ b/src/cloudai/_core/test_template_parser.py
@@ -24,6 +24,7 @@ from .grading_strategy import GradingStrategy
 from .install_strategy import InstallStrategy
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
 from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
+from .json_gen_strategy import JsonGenStrategy
 from .registry import Registry
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
@@ -126,6 +127,10 @@ class TestTemplateParser(BaseMultiFileParser):
         obj.command_gen_strategy = cast(
             CommandGenStrategy,
             self._fetch_strategy(CommandGenStrategy, type(obj.system), type(obj), env_vars, cmd_args),
+        )
+        obj.json_gen_strategy = cast(
+            JsonGenStrategy,
+            self._fetch_strategy(JsonGenStrategy, type(obj.system), type(obj), env_vars, cmd_args),
         )
         obj.job_id_retrieval_strategy = cast(
             JobIdRetrievalStrategy,

--- a/src/cloudai/installer/kubernetes_installer.py
+++ b/src/cloudai/installer/kubernetes_installer.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+from cloudai import BaseInstaller, InstallStatusResult
+
+
+class KubernetesInstaller(BaseInstaller):
+    """
+    Installer for systems that use Kubernetes.
+
+    Handles the installation of benchmarks or test templates for Kubernetes-based systems.
+    """
+
+    def _check_prerequisites(self) -> InstallStatusResult:
+        """
+        Check for the presence of required binaries and Kubernetes configurations.
+
+        This ensures the system environment is properly set up before proceeding with the installation
+        or uninstallation processes.
+
+        Returns
+            InstallStatusResult: Result containing the status of the prerequisite check and any error message.
+        """
+        # Check base prerequisites using the parent class method
+        base_prerequisites_result = super()._check_prerequisites()
+        if not base_prerequisites_result.success:
+            logging.error(f"Prerequisite check failed in base installer: {base_prerequisites_result.message}")
+            return InstallStatusResult(False, base_prerequisites_result.message)
+
+        # Load Kubernetes configuration
+        try:
+            config.load_kube_config()
+        except Exception as e:
+            message = (
+                f"Installation failed during prerequisite checking stage because Kubernetes configuration could not "
+                f"be loaded. Please ensure that your Kubernetes configuration is properly set up. Original error: "
+                f"{str(e)}"
+            )
+            logging.error(message)
+            return InstallStatusResult(False, message)
+
+        # Check MPIJob-related prerequisites
+        mpi_job_result = self._check_mpi_job_prerequisites()
+        if not mpi_job_result.success:
+            return mpi_job_result
+
+        logging.info("All prerequisites are met. Proceeding with installation.")
+        return InstallStatusResult(True)
+
+    def _check_mpi_job_prerequisites(self) -> InstallStatusResult:
+        """
+        Check if the MPIJob CRD is installed and if MPIJob kind is supported in the Kubernetes cluster.
+
+        This ensures that the system is ready for MPI-based operations.
+
+        Returns
+            InstallStatusResult: Result containing the status of the MPIJob prerequisite check and any error message.
+        """
+        # Check if MPIJob CRD is installed
+        try:
+            custom_api = client.CustomObjectsApi()
+            custom_api.get_cluster_custom_object(group="kubeflow.org", version="v1", plural="mpijobs", name="mpijobs")
+        except ApiException as e:
+            if e.status == 404:
+                message = (
+                    "Installation failed during prerequisite checking stage because MPIJob CRD is not installed on "
+                    "this Kubernetes cluster. Please ensure that the MPI Operator is installed and MPIJob kind is "
+                    "supported. You can follow the instructions in the MPI Operator repository to install it: "
+                    "https://github.com/kubeflow/mpi-operator"
+                )
+                logging.error(message)
+                return InstallStatusResult(False, message)
+            else:
+                message = (
+                    f"Installation failed during prerequisite checking stage due to an error while checking for MPIJob "
+                    f"CRD. Original error: {str(e)}. Please ensure that the Kubernetes cluster is accessible and the "
+                    f"MPI Operator is correctly installed."
+                )
+                logging.error(message)
+                return InstallStatusResult(False, message)
+
+        # Check if MPIJob kind is supported
+        try:
+            api_resources = client.ApiextensionsV1Api().list_custom_resource_definition()
+            mpi_job_supported = any(item.metadata.name == "mpijobs.kubeflow.org" for item in api_resources.items)
+        except ApiException as e:
+            message = (
+                f"Installation failed during prerequisite checking stage due to an error while checking for MPIJob "
+                f"kind support. Original error: {str(e)}. Please ensure that the Kubernetes cluster is accessible and "
+                f"the MPI Operator is correctly installed."
+            )
+            logging.error(message)
+            return InstallStatusResult(False, message)
+
+        if not mpi_job_supported:
+            message = (
+                "Installation failed during prerequisite checking stage because MPIJob kind is not supported on this "
+                "Kubernetes cluster. Please ensure that the MPI Operator is installed and MPIJob kind is supported. "
+                "You can follow the instructions in the MPI Operator repository to install it: "
+                "https://github.com/kubeflow/mpi-operator"
+            )
+            logging.error(message)
+            return InstallStatusResult(False, message)
+
+        return InstallStatusResult(True)

--- a/src/cloudai/parser/system_parser/kubernetes_system_parser.py
+++ b/src/cloudai/parser/system_parser/kubernetes_system_parser.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any, Dict
+
+from cloudai import BaseSystemParser
+from cloudai.systems.kubernetes import KubernetesSystem
+
+
+class KubernetesSystemParser(BaseSystemParser):
+    """Parser for parsing Kubernetes system configurations."""
+
+    def parse(self, data: Dict[str, Any]) -> KubernetesSystem:
+        """
+        Parse the Kubernetes system configuration.
+
+        Args:
+            data (Dict[str, Any]): The loaded configuration data.
+
+        Returns:
+            KubernetesSystem: The parsed Kubernetes system object.
+
+        Raises:
+            ValueError: If any mandatory field is missing from the data.
+        """
+
+        def get_mandatory_field(field_name: str) -> str:
+            value = data.get(field_name)
+            if not value:
+                raise ValueError(
+                    f"Mandatory field '{field_name}' is missing in the Kubernetes system schema. "
+                    f"Please ensure that '{field_name}' is present and correctly defined in your system configuration."
+                )
+            return value
+
+        def safe_int(value):
+            try:
+                return int(value) if value is not None else None
+            except ValueError:
+                return None
+
+        def str_to_bool(value: Any) -> bool:
+            if isinstance(value, bool):
+                return value
+            return value.lower() in ("true", "1", "yes")
+
+        # Extract and validate mandatory fields
+        name = get_mandatory_field("name")
+        install_path = Path(get_mandatory_field("install_path")).resolve()
+        output_path = Path(get_mandatory_field("output_path")).resolve()
+        default_image = get_mandatory_field("default_image")
+        default_namespace = get_mandatory_field("default_namespace")
+
+        # Extract optional fields
+        kube_config_path = data.get("kube_config_path")
+        if not kube_config_path or len(kube_config_path) == 0 or kube_config_path.isspace():
+            home_directory = Path.home()
+            kube_config_path = home_directory / ".kube" / "config"
+        else:
+            kube_config_path = Path(kube_config_path).resolve()
+
+        global_env_vars = data.get("global_env_vars", {})
+
+        return KubernetesSystem(
+            name=name,
+            install_path=install_path,
+            output_path=output_path,
+            kube_config_path=kube_config_path,
+            default_namespace=default_namespace,
+            default_image=default_image,
+            global_env_vars=global_env_vars,
+        )

--- a/src/cloudai/runner/kubernetes/__init__.py
+++ b/src/cloudai/runner/kubernetes/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/cloudai/runner/kubernetes/kubernetes_job.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_job.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from typing import Union
+
+from cloudai import BaseJob, System, Test
+
+
+class KubernetesJob(BaseJob):
+    """
+    A job class for execution on a Kubernetes system.
+
+    Attributes
+        mode (str): The mode of the job (e.g., 'run', 'dry-run').
+        system (System): The system in which the job is running.
+        test (Test): The test instance associated with this job.
+        namespace (str): The namespace of the job.
+        name (str): The name of the job.
+        kind (str): The kind of the job.
+        output_path (Path): The path where the job's output is stored.
+    """
+
+    def __init__(self, mode: str, system: System, test: Test, namespace: str, name: str, kind: str, output_path: Path):
+        """
+        Initialize a KubernetesJob instance.
+
+        Args:
+            mode (str): The mode of the job (e.g., 'run', 'dry-run').
+            system (System): The system in which the job is running.
+            test (Test): The test instance associated with this job.
+            namespace (str): The namespace of the job.
+            name (str): The name of the job.
+            kind (str): The kind of the job.
+            output_path (Path): The path where the job's output is stored.
+        """
+        super().__init__(mode, system, test, output_path)
+        self.namespace = namespace
+        self.name = name
+        self.kind = kind
+
+    def get_id(self) -> Union[str, int]:
+        """
+        Retrieve the unique name of the Kubernetes job.
+
+        Returns
+            Union[str, int]: The unique identifier of the job.
+        """
+        return self.name
+
+    def get_namespace(self) -> str:
+        """
+        Retrieve the namespace of the Kubernetes job.
+
+        Returns
+            str: The namespace of the job.
+        """
+        return self.namespace
+
+    def get_name(self) -> str:
+        """
+        Retrieve the name of the Kubernetes job.
+
+        Returns
+            str: The name of the job.
+        """
+        return self.name
+
+    def get_kind(self) -> str:
+        """
+        Retrieve the kind of the Kubernetes job.
+
+        Returns
+            str: The kind of the job.
+        """
+        return self.kind
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the KubernetesJob instance.
+
+        Returns
+            str: String representation of the job.
+        """
+        return f"KubernetesJob(name={self.name}, namespace={self.namespace}, test={self.test.name}, kind={self.kind})"

--- a/src/cloudai/runner/kubernetes/kubernetes_job.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_job.py
@@ -16,9 +16,8 @@
 
 
 from pathlib import Path
-from typing import Union
 
-from cloudai import BaseJob, System, Test
+from cloudai import BaseJob, System, TestRun
 
 
 class KubernetesJob(BaseJob):
@@ -28,66 +27,33 @@ class KubernetesJob(BaseJob):
     Attributes
         mode (str): The mode of the job (e.g., 'run', 'dry-run').
         system (System): The system in which the job is running.
-        test (Test): The test instance associated with this job.
+        test_run (TestRun): The test instance associated with this job.
         namespace (str): The namespace of the job.
         name (str): The name of the job.
         kind (str): The kind of the job.
         output_path (Path): The path where the job's output is stored.
     """
 
-    def __init__(self, mode: str, system: System, test: Test, namespace: str, name: str, kind: str, output_path: Path):
+    def __init__(
+        self, mode: str, system: System, test_run: TestRun, namespace: str, name: str, kind: str, output_path: Path
+    ):
         """
         Initialize a KubernetesJob instance.
 
         Args:
             mode (str): The mode of the job (e.g., 'run', 'dry-run').
             system (System): The system in which the job is running.
-            test (Test): The test instance associated with this job.
+            test_run (TestRun): The test instance associated with this job.
             namespace (str): The namespace of the job.
             name (str): The name of the job.
             kind (str): The kind of the job.
             output_path (Path): The path where the job's output is stored.
         """
-        super().__init__(mode, system, test, output_path)
+        super().__init__(mode, system, test_run, output_path)
+        self.id = name
         self.namespace = namespace
         self.name = name
         self.kind = kind
-
-    def get_id(self) -> Union[str, int]:
-        """
-        Retrieve the unique name of the Kubernetes job.
-
-        Returns
-            Union[str, int]: The unique identifier of the job.
-        """
-        return self.name
-
-    def get_namespace(self) -> str:
-        """
-        Retrieve the namespace of the Kubernetes job.
-
-        Returns
-            str: The namespace of the job.
-        """
-        return self.namespace
-
-    def get_name(self) -> str:
-        """
-        Retrieve the name of the Kubernetes job.
-
-        Returns
-            str: The name of the job.
-        """
-        return self.name
-
-    def get_kind(self) -> str:
-        """
-        Retrieve the kind of the Kubernetes job.
-
-        Returns
-            str: The kind of the job.
-        """
-        return self.kind
 
     def __repr__(self) -> str:
         """
@@ -96,4 +62,7 @@ class KubernetesJob(BaseJob):
         Returns
             str: String representation of the job.
         """
-        return f"KubernetesJob(name={self.name}, namespace={self.namespace}, test={self.test.name}, kind={self.kind})"
+        return (
+            f"KubernetesJob(name={self.name}, namespace={self.namespace}, test={self.test_run.test.name}, "
+            f"kind={self.kind})"
+        )

--- a/src/cloudai/runner/kubernetes/kubernetes_runner.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_runner.py
@@ -50,6 +50,18 @@ class KubernetesRunner(BaseRunner):
 
         return KubernetesJob(self.mode, self.system, tr, job_namespace, job_name, job_kind, job_output_path)
 
+    async def job_completion_callback(self, job: BaseJob) -> None:
+        """
+        Handle job completion by storing job logs and deleting the job.
+
+        Args:
+            job (BaseJob): The job that has completed.
+        """
+        k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
+        k_job = cast(KubernetesJob, job)
+        k8s_system.store_logs_for_job(k_job.namespace, k_job.name, k_job.output_path)
+        k8s_system.delete_job(k_job.namespace, k_job.name, k_job.kind)
+
     def kill_job(self, job: BaseJob) -> None:
         """
         Terminate a Kubernetes job.
@@ -59,4 +71,5 @@ class KubernetesRunner(BaseRunner):
         """
         k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
         k_job = cast(KubernetesJob, job)
+        k8s_system.store_logs_for_job(k_job.namespace, k_job.name, k_job.output_path)
         k8s_system.delete_job(k_job.namespace, k_job.name, k_job.kind)

--- a/src/cloudai/runner/kubernetes/kubernetes_runner.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_runner.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import cast
+
+from cloudai import BaseJob, BaseRunner, Test
+from cloudai.systems import KubernetesSystem
+
+from .kubernetes_job import KubernetesJob
+
+
+class KubernetesRunner(BaseRunner):
+    """Implementation of the Runner for a system using Kubernetes."""
+
+    def _submit_test(self, test: Test) -> KubernetesJob:
+        """
+        Submit a test for execution on Kubernetes and return a KubernetesJob object.
+
+        Args:
+            test (Test): The test to be executed.
+
+        Returns:
+            KubernetesJob: A KubernetesJob object containing job details.
+        """
+        logging.info(f"Running test: {test.section_name}")
+        job_output_path = self.get_job_output_path(test)
+        job_name = test.section_name.replace(".", "-").lower()
+        job_spec = test.gen_json(job_output_path, job_name)
+        job_kind = job_spec.get("kind", "").lower()
+        logging.info(f"Generated JSON string for test {test.section_name}: {job_spec}")
+        job_namespace = ""
+
+        if self.mode == "run":
+            k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
+            job_name, job_namespace = k8s_system.create_job(job_spec)
+
+        return KubernetesJob(self.mode, self.system, test, job_namespace, job_name, job_kind, job_output_path)
+
+    def kill_job(self, job: BaseJob) -> None:
+        """
+        Terminate a Kubernetes job.
+
+        Args:
+            job (BaseJob): The job to be terminated, casted to KubernetesJob.
+        """
+        k8s_system = cast(KubernetesSystem, self.system)
+        k_job = cast(KubernetesJob, job)
+        k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
+        k8s_system.delete_job(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())

--- a/src/cloudai/schema/test_template/nccl_test/__init__.py
+++ b/src/cloudai/schema/test_template/nccl_test/__init__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from .grading_strategy import NcclTestGradingStrategy
+from .kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
 from .report_generation_strategy import NcclTestReportGenerationStrategy
 from .slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 from .slurm_install_strategy import NcclTestSlurmInstallStrategy
@@ -24,6 +25,7 @@ __all__ = [
     "NcclTest",
     "NcclTestSlurmInstallStrategy",
     "NcclTestSlurmCommandGenStrategy",
+    "NcclTestKubernetesJsonGenStrategy",
     "NcclTestReportGenerationStrategy",
     "NcclTestGradingStrategy",
 ]

--- a/src/cloudai/schema/test_template/nccl_test/grading_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/grading_strategy.py
@@ -18,10 +18,12 @@ from pathlib import Path
 
 from cloudai import GradingStrategy
 
+from .output_reader_mixin import NcclTestOutputReaderMixin
 
-class NcclTestGradingStrategy(GradingStrategy):
+
+class NcclTestGradingStrategy(NcclTestOutputReaderMixin, GradingStrategy):
     """
-    Performance grading strategy for NcclTest test templates on Slurm systems.
+    Base grading strategy for NCCL tests.
 
     Evaluates the test's performance by comparing the maximum bus bandwidth achieved during the test against the test's
     ideal performance metric. The grade is normalized and scaled between 0 and 100.
@@ -29,9 +31,7 @@ class NcclTestGradingStrategy(GradingStrategy):
 
     def grade(self, directory_path: Path, ideal_perf: float) -> float:
         """
-        Grades the performance of an NcclTest based on the maximum bus bandwidth.
-
-        Reported in the test's stdout.txt file, considering both in-place and out-of-place updates.
+        Grades the performance of an NCCL test based on the maximum bus bandwidth.
 
         Args:
             directory_path (Path): Path to the directory containing the test's output.
@@ -40,37 +40,35 @@ class NcclTestGradingStrategy(GradingStrategy):
         Returns:
             float: The performance grade of the test, normalized and scaled between 0 and 100.
         """
-        stdout_path = directory_path / "stdout.txt"
-        if not stdout_path.is_file():
+        content = self._get_stdout_content(directory_path)
+        if content is None:
             return 0.0
 
-        max_bus_bw = self._extract_max_bus_bandwidth(stdout_path)
+        max_bus_bw = self._extract_max_bus_bandwidth(content)
         if max_bus_bw is None or ideal_perf <= 0:
             return 0.0
 
         normalized_perf = (max_bus_bw / ideal_perf) * 100
-        grade = min(max(normalized_perf, 0), 100)
-        return grade
+        return min(max(normalized_perf, 0), 100)
 
-    def _extract_max_bus_bandwidth(self, stdout_path: Path) -> float:
+    def _extract_max_bus_bandwidth(self, content: str) -> float:
         """
-        Extract the maximum bus bandwidth from the NcclTest output file.
+        Extract the maximum bus bandwidth from the NCCL test output content.
 
         Args:
-            stdout_path (Path): Path to the stdout.txt file containing the NcclTest output.
+            content (str): The content of the stdout file.
 
         Returns:
             float: The maximum bus bandwidth value.
         """
         max_bus_bw = 0.0
-        with stdout_path.open("r") as file:
-            for line in file:
-                if line.strip().startswith("#"):
-                    continue
-                parts = line.split()
-                if len(parts) > 10:  # Ensure it's a data line
-                    out_of_place_bw = float(parts[7])
-                    in_place_bw = float(parts[10])
-                    max_bw = max(out_of_place_bw, in_place_bw)
-                    max_bus_bw = max(max_bus_bw, max_bw)
+        for line in content.splitlines():
+            if line.strip().startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) > 10:  # Ensure it's a data line
+                out_of_place_bw = float(parts[7])
+                in_place_bw = float(parts[10])
+                max_bw = max(out_of_place_bw, in_place_bw)
+                max_bus_bw = max(max_bus_bw, max_bw)
         return max_bus_bw

--- a/src/cloudai/schema/test_template/nccl_test/job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/job_status_retrieval_strategy.py
@@ -18,75 +18,74 @@ from pathlib import Path
 
 from cloudai import JobStatusResult, JobStatusRetrievalStrategy
 
+from .output_reader_mixin import NcclTestOutputReaderMixin
 
-class NcclTestJobStatusRetrievalStrategy(JobStatusRetrievalStrategy):
-    """Strategy to retrieve job status for NCCL tests by checking the contents of 'stdout.txt'."""
+
+class NcclTestJobStatusRetrievalStrategy(NcclTestOutputReaderMixin, JobStatusRetrievalStrategy):
+    """Strategy to retrieve job status for NCCL tests by checking the contents of stdout."""
 
     def get_job_status(self, output_path: Path) -> JobStatusResult:
         """
-        Determine the job status by examining 'stdout.txt' in the output directory.
+        Determine the job status by examining stdout in the output directory.
 
         Args:
-            output_path (Path): Path to the directory containing 'stdout.txt'.
+            output_path (Path): Path to the directory containing stdout.
 
         Returns:
             JobStatusResult: The result containing the job status and an optional error message.
         """
-        stdout_path = output_path / "stdout.txt"
-        if stdout_path.is_file():
-            with stdout_path.open("r") as file:
-                content = file.read()
-
-                # Check for specific error patterns
-                if "Test NCCL failure" in content:
-                    return JobStatusResult(
-                        is_successful=False,
-                        error_message=(
-                            f"NCCL test failure detected in {stdout_path}. "
-                            "Possible reasons include network errors or remote process exits. "
-                            "Please review the NCCL test output and errors in the file first. "
-                            "If the issue persists, contact the system administrator."
-                        ),
-                    )
-                if "Test failure" in content:
-                    return JobStatusResult(
-                        is_successful=False,
-                        error_message=(
-                            f"Test failure detected in {stdout_path}. "
-                            "Please review the specific test failure messages in the file. "
-                            "Ensure that the NCCL test environment is correctly set up and configured. "
-                            "If the issue persists, contact the system administrator."
-                        ),
-                    )
-
-                # Check for success indicators
-                if "# Out of bounds values" in content and "# Avg bus bandwidth" in content:
-                    return JobStatusResult(is_successful=True)
-
-                # Identify missing success indicators
-                missing_indicators = []
-                if "# Out of bounds values" not in content:
-                    missing_indicators.append("'# Out of bounds values'")
-                if "# Avg bus bandwidth" not in content:
-                    missing_indicators.append("'# Avg bus bandwidth'")
-
-                error_message = (
-                    f"Missing success indicators in {stdout_path}: {', '.join(missing_indicators)}. "
-                    "These keywords are expected to be present in stdout.txt, usually towards the end of the file. "
-                    "Please review the NCCL test output and errors in the file. "
-                    "Ensure the NCCL test ran to completion. You can run the generated sbatch script manually "
-                    f"and check if {stdout_path} is created and contains the expected keywords. "
+        content = self._get_stdout_content(output_path)
+        if content is None:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=(
+                    "stdout file not found in the specified output directory. "
+                    "This file is expected to be created as a result of the NCCL test run. "
+                    "Please ensure the NCCL test was executed properly and that stdout is generated. "
+                    "You can run the generated NCCL test command manually and verify the creation of stdout. "
                     "If the issue persists, contact the system administrator."
-                )
-                return JobStatusResult(is_successful=False, error_message=error_message)
+                ),
+            )
 
-        return JobStatusResult(
-            is_successful=False,
-            error_message=(
-                f"stdout.txt file not found in the specified output directory {output_path}. "
-                "This file is expected to be created as a result of the NCCL test run. "
-                "Please ensure the NCCL test was executed properly and that stdout.txt is generated. "
-                f"You can run the generated NCCL test command manually and verify the creation of {stdout_path}. "
-                "If the issue persists, contact the system administrator."
-            ),
+        # Check for specific error patterns
+        if "Test NCCL failure" in content:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=(
+                    "NCCL test failure detected in stdout. "
+                    "Possible reasons include network errors or remote process exits. "
+                    "Please review the NCCL test output and errors in the file first. "
+                    "If the issue persists, contact the system administrator."
+                ),
+            )
+        if "Test failure" in content:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=(
+                    "Test failure detected in stdout. "
+                    "Please review the specific test failure messages in the file. "
+                    "Ensure that the NCCL test environment is correctly set up and configured. "
+                    "If the issue persists, contact the system administrator."
+                ),
+            )
+
+        # Check for success indicators
+        if "# Out of bounds values" in content and "# Avg bus bandwidth" in content:
+            return JobStatusResult(is_successful=True)
+
+        # Identify missing success indicators
+        missing_indicators = []
+        if "# Out of bounds values" not in content:
+            missing_indicators.append("'# Out of bounds values'")
+        if "# Avg bus bandwidth" not in content:
+            missing_indicators.append("'# Avg bus bandwidth'")
+
+        error_message = (
+            f"Missing success indicators in stdout: {', '.join(missing_indicators)}. "
+            "These keywords are expected to be present in stdout, usually towards the end of the file. "
+            "Please review the NCCL test output and errors in the file. "
+            "Ensure the NCCL test ran to completion. You can run the generated sbatch script manually "
+            "and check if stdout is created and contains the expected keywords. "
+            "If the issue persists, contact the system administrator."
         )
+        return JobStatusResult(is_successful=False, error_message=error_message)

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_grading_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_grading_strategy.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .grading_strategy import NcclTestGradingStrategy
+from .kubernetes_output_reader_mixin import KubernetesNcclTestOutputReaderMixin
+
+
+class KubernetesNcclTestGradingStrategy(KubernetesNcclTestOutputReaderMixin, NcclTestGradingStrategy):
+    """Kubernetes-specific grading strategy for NCCL tests."""

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_job_status_retrieval_strategy.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .job_status_retrieval_strategy import NcclTestJobStatusRetrievalStrategy
+from .kubernetes_output_reader_mixin import KubernetesNcclTestOutputReaderMixin
+
+
+class KubernetesNcclTestJobStatusRetrievalStrategy(
+    KubernetesNcclTestOutputReaderMixin, NcclTestJobStatusRetrievalStrategy
+):
+    """Kubernetes-specific strategy to retrieve job status for NCCL tests."""

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from cloudai import JsonGenStrategy
+
+
+class NcclTestKubernetesJsonGenStrategy(JsonGenStrategy):
+    """JSON generation strategy for NCCL tests on Kubernetes systems."""
+
+    def gen_json(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: Path,
+        job_name: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> Dict[Any, Any]:
+        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
+        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+        final_num_nodes = self._determine_num_nodes(num_nodes, nodes)
+        job_spec = self._create_job_spec(
+            job_name, final_num_nodes, nodes, final_env_vars, final_cmd_args, extra_cmd_args
+        )
+
+        return job_spec
+
+    def _determine_num_nodes(self, num_nodes: int, nodes: List[str]) -> int:
+        """
+        Determine the final number of nodes based on provided nodes or num_nodes.
+
+        Args:
+            num_nodes (int): The initial number of nodes specified.
+            nodes (List[str]): A list of specific nodes provided.
+
+        Returns:
+            int: The final number of nodes to be used for the job.
+        """
+        return len(nodes) if nodes else num_nodes
+
+    def _create_job_spec(
+        self,
+        job_name: str,
+        final_num_nodes: int,
+        nodes: List[str],
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_cmd_args: str,
+    ) -> Dict[Any, Any]:
+        """
+        Create the MPIJob specification for running NCCL tests on a Kubernetes cluster.
+
+        Args:
+            job_name (str): The name of the Kubernetes job.
+            final_num_nodes (int): The final number of nodes determined.
+            nodes (List[str]): A list of specific nodes to run the job on.
+            env_vars (Dict[str, str]): A dictionary of environment variables for the job.
+            cmd_args (Dict[str, str]): A dictionary of command-line arguments for the NCCL test.
+            extra_cmd_args (str): Additional command-line arguments for the NCCL test.
+
+        Returns:
+            Dict[Any, Any]: A dictionary representing the Kubernetes MPIJob specification.
+        """
+        docker_image_url = "ghcr.io/coreweave/nccl-tests:12.4.1-cudnn-devel-ubuntu20.04-nccl2.21.5-1-85f9143"
+
+        return {
+            "apiVersion": "kubeflow.org/v2beta1",
+            "kind": "MPIJob",
+            "metadata": {
+                "name": job_name,
+            },
+            "spec": {
+                "slotsPerWorker": 1,
+                "runPolicy": {"cleanPodPolicy": "Running"},
+                "mpiReplicaSpecs": {
+                    "Launcher": {
+                        "replicas": 1,
+                        "template": {
+                            "metadata": {"annotations": {"k8s.v1.cni.cncf.io/networks": "ipoib-cx7-h1@ib0"}},
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "image": docker_image_url,
+                                        "name": "nccl",
+                                        "env": self._generate_env_list(env_vars),
+                                        "command": self._generate_launcher_command(
+                                            final_num_nodes, nodes, env_vars, cmd_args, extra_cmd_args
+                                        ),
+                                        "resources": self._prepare_launcher_resources(),
+                                    }
+                                ],
+                                "restartPolicy": "Never",
+                            },
+                        },
+                    },
+                    "Worker": {
+                        "replicas": final_num_nodes,
+                        "template": {
+                            "metadata": {"annotations": {"k8s.v1.cni.cncf.io/networks": "ipoib-cx7-h1@ib0"}},
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "image": docker_image_url,
+                                        "env": self._generate_env_list(env_vars),
+                                        "name": "nccl",
+                                        "resources": self._prepare_worker_resources(),
+                                        "volumeMounts": [
+                                            {"mountPath": "/dev/shm", "name": "dshm"},
+                                        ],
+                                    }
+                                ],
+                                "volumes": [
+                                    {"name": "dshm", "emptyDir": {"medium": "Memory"}},
+                                    {"name": "hugepage-2mi", "emptyDir": {"medium": "HugePages"}},
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+    def _generate_env_list(self, env_vars: Dict[str, str]) -> List[Dict[str, str]]:
+        """
+        Generate the environment variables list for the Kubernetes container.
+
+        Args:
+            env_vars (Dict[str, str]): A dictionary of environment variables to include.
+
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries representing the environment variables.
+        """
+        env_list = [{"name": "OMPI_ALLOW_RUN_AS_ROOT", "value": "1"}]
+        # Include additional environment variables from env_vars
+        for key, value in env_vars.items():
+            env_list.append({"name": key, "value": value})
+        return env_list
+
+    def _generate_launcher_command(
+        self,
+        final_num_nodes: int,
+        nodes: List[str],
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_cmd_args: str,
+    ) -> List[str]:
+        """
+        Generate the launcher command for the Kubernetes container.
+
+        Args:
+            final_num_nodes (int): The final number of nodes determined.
+            nodes (List[str]): A list of specific nodes to run the job on.
+            env_vars (Dict[str, str]): A dictionary of environment variables for the job.
+            cmd_args (Dict[str, str]): A dictionary of command-line arguments for the NCCL test.
+            extra_cmd_args (str): Additional command-line arguments for the NCCL test.
+
+        Returns:
+            List[str]: A list representing the launcher command to be executed.
+        """
+        subtest_name = cmd_args.get("subtest_name")
+        if subtest_name is None:
+            raise ValueError(
+                "The NCCL test's 'subtest_name' is not provided. Please ensure 'subtest_name' "
+                "is included in the command arguments. Valid subtest names include: "
+                "all_reduce_perf, all_gather_perf, alltoall_perf, broadcast_perf, "
+                "gather_perf, hypercube_perf, reduce_perf, reduce_scatter_perf, "
+                "scatter_perf, and sendrecv_perf."
+            )
+
+        nccl_test_args = [
+            "nthreads",
+            "ngpus",
+            "minbytes",
+            "maxbytes",
+            "stepbytes",
+            "op",
+            "datatype",
+            "root",
+            "iters",
+            "warmup_iters",
+            "agg_iters",
+            "average",
+            "parallel_init",
+            "check",
+            "blocking",
+            "cudagraph",
+        ]
+
+        command_parts = [f"/opt/nccl_tests/build/{subtest_name}"]
+        for arg in nccl_test_args:
+            if arg in cmd_args:
+                command_parts.append(f"--{arg} {cmd_args[arg]}")
+
+        if extra_cmd_args:
+            command_parts.append(extra_cmd_args)
+
+        return [
+            "/bin/bash",
+            "-c",
+            (
+                f"mpirun -v --allow-run-as-root -np {final_num_nodes} "
+                "--hostfile /etc/mpi/hostfile "
+                "-mca coll ^hcoll -bind-to none "
+                f"{' '.join([f'-x {key}={value}' for key, value in env_vars.items()])} "
+                f"{' '.join(command_parts)}"
+            ),
+        ]
+
+    def _prepare_launcher_resources(self) -> Dict[str, Dict[str, str]]:
+        """
+        Prepare resource requests and limits for the launcher container.
+
+        Returns
+            Dict[str, Dict[str, str]]: A dictionary representing the resource requests and limits.
+        """
+        return {
+            "requests": {"cpu": "2", "memory": "128Mi", "rdma/rdma_ib": "1"},
+            "limits": {"cpu": "2", "memory": "128Mi", "rdma/rdma_ib": "1"},
+        }
+
+    def _prepare_worker_resources(self) -> Dict[str, Dict[str, str]]:
+        """
+        Prepare resource requests and limits for the worker containers.
+
+        Returns
+            Dict[str, Dict[str, str]]: A dictionary representing the resource requests and limits.
+        """
+        return {
+            "requests": {
+                "cpu": "24",
+                "memory": "32Gi",
+                "nvidia.com/gpu": "1",
+                "rdma/rdma_ib": "1",
+                "hugepages-2Mi": "2Gi",
+            },
+            "limits": {
+                "cpu": "48",
+                "memory": "32Gi",
+                "nvidia.com/gpu": "1",
+                "rdma/rdma_ib": "1",
+                "hugepages-2Mi": "2Gi",
+            },
+        }

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_output_reader_mixin.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_output_reader_mixin.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional
+
+from .output_reader_mixin import NcclTestOutputReaderMixin
+
+
+class KubernetesNcclTestOutputReaderMixin(NcclTestOutputReaderMixin):
+    """Mixin to provide output reading functionality for Kubernetes NCCL tests."""
+
+    def _get_stdout_content(self, directory_path: Path) -> Optional[str]:
+        aggregated_content = []
+        for pod_log_file in directory_path.glob("*-launcher-*.txt"):
+            with pod_log_file.open("r") as pod_file:
+                aggregated_content.append(pod_file.read())
+        return "\n".join(aggregated_content) if aggregated_content else None

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_report_generation_strategy.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .kubernetes_output_reader_mixin import KubernetesNcclTestOutputReaderMixin
+from .report_generation_strategy import NcclTestReportGenerationStrategy
+
+
+class KubernetesNcclTestReportGenerationStrategy(KubernetesNcclTestOutputReaderMixin, NcclTestReportGenerationStrategy):
+    """Kubernetes-specific strategy for generating reports from NCCL tests."""

--- a/src/cloudai/schema/test_template/nccl_test/output_reader_mixin.py
+++ b/src/cloudai/schema/test_template/nccl_test/output_reader_mixin.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+
+class NcclTestOutputReaderMixin(ABC):
+    """Base mixin to provide a standardized interface for reading NCCL test output."""
+
+    @abstractmethod
+    def _get_stdout_content(self, directory_path: Path) -> Optional[str]:
+        """
+        Abstract method to retrieve the content of stdout based on the system.
+
+        Args:
+            directory_path (Path): Path to the directory containing the output files.
+
+        Returns:
+            Optional[str]: Content of the stdout file, or None if not found.
+        """
+        pass

--- a/src/cloudai/schema/test_template/nccl_test/slurm_grading_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_grading_strategy.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .grading_strategy import NcclTestGradingStrategy
+from .slurm_output_reader_mixin import SlurmNcclTestOutputReaderMixin
+
+
+class SlurmNcclTestGradingStrategy(SlurmNcclTestOutputReaderMixin, NcclTestGradingStrategy):
+    """Slurm-specific grading strategy for NCCL tests."""

--- a/src/cloudai/schema/test_template/nccl_test/slurm_job_status_retrieval_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_job_status_retrieval_strategy.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .job_status_retrieval_strategy import NcclTestJobStatusRetrievalStrategy
+from .slurm_output_reader_mixin import SlurmNcclTestOutputReaderMixin
+
+
+class SlurmNcclTestJobStatusRetrievalStrategy(SlurmNcclTestOutputReaderMixin, NcclTestJobStatusRetrievalStrategy):
+    """Slurm-specific strategy to retrieve job status for NCCL tests."""

--- a/src/cloudai/schema/test_template/nccl_test/slurm_output_reader_mixin.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_output_reader_mixin.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional
+
+from .output_reader_mixin import NcclTestOutputReaderMixin
+
+
+class SlurmNcclTestOutputReaderMixin(NcclTestOutputReaderMixin):
+    """Mixin to provide output reading functionality for Slurm NCCL tests."""
+
+    def _get_stdout_content(self, directory_path: Path) -> Optional[str]:
+        stdout_path = directory_path / "stdout.txt"
+        if stdout_path.exists():
+            return stdout_path.read_text()
+        return None

--- a/src/cloudai/schema/test_template/nccl_test/slurm_report_generation_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_report_generation_strategy.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .report_generation_strategy import NcclTestReportGenerationStrategy
+from .slurm_output_reader_mixin import SlurmNcclTestOutputReaderMixin
+
+
+class SlurmNcclTestReportGenerationStrategy(SlurmNcclTestOutputReaderMixin, NcclTestReportGenerationStrategy):
+    """Slurm-specific strategy for generating reports from NCCL tests."""

--- a/src/cloudai/schema/test_template/sleep/__init__.py
+++ b/src/cloudai/schema/test_template/sleep/__init__.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 from .grading_strategy import SleepGradingStrategy
+from .kubernetes_install_strategy import SleepKubernetesInstallStrategy
+from .kubernetes_json_gen_strategy import SleepKubernetesJsonGenStrategy
 from .report_generation_strategy import SleepReportGenerationStrategy
 from .slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from .standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
@@ -25,6 +27,8 @@ __all__ = [
     "Sleep",
     "SleepStandaloneInstallStrategy",
     "SleepStandaloneCommandGenStrategy",
+    "SleepKubernetesJsonGenStrategy",
+    "SleepKubernetesInstallStrategy",
     "SleepSlurmCommandGenStrategy",
     "SleepReportGenerationStrategy",
     "SleepGradingStrategy",

--- a/src/cloudai/schema/test_template/sleep/kubernetes_install_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/kubernetes_install_strategy.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudai import InstallStatusResult, InstallStrategy
+
+
+class SleepKubernetesInstallStrategy(InstallStrategy):
+    """Installation strategy for the Sleep test on Kubernetes systems."""
+
+    def is_installed(self) -> InstallStatusResult:
+        return InstallStatusResult(success=True)
+
+    def install(self) -> InstallStatusResult:
+        return InstallStatusResult(success=True)
+
+    def uninstall(self) -> InstallStatusResult:
+        return InstallStatusResult(success=True)

--- a/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+from cloudai import JsonGenStrategy
+from cloudai.systems import KubernetesSystem
+
+
+class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
+    """JSON generation strategy for Sleep on Kubernetes systems."""
+
+    def gen_json(
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: Path,
+        job_name: str,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> Dict[Any, Any]:
+        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+        sec = self.final_cmd_args["seconds"]
+
+        kubernetes_system = cast(KubernetesSystem, self.system)
+
+        job_spec = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {"name": job_name, "namespace": kubernetes_system.default_namespace},
+            "spec": {
+                "ttlSecondsAfterFinished": 0,
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "args": ["sleep " + sec],
+                                "command": ["/bin/bash", "-c"],
+                                "image": kubernetes_system.default_image,
+                                "name": "task",
+                            }
+                        ],
+                        "restartPolicy": "Never",
+                    }
+                },
+            },
+        }
+
+        return job_spec

--- a/src/cloudai/systems/kubernetes/__init__.py
+++ b/src/cloudai/systems/kubernetes/__init__.py
@@ -14,12 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .kubernetes.kubernetes_system import KubernetesSystem
-from .slurm.slurm_system import SlurmSystem
-from .standalone_system import StandaloneSystem
+from .kubernetes_system import KubernetesSystem
 
 __all__ = [
-    "SlurmSystem",
-    "StandaloneSystem",
     "KubernetesSystem",
 ]

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -116,7 +116,7 @@ class KubernetesSystem(System):
             bool: True if the job is running, False otherwise.
         """
         k_job: KubernetesJob = cast(KubernetesJob, job)
-        return self._is_job_running(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())
+        return self._is_job_running(k_job.namespace, k_job.name, k_job.kind)
 
     def is_job_completed(self, job: BaseJob) -> bool:
         """
@@ -129,7 +129,7 @@ class KubernetesSystem(System):
             bool: True if the job is completed, False otherwise.
         """
         k_job: KubernetesJob = cast(KubernetesJob, job)
-        return not self._is_job_running(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())
+        return not self._is_job_running(k_job.namespace, k_job.name, k_job.kind)
 
     def _is_job_running(self, job_namespace: str, job_name: str, job_kind: str) -> bool:
         """
@@ -266,7 +266,7 @@ class KubernetesSystem(System):
             job (BaseJob): The job to be terminated.
         """
         k_job: KubernetesJob = cast(KubernetesJob, job)
-        self.delete_job(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())
+        self.delete_job(k_job.namespace, k_job.name, k_job.kind)
 
     def delete_job(self, namespace: str, job_name: str, job_kind: str) -> None:
         """

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -234,6 +234,10 @@ class KubernetesSystem(System):
 
             conditions = k8s_job.status.conditions or []
 
+            # Consider an empty conditions list as running
+            if not conditions:
+                return True
+
             for condition in conditions:
                 if condition.type == "Complete" and condition.status == "True":
                     return False

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
@@ -590,6 +591,32 @@ class KubernetesSystem(System):
         """
         namespaces = self.core_v1.list_namespace().items
         return [ns.metadata.name for ns in namespaces]
+
+    def store_logs_for_job(self, namespace: str, job_name: str, output_dir: Path) -> None:
+        """
+        Retrieve and store logs for all pods associated with a given job.
+
+        Args:
+            namespace (str): The namespace where the job is running.
+            job_name (str): The name of the job.
+            output_dir (Path): The directory where logs will be saved.
+        """
+        pod_names = self.get_pod_names_for_job(namespace, job_name)
+        if not pod_names:
+            logging.warning(f"No pods found for job '{job_name}' in namespace '{namespace}'")
+            return
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        for pod_name in pod_names:
+            try:
+                logs = self.core_v1.read_namespaced_pod_log(name=pod_name, namespace=namespace)
+                log_file_path = output_dir / f"{pod_name}.txt"
+                with open(log_file_path, "w") as log_file:
+                    log_file.write(logs)
+                logging.info(f"Logs for pod '{pod_name}' saved to '{log_file_path}'")
+            except client.ApiException as e:
+                logging.error(f"Error retrieving logs for pod '{pod_name}' in namespace '{namespace}': {e}")
 
     def get_pod_names_for_job(self, namespace: str, job_name: str) -> List[str]:
         """

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -1,0 +1,609 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from kubernetes import client, config
+from kubernetes.client import ApiException, CustomObjectsApi, V1DeleteOptions, V1Job
+
+from cloudai import BaseJob, System
+from cloudai.runner.kubernetes.kubernetes_job import KubernetesJob
+
+
+class KubernetesSystem(System):
+    """
+    Represents a Kubernetes system.
+
+    Attributes
+        kube_config_path (Path): Path to the Kubernetes config file.
+        default_namespace (str): The default Kubernetes namespace for jobs.
+        default_image (str): Default Docker image to be used for jobs.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        install_path: Path,
+        output_path: Path,
+        kube_config_path: Path,
+        default_namespace: str,
+        default_image: str,
+        global_env_vars: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Initialize a KubernetesSystem instance.
+
+        Args:
+            name (str): Name of the Kubernetes system.
+            install_path (Path): The installation path of CloudAI.
+            output_path (Path): Path to the output directory.
+            kube_config_path (Path): Path to the Kubernetes config file.
+            default_namespace (str): The default Kubernetes namespace for jobs.
+            default_image (str): Default Docker image to be used for jobs.
+            global_env_vars (Optional[Dict[str, Any]]): Dictionary containing additional configuration settings for
+                the system.
+        """
+        super().__init__(name, "kubernetes", install_path, output_path, global_env_vars)
+        self.kube_config_path = kube_config_path.resolve()
+        self.default_namespace = default_namespace
+        self.default_image = default_image
+
+        # Load the Kubernetes configuration
+        if not self.kube_config_path.exists():
+            error_message = (
+                f"Kube config file '{self.kube_config_path}' not found. This file is required to configure the "
+                f"Kubernetes environment. Please verify that the file exists at the specified path."
+            )
+            logging.error(error_message)
+            raise FileNotFoundError(error_message)
+
+        # Instantiate Kubernetes APIs
+        logging.debug(f"Loading kube config from: {self.kube_config_path}")
+        config.load_kube_config(config_file=str(self.kube_config_path))
+        self.core_v1 = client.CoreV1Api()
+        self.batch_v1 = client.BatchV1Api()
+        self.custom_objects_api = CustomObjectsApi()
+
+        logging.debug(f"{self.__class__.__name__} initialized")
+
+    def __repr__(self) -> str:
+        """
+        Provide a structured string representation of the system.
+
+        Returns
+            str: A string that contains the system name and scheduler type.
+        """
+        return (
+            f"System Name: {self.name}\n"
+            f"Scheduler Type: {self.scheduler}\n"
+            f"Kube Config Path: {self.kube_config_path}\n"
+            f"Default Namespace: {self.default_namespace}\n"
+            f"Default Docker Image: {self.default_image}"
+        )
+
+    def update(self) -> None:
+        """
+        Update the system object for a Kubernetes system.
+
+        Currently not implemented for KubernetesSystem.
+        """
+        pass
+
+    def is_job_running(self, job: BaseJob) -> bool:
+        """
+        Check if a given Kubernetes job is currently running.
+
+        Args:
+            job (BaseJob): The job to check.
+
+        Returns:
+            bool: True if the job is running, False otherwise.
+        """
+        k_job: KubernetesJob = cast(KubernetesJob, job)
+        return self._is_job_running(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())
+
+    def is_job_completed(self, job: BaseJob) -> bool:
+        """
+        Check if a given Kubernetes job is completed.
+
+        Args:
+            job (BaseJob): The job to check.
+
+        Returns:
+            bool: True if the job is completed, False otherwise.
+        """
+        k_job: KubernetesJob = cast(KubernetesJob, job)
+        return not self._is_job_running(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())
+
+    def _is_job_running(self, job_namespace: str, job_name: str, job_kind: str) -> bool:
+        """
+        Check if a job is currently running.
+
+        Args:
+            job_namespace (str): The namespace of the job.
+            job_name (str): The name of the job.
+            job_kind (str): The kind of the job ('MPIJob' or 'Job').
+
+        Returns:
+            bool: True if the job is running, False if the job has completed or is not found.
+        """
+        logging.debug(
+            f"Checking for job '{job_name}' of kind '{job_kind}' in namespace '{job_namespace}' to determine if "
+            "it is running."
+        )
+
+        if "mpijob" in job_kind.lower():
+            return self._is_mpijob_running(job_namespace, job_name)
+        elif "job" in job_kind.lower():
+            return self._is_batch_job_running(job_namespace, job_name)
+        else:
+            error_message = (
+                f"Unsupported job kind: '{job_kind}'. Supported kinds are 'MPIJob' for MPI workloads and 'Job' for "
+                f"batch jobs. Please verify that the 'job_kind' field is correctly set in the job specification."
+            )
+            logging.error(error_message)
+            raise ValueError(error_message)
+
+    def _is_mpijob_running(self, job_namespace: str, job_name: str) -> bool:
+        """
+        Check if an MPIJob is currently running.
+
+        Args:
+            job_namespace (str): The namespace of the MPIJob.
+            job_name (str): The name of the MPIJob.
+
+        Returns:
+            bool: True if the MPIJob is running, False if the MPIJob has completed or is not found.
+        """
+        try:
+            mpijob = self.custom_objects_api.get_namespaced_custom_object(
+                group="kubeflow.org", version="v2beta1", namespace=job_namespace, plural="mpijobs", name=job_name
+            )
+
+            assert isinstance(mpijob, dict)
+            status = mpijob.get("status", {})
+            conditions = status.get("conditions", [])
+
+            # Consider an empty conditions list as running
+            if not conditions:
+                return True
+
+            for condition in conditions:
+                if condition["type"] == "Succeeded" and condition["status"] == "True":
+                    return False
+                if condition["type"] == "Failed" and condition["status"] == "True":
+                    return False
+
+            # If the job has been created but is neither succeeded nor failed, it is considered running
+            if any(condition["type"] == "Created" and condition["status"] == "True" for condition in conditions):
+                return True
+
+            return False
+
+        except ApiException as e:
+            if e.status == 404:
+                logging.debug(
+                    f"MPIJob '{job_name}' not found in namespace '{job_namespace}'. It may have completed and been "
+                    "removed from the system."
+                )
+                return False
+            else:
+                error_message = (
+                    f"Error occurred while retrieving status for MPIJob '{job_name}' in namespace '{job_namespace}'. "
+                    f"Error code: {e.status}. Message: {e.reason}. Please check the job name, namespace, and "
+                    "Kubernetes API server."
+                )
+                logging.error(error_message)
+                raise
+
+    def _is_batch_job_running(self, job_namespace: str, job_name: str) -> bool:
+        """
+        Check if a batch job is currently running.
+
+        Args:
+            job_namespace (str): The namespace of the batch job.
+            job_name (str): The name of the batch job.
+
+        Returns:
+            bool: True if the batch job is running, False if the job has completed or is not found.
+        """
+        try:
+            k8s_job: Any = self.batch_v1.read_namespaced_job_status(name=job_name, namespace=job_namespace)
+
+            if not (hasattr(k8s_job, "status") and hasattr(k8s_job.status, "conditions")):
+                logging.debug(
+                    f"Job '{job_name}' in namespace '{job_namespace}' does not have expected status attributes."
+                )
+                return False
+
+            conditions = k8s_job.status.conditions or []
+
+            for condition in conditions:
+                if condition.type == "Complete" and condition.status == "True":
+                    return False
+                if condition.type == "Failed" and condition.status == "True":
+                    return False
+
+            return any(condition.type == "Created" and condition.status == "True" for condition in conditions)
+
+        except ApiException as e:
+            if e.status == 404:
+                logging.debug(
+                    f"Batch job '{job_name}' not found in namespace '{job_namespace}'."
+                    "It may have completed and been removed from the system."
+                )
+                return False
+            else:
+                logging.error(
+                    f"Error occurred while retrieving status for batch job '{job_name}' in namespace "
+                    "'{job_namespace}'."
+                    f"Error code: {e.status}. Message: {e.reason}. Please check the job name, namespace, "
+                    "and Kubernetes API server."
+                )
+                raise
+
+    def kill(self, job: BaseJob) -> None:
+        """
+        Terminate a Kubernetes job.
+
+        Args:
+            job (BaseJob): The job to be terminated.
+        """
+        k_job: KubernetesJob = cast(KubernetesJob, job)
+        self.delete_job(k_job.get_namespace(), k_job.get_name(), k_job.get_kind())
+
+    def delete_job(self, namespace: str, job_name: str, job_kind: str) -> None:
+        """
+        Delete a job in the specified namespace.
+
+        Args:
+            namespace (str): The namespace of the job.
+            job_name (str): The name of the job.
+            job_kind (str): The kind of the job ('MPIJob' or 'Job').
+        """
+        if "mpijob" in job_kind.lower():
+            self._delete_mpi_job(namespace, job_name)
+        elif "job" in job_kind.lower():
+            self._delete_batch_job(namespace, job_name)
+        else:
+            error_message = (
+                f"Unsupported job kind: '{job_kind}'. Supported kinds are 'MPIJob' for MPI workloads and 'Job' for "
+                "batch jobs. Please verify that the 'job_kind' field is correctly set in the job specification."
+            )
+            logging.error(error_message)
+            raise ValueError(error_message)
+
+    def _delete_mpi_job(self, namespace: str, job_name: str) -> None:
+        """
+        Delete an MPIJob in the specified namespace.
+
+        Args:
+            namespace (str): The namespace of the job.
+            job_name (str): The name of the job.
+        """
+        logging.debug(f"Deleting MPIJob '{job_name}' in namespace '{namespace}'")
+        try:
+            self.custom_objects_api.delete_namespaced_custom_object(
+                group="kubeflow.org",
+                version="v2beta1",
+                namespace=namespace,
+                plural="mpijobs",
+                name=job_name,
+                body=V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
+            )
+            logging.debug(f"MPIJob '{job_name}' deleted successfully in namespace '{namespace}'")
+        except ApiException as e:
+            if e.status == 404:
+                logging.debug(
+                    f"MPIJob '{job_name}' not found in namespace '{namespace}'. " "It may have already been deleted."
+                )
+            else:
+                logging.error(
+                    f"An error occurred while attempting to delete MPIJob '{job_name}' in namespace '{namespace}'. "
+                    f"Error code: {e.status}. Message: {e.reason}. Please verify the job name, namespace, "
+                    "and Kubernetes API server."
+                )
+                raise
+
+    def _delete_batch_job(self, namespace: str, job_name: str) -> None:
+        """
+        Delete a batch job in the specified namespace.
+
+        Args:
+            namespace (str): The namespace of the job.
+            job_name (str): The name of the job.
+        """
+        logging.debug(f"Deleting batch job '{job_name}' in namespace '{namespace}'")
+        api_response = self.batch_v1.delete_namespaced_job(
+            name=job_name,
+            namespace=namespace,
+            body=V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
+        )
+        api_response = cast(V1Job, api_response)
+
+        logging.debug(f"Batch job '{job_name}' deleted with status: {api_response.status}")
+
+    def create_job(self, job_spec: Dict[Any, Any], timeout: int = 60, interval: int = 1) -> Tuple[str, str]:
+        """
+        Create a job in the Kubernetes system in a blocking manner.
+
+        Args:
+            job_spec (Dict[Any, Any]): The job specification.
+            timeout (int): The maximum time to wait for the job to be created and observable.
+            interval (int): The time to wait between checks, in seconds.
+
+        Returns:
+            Tuple[str, str]: The job name and namespace.
+
+        Raises:
+            ValueError: If the job specification does not contain a valid 'kind' field.
+            TimeoutError: If the job is not observable within the timeout period.
+        """
+        logging.debug(f"Creating job with spec: {job_spec}")
+        job_name, namespace = self._create_job(self.default_namespace, job_spec)
+
+        # Wait for the job to be observable by Kubernetes
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if self._is_job_observable(namespace, job_name, job_spec.get("kind", "")):
+                logging.debug(f"Job '{job_name}' is now observable in namespace '{namespace}'.")
+                return job_name, namespace
+            logging.debug(f"Waiting for job '{job_name}' to become observable in namespace '{namespace}'...")
+            time.sleep(interval)
+
+        raise TimeoutError(f"Job '{job_name}' in namespace '{namespace}' was not observable within {timeout} seconds.")
+
+    def _create_job(self, namespace: str, job_spec: Dict[Any, Any]) -> Tuple[str, str]:
+        """
+        Submit a job to the specified namespace.
+
+        Args:
+            namespace (str): The namespace where the job will be created.
+            job_spec (Dict[Any, Any]): The job specification.
+
+        Returns:
+            Tuple[str, str]: The job name and namespace.
+
+        Raises:
+            ValueError: If the job specification does not contain a valid 'kind' field.
+        """
+        api_version = job_spec.get("apiVersion", "")
+        kind = job_spec.get("kind", "").lower()
+
+        if "mpijob" in kind:
+            return self._create_mpi_job(namespace, job_spec)
+        elif ("batch" in api_version) and ("job" in kind):
+            return self._create_batch_job(namespace, job_spec)
+        else:
+            error_message = (
+                f"Unsupported job kind: '{job_spec.get('kind')}'.\n"
+                "The supported kinds are: 'MPIJob' for MPI workloads and 'Job' for batch jobs.\n"
+                "Please review the job specification generation logic to ensure that the 'kind' field is set "
+                "correctly.\n"
+            )
+            logging.error(error_message)
+            raise ValueError(error_message)
+
+    def _create_batch_job(self, namespace: str, job_spec: Dict[Any, Any]) -> Tuple[str, str]:
+        """
+        Submit a batch job to the specified namespace.
+
+        Args:
+            namespace (str): The namespace where the job will be created.
+            job_spec (Dict[Any, Any]): The job specification.
+
+        Returns:
+            Tuple[str, str]: The job name and namespace.
+        """
+        logging.debug(f"Creating job in namespace '{namespace}'")
+        api_response = self.batch_v1.create_namespaced_job(body=job_spec, namespace=namespace)
+
+        if not isinstance(api_response, V1Job) or api_response.metadata is None:
+            raise ValueError("Job creation failed or returned an unexpected type")
+
+        job_name: str = api_response.metadata.name
+        job_namespace: str = api_response.metadata.namespace
+        logging.debug(f"Job '{job_name}' created with status: {api_response.status}")
+        return job_name, job_namespace
+
+    def _create_mpi_job(self, namespace: str, job_spec: Dict[Any, Any]) -> Tuple[str, str]:
+        """
+        Submit an MPIJob to the specified namespace.
+
+        Args:
+            namespace (str): The namespace where the MPIJob will be created.
+            job_spec (Dict[Any, Any]): The MPIJob specification.
+
+        Returns:
+            Tuple[str, str]: The job name and namespace.
+        """
+        logging.debug(f"Creating MPIJob in namespace '{namespace}'")
+        api_response = self.custom_objects_api.create_namespaced_custom_object(
+            group="kubeflow.org",
+            version="v2beta1",
+            namespace=namespace,
+            plural="mpijobs",
+            body=job_spec,
+        )
+
+        job_name: str = api_response["metadata"]["name"]
+        job_namespace: str = api_response["metadata"]["namespace"]
+        logging.debug(f"MPIJob '{job_name}' created with status: {api_response.get('status')}")
+        return job_name, job_namespace
+
+    def _is_job_observable(self, namespace: str, job_name: str, job_kind: str) -> bool:
+        """
+        Check if a job is observable by the Kubernetes client.
+
+        Args:
+            namespace (str): The namespace of the job.
+            job_name (str): The name of the job.
+            job_kind (str): The kind of the job (e.g., 'Job', 'MPIJob').
+
+        Returns:
+            bool: True if the job is observable, False otherwise.
+        """
+        logging.debug(f"Checking if job '{job_name}' of kind '{job_kind}' in namespace '{namespace}' is observable.")
+
+        if "mpijob" in job_kind.lower():
+            return self._is_mpijob_observable(namespace, job_name)
+        elif "job" in job_kind.lower():
+            return self._is_batch_job_observable(namespace, job_name)
+        else:
+            logging.error(f"Unsupported job kind: '{job_kind}'")
+            return False
+
+    def _is_mpijob_observable(self, namespace: str, job_name: str) -> bool:
+        """
+        Check if an MPIJob is observable by the Kubernetes client.
+
+        Args:
+            namespace (str): The namespace of the MPIJob.
+            job_name (str): The name of the MPIJob.
+
+        Returns:
+            bool: True if the MPIJob is observable, False otherwise.
+        """
+        logging.debug(f"Attempting to observe MPIJob '{job_name}' in namespace '{namespace}'.")
+        try:
+            api_instance = CustomObjectsApi()
+            mpijob = api_instance.get_namespaced_custom_object(
+                group="kubeflow.org",
+                version="v2beta1",
+                namespace=namespace,
+                plural="mpijobs",
+                name=job_name,
+            )
+            if mpijob:
+                logging.debug(f"MPIJob '{job_name}' found in namespace '{namespace}' with details: {mpijob}.")
+                return True
+            else:
+                logging.debug(f"MPIJob '{job_name}' in namespace '{namespace}' is not yet observable.")
+                return False
+        except ApiException as e:
+            if e.status == 404:
+                logging.debug(f"MPIJob '{job_name}' not found in namespace '{namespace}'.")
+                return False
+            else:
+                logging.error(
+                    f"An error occurred while checking if MPIJob '{job_name}' is observable: {e.reason}. "
+                    f"Please check the job name, namespace, and Kubernetes API server."
+                )
+                raise
+
+    def _is_batch_job_observable(self, namespace: str, job_name: str) -> bool:
+        """
+        Check if a batch job is observable by the Kubernetes client.
+
+        Args:
+            namespace (str): The namespace of the batch job.
+            job_name (str): The name of the batch job.
+
+        Returns:
+            bool: True if the batch job is observable, False otherwise.
+        """
+        logging.debug(f"Attempting to observe batch job '{job_name}' in namespace '{namespace}'.")
+        try:
+            return self.batch_v1.read_namespaced_job_status(name=job_name, namespace=namespace) is not None
+        except ApiException as e:
+            if e.status == 404:
+                logging.debug(f"Batch job '{job_name}' not found in namespace '{namespace}'.")
+                return False
+            else:
+                logging.error(
+                    f"An error occurred while checking if batch job '{job_name}' is observable: {e.reason}. "
+                    f"Please check the job name, namespace, and Kubernetes API server."
+                )
+                raise
+
+    def list_jobs(self) -> List[Any]:
+        """
+        List all jobs in the Kubernetes system's default namespace.
+
+        Returns
+            List[Any]: A list of jobs in the namespace.
+        """
+        logging.debug(f"Listing jobs in namespace '{self.default_namespace}'")
+        return self.batch_v1.list_namespaced_job(namespace=self.default_namespace).items
+
+    def create_node_group(self, name: str, node_list: List[str]) -> None:
+        """
+        Create a node group in the Kubernetes system.
+
+        Args:
+            name (str): The name of the node group.
+            node_list (List[str]): List of node names to be included in the group.
+        """
+        logging.debug(f"Creating node group '{name}' with nodes: {node_list}")
+        for node in node_list:
+            body = {"metadata": {"labels": {"cloudai/node-group": name}}}
+            logging.debug(f"Labeling node '{node}' with group '{name}'")
+            self.core_v1.patch_node(node, body)
+
+    def create_namespace(self, namespace: str) -> None:
+        """
+        Create a new namespace in the Kubernetes cluster.
+
+        Args:
+            namespace (str): The name of the namespace to create.
+        """
+        body = client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
+        self.core_v1.create_namespace(body=body)
+        logging.debug(f"Namespace '{namespace}' created successfully.")
+
+    def delete_namespace(self, namespace: str) -> None:
+        """
+        Delete an existing namespace from the Kubernetes cluster.
+
+        Args:
+            namespace (str): The name of the namespace to delete.
+        """
+        self.core_v1.delete_namespace(name=namespace, body=client.V1DeleteOptions())
+        logging.debug(f"Namespace '{namespace}' deleted successfully.")
+
+    def list_namespaces(self) -> List[str]:
+        """
+        List all namespaces in the Kubernetes cluster.
+
+        Returns
+            List[str]: A list of namespace names.
+        """
+        namespaces = self.core_v1.list_namespace().items
+        return [ns.metadata.name for ns in namespaces]
+
+    def get_pod_names_for_job(self, namespace: str, job_name: str) -> List[str]:
+        """
+        Retrieve pod names associated with a given job.
+
+        Args:
+            namespace (str): The namespace where the job is running.
+            job_name (str): The name of the job.
+
+        Returns:
+            List[str]: A list of pod names associated with the job.
+        """
+        pod_names = []
+        try:
+            pods = self.core_v1.list_namespaced_pod(namespace=namespace)
+            for pod in pods.items:
+                if pod.metadata.labels and pod.metadata.labels.get("training.kubeflow.org/job-name") == job_name:
+                    pod_names.append(pod.metadata.name)
+        except client.ApiException as e:
+            logging.error(f"Error retrieving pods for job '{job_name}' in namespace '{namespace}': {e}")
+        return pod_names

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -78,7 +78,8 @@ def test_runners():
     runners = Registry().runners_map.keys()
     assert "standalone" in runners
     assert "slurm" in runners
-    assert len(runners) == 2
+    assert "kubernetes" in runners
+    assert len(runners) == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,6 +20,7 @@ from cloudai import (
     GradingStrategy,
     InstallStrategy,
     JobIdRetrievalStrategy,
+    JsonGenStrategy,
     Registry,
     ReportGenerationStrategy,
 )
@@ -52,6 +53,7 @@ from cloudai.schema.test_template.nemo_launcher.slurm_job_id_retrieval_strategy 
 )
 from cloudai.schema.test_template.nemo_launcher.template import NeMoLauncher
 from cloudai.schema.test_template.sleep.grading_strategy import SleepGradingStrategy
+from cloudai.schema.test_template.sleep.kubernetes_json_gen_strategy import SleepKubernetesJsonGenStrategy
 from cloudai.schema.test_template.sleep.report_generation_strategy import SleepReportGenerationStrategy
 from cloudai.schema.test_template.sleep.slurm_command_gen_strategy import SleepSlurmCommandGenStrategy
 from cloudai.schema.test_template.sleep.standalone_command_gen_strategy import SleepStandaloneCommandGenStrategy
@@ -62,6 +64,7 @@ from cloudai.schema.test_template.ucc_test.report_generation_strategy import UCC
 from cloudai.schema.test_template.ucc_test.slurm_command_gen_strategy import UCCTestSlurmCommandGenStrategy
 from cloudai.schema.test_template.ucc_test.slurm_install_strategy import UCCTestSlurmInstallStrategy
 from cloudai.schema.test_template.ucc_test.template import UCCTest
+from cloudai.systems.kubernetes.kubernetes_system import KubernetesSystem
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.systems.standalone_system import StandaloneSystem
 
@@ -111,6 +114,7 @@ def test_runners():
         ((JobIdRetrievalStrategy, SlurmSystem, NeMoLauncher), NeMoLauncherSlurmJobIdRetrievalStrategy),
         ((JobIdRetrievalStrategy, SlurmSystem, UCCTest), SlurmJobIdRetrievalStrategy),
         ((JobIdRetrievalStrategy, StandaloneSystem, Sleep), StandaloneJobIdRetrievalStrategy),
+        ((JsonGenStrategy, KubernetesSystem, Sleep), SleepKubernetesJsonGenStrategy),
         ((ReportGenerationStrategy, SlurmSystem, ChakraReplay), ChakraReplayReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, JaxToolbox), JaxToolboxReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, NcclTest), NcclTestReportGenerationStrategy),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,7 +69,8 @@ def test_system_parsers():
     parsers = Registry().system_parsers_map.keys()
     assert "standalone" in parsers
     assert "slurm" in parsers
-    assert len(parsers) == 2
+    assert "kubernetes" in parsers
+    assert len(parsers) == 3
 
 
 def test_runners():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,11 +39,16 @@ from cloudai.schema.test_template.jax_toolbox.report_generation_strategy import 
 from cloudai.schema.test_template.jax_toolbox.slurm_command_gen_strategy import JaxToolboxSlurmCommandGenStrategy
 from cloudai.schema.test_template.jax_toolbox.slurm_install_strategy import JaxToolboxSlurmInstallStrategy
 from cloudai.schema.test_template.jax_toolbox.template import JaxToolbox
-from cloudai.schema.test_template.nccl_test.grading_strategy import NcclTestGradingStrategy
 from cloudai.schema.test_template.nccl_test.kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
-from cloudai.schema.test_template.nccl_test.report_generation_strategy import NcclTestReportGenerationStrategy
+from cloudai.schema.test_template.nccl_test.kubernetes_report_generation_strategy import (
+    KubernetesNcclTestReportGenerationStrategy,
+)
 from cloudai.schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
+from cloudai.schema.test_template.nccl_test.slurm_grading_strategy import SlurmNcclTestGradingStrategy
 from cloudai.schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
+from cloudai.schema.test_template.nccl_test.slurm_report_generation_strategy import (
+    SlurmNcclTestReportGenerationStrategy,
+)
 from cloudai.schema.test_template.nccl_test.template import NcclTest
 from cloudai.schema.test_template.nemo_launcher.grading_strategy import NeMoLauncherGradingStrategy
 from cloudai.schema.test_template.nemo_launcher.report_generation_strategy import NeMoLauncherReportGenerationStrategy
@@ -98,7 +103,7 @@ def test_runners():
         ((CommandGenStrategy, StandaloneSystem, Sleep), SleepStandaloneCommandGenStrategy),
         ((GradingStrategy, SlurmSystem, ChakraReplay), ChakraReplayGradingStrategy),
         ((GradingStrategy, SlurmSystem, JaxToolbox), JaxToolboxGradingStrategy),
-        ((GradingStrategy, SlurmSystem, NcclTest), NcclTestGradingStrategy),
+        ((GradingStrategy, SlurmSystem, NcclTest), SlurmNcclTestGradingStrategy),
         ((GradingStrategy, SlurmSystem, NeMoLauncher), NeMoLauncherGradingStrategy),
         ((GradingStrategy, SlurmSystem, Sleep), SleepGradingStrategy),
         ((GradingStrategy, SlurmSystem, UCCTest), UCCTestGradingStrategy),
@@ -117,9 +122,10 @@ def test_runners():
         ((JobIdRetrievalStrategy, StandaloneSystem, Sleep), StandaloneJobIdRetrievalStrategy),
         ((JsonGenStrategy, KubernetesSystem, NcclTest), NcclTestKubernetesJsonGenStrategy),
         ((JsonGenStrategy, KubernetesSystem, Sleep), SleepKubernetesJsonGenStrategy),
+        ((ReportGenerationStrategy, KubernetesSystem, NcclTest), KubernetesNcclTestReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, ChakraReplay), ChakraReplayReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, JaxToolbox), JaxToolboxReportGenerationStrategy),
-        ((ReportGenerationStrategy, SlurmSystem, NcclTest), NcclTestReportGenerationStrategy),
+        ((ReportGenerationStrategy, SlurmSystem, NcclTest), SlurmNcclTestReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, NeMoLauncher), NeMoLauncherReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, Sleep), SleepReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, UCCTest), UCCTestReportGenerationStrategy),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,6 +40,7 @@ from cloudai.schema.test_template.jax_toolbox.slurm_command_gen_strategy import 
 from cloudai.schema.test_template.jax_toolbox.slurm_install_strategy import JaxToolboxSlurmInstallStrategy
 from cloudai.schema.test_template.jax_toolbox.template import JaxToolbox
 from cloudai.schema.test_template.nccl_test.grading_strategy import NcclTestGradingStrategy
+from cloudai.schema.test_template.nccl_test.kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
 from cloudai.schema.test_template.nccl_test.report_generation_strategy import NcclTestReportGenerationStrategy
 from cloudai.schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 from cloudai.schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
@@ -114,6 +115,7 @@ def test_runners():
         ((JobIdRetrievalStrategy, SlurmSystem, NeMoLauncher), NeMoLauncherSlurmJobIdRetrievalStrategy),
         ((JobIdRetrievalStrategy, SlurmSystem, UCCTest), SlurmJobIdRetrievalStrategy),
         ((JobIdRetrievalStrategy, StandaloneSystem, Sleep), StandaloneJobIdRetrievalStrategy),
+        ((JsonGenStrategy, KubernetesSystem, NcclTest), NcclTestKubernetesJsonGenStrategy),
         ((JsonGenStrategy, KubernetesSystem, Sleep), SleepKubernetesJsonGenStrategy),
         ((ReportGenerationStrategy, SlurmSystem, ChakraReplay), ChakraReplayReportGenerationStrategy),
         ((ReportGenerationStrategy, SlurmSystem, JaxToolbox), JaxToolboxReportGenerationStrategy),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,6 +23,7 @@ from cloudai import (
     Registry,
     ReportGenerationStrategy,
 )
+from cloudai.installer.kubernetes_installer import KubernetesInstaller
 from cloudai.installer.slurm_installer import SlurmInstaller
 from cloudai.installer.standalone_installer import StandaloneInstaller
 from cloudai.schema.test_template.chakra_replay.grading_strategy import ChakraReplayGradingStrategy
@@ -136,6 +137,7 @@ def test_test_templates():
 
 def test_installers():
     installers = Registry().installers_map
-    assert len(installers) == 2
+    assert len(installers) == 3
     assert installers["standalone"] == StandaloneInstaller
     assert installers["slurm"] == SlurmInstaller
+    assert installers["kubernetes"] == KubernetesInstaller

--- a/tests/test_slurm_report_generation_strategy.py
+++ b/tests/test_slurm_report_generation_strategy.py
@@ -18,11 +18,13 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from cloudai.schema.test_template.nccl_test.report_generation_strategy import NcclTestReportGenerationStrategy
+from cloudai.schema.test_template.nccl_test.slurm_report_generation_strategy import (
+    SlurmNcclTestReportGenerationStrategy,
+)
 
 
 @pytest.fixture
-def setup_test_environment(tmp_path: Path):
+def setup_test_environment(tmp_path: Path) -> Path:
     # Create a temporary directory for the test
     test_dir = tmp_path / "test_env"
     test_dir.mkdir()
@@ -65,11 +67,12 @@ def setup_test_environment(tmp_path: Path):
     return test_dir
 
 
-def test_nccl_report_generation(setup_test_environment):
+def test_nccl_report_generation(setup_test_environment: Path) -> None:
+    """Test the NCCL report generation process."""
     test_dir = setup_test_environment
 
     # Instantiate the strategy
-    strategy = NcclTestReportGenerationStrategy()
+    strategy = SlurmNcclTestReportGenerationStrategy()
 
     # Validate the directory can be handled
     assert strategy.can_handle_directory(test_dir) is True


### PR DESCRIPTION
## Summary
This PR relies on https://github.com/NVIDIA/cloudai/pull/180

- **Refactoring**: Refactored code to separate Kubernetes and Slurm strategies, including output readers and report generation.
- **Kubernetes Support**: Added Kubernetes-specific strategies for NCCL tests, including:
  - KubernetesNcclTestGradingStrategy
  - KubernetesNcclTestJobStatusRetrievalStrategy
  - NcclTestKubernetesJsonGenStrategy
  - KubernetesNcclTestReportGenerationStrategy
- **NCCL Test Templates**: Removed the "_mpi" suffix from subtest_name in all NCCL test templates.
- **Test Coverage**: Added unit tests for new Kubernetes strategies and updated existing tests to accommodate changes.

## Test Plan
CI passes.