### PR TITLE
Make GradingStrategy independant from TestTemplateStrategy

### DIFF
--- a/src/cloudai/_core/grading_strategy.py
+++ b/src/cloudai/_core/grading_strategy.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 
 
-class GradingStrategy:
+class GradingStrategy(ABC):
     """Abstract class for grading test performance."""
 
     @abstractmethod

--- a/src/cloudai/_core/grading_strategy.py
+++ b/src/cloudai/_core/grading_strategy.py
@@ -17,10 +17,8 @@
 from abc import abstractmethod
 from pathlib import Path
 
-from .test_template_strategy import TestTemplateStrategy
 
-
-class GradingStrategy(TestTemplateStrategy):
+class GradingStrategy:
     """Abstract class for grading test performance."""
 
     @abstractmethod

--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Tuple, Type, Union
 from .base_installer import BaseInstaller
 from .base_runner import BaseRunner
 from .base_system_parser import BaseSystemParser
+from .grading_strategy import GradingStrategy
 from .job_id_retrieval_strategy import JobIdRetrievalStrategy
 from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .report_generation_strategy import ReportGenerationStrategy
@@ -47,13 +48,25 @@ class Registry(metaclass=Singleton):
         Tuple[
             Type[
                 Union[
-                    TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy
+                    TestTemplateStrategy,
+                    ReportGenerationStrategy,
+                    JobIdRetrievalStrategy,
+                    JobStatusRetrievalStrategy,
+                    GradingStrategy,
                 ]
             ],
             Type[System],
             Type[TestTemplate],
         ],
-        Type[Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]],
+        Type[
+            Union[
+                TestTemplateStrategy,
+                ReportGenerationStrategy,
+                JobIdRetrievalStrategy,
+                JobStatusRetrievalStrategy,
+                GradingStrategy,
+            ]
+        ],
     ] = {}
     test_templates_map: Dict[str, Type[TestTemplate]] = {}
     installers_map: Dict[str, Type[BaseInstaller]] = {}
@@ -121,12 +134,24 @@ class Registry(metaclass=Singleton):
     def add_strategy(
         self,
         strategy_interface: Type[
-            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+            Union[
+                TestTemplateStrategy,
+                ReportGenerationStrategy,
+                JobIdRetrievalStrategy,
+                JobStatusRetrievalStrategy,
+                GradingStrategy,
+            ]
         ],
         system_types: List[Type[System]],
         template_types: List[Type[TestTemplate]],
         strategy: Type[
-            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+            Union[
+                TestTemplateStrategy,
+                ReportGenerationStrategy,
+                JobIdRetrievalStrategy,
+                JobStatusRetrievalStrategy,
+                GradingStrategy,
+            ]
         ],
     ) -> None:
         for system_type in system_types:
@@ -141,14 +166,24 @@ class Registry(metaclass=Singleton):
         key: Tuple[
             Type[
                 Union[
-                    TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy
+                    TestTemplateStrategy,
+                    ReportGenerationStrategy,
+                    JobIdRetrievalStrategy,
+                    JobStatusRetrievalStrategy,
+                    GradingStrategy,
                 ]
             ],
             Type[System],
             Type[TestTemplate],
         ],
         value: Type[
-            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+            Union[
+                TestTemplateStrategy,
+                ReportGenerationStrategy,
+                JobIdRetrievalStrategy,
+                JobStatusRetrievalStrategy,
+                GradingStrategy,
+            ]
         ],
     ) -> None:
         if not (
@@ -156,10 +191,12 @@ class Registry(metaclass=Singleton):
             or issubclass(key[0], ReportGenerationStrategy)
             or issubclass(key[0], JobIdRetrievalStrategy)
             or issubclass(key[0], JobStatusRetrievalStrategy)
+            or issubclass(key[0], GradingStrategy)
         ):
             raise ValueError(
                 "Invalid strategy interface type, should be subclass of 'TestTemplateStrategy' or "
-                "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy' or 'JobStatusRetrievalStrategy'."
+                "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy' or 'JobStatusRetrievalStrategy' or "
+                "'GradingStrategy'."
             )
         if not issubclass(key[1], System):
             raise ValueError("Invalid system type, should be subclass of 'System'.")
@@ -171,6 +208,7 @@ class Registry(metaclass=Singleton):
             or issubclass(value, ReportGenerationStrategy)
             or issubclass(value, JobIdRetrievalStrategy)
             or issubclass(value, JobStatusRetrievalStrategy)
+            or issubclass(value, GradingStrategy)
         ):
             raise ValueError(f"Invalid strategy implementation {value}, should be subclass of 'TestTemplateStrategy'.")
         self.strategies_map[key] = value

--- a/src/cloudai/_core/test_template_parser.py
+++ b/src/cloudai/_core/test_template_parser.py
@@ -59,14 +59,26 @@ class TestTemplateParser(BaseMultiFileParser):
     def _fetch_strategy(  # noqa: D417
         self,
         strategy_interface: Type[
-            Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+            Union[
+                TestTemplateStrategy,
+                ReportGenerationStrategy,
+                JobIdRetrievalStrategy,
+                JobStatusRetrievalStrategy,
+                GradingStrategy,
+            ]
         ],
         system_type: Type[System],
         test_template_type: Type[TestTemplate],
         env_vars: Dict[str, Any],
         cmd_args: Dict[str, Any],
     ) -> Optional[
-        Union[TestTemplateStrategy, ReportGenerationStrategy, JobIdRetrievalStrategy, JobStatusRetrievalStrategy]
+        Union[
+            TestTemplateStrategy,
+            ReportGenerationStrategy,
+            JobIdRetrievalStrategy,
+            JobStatusRetrievalStrategy,
+            GradingStrategy,
+        ]
     ]:
         """
         Fetch a strategy from the registry based on system and template.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -170,7 +170,8 @@ class TestRegistry__StrategiesMap:
             registry.update_strategy((str, MySystem, MyTestTemplate), MyStrategy)  # pyright: ignore
         err = (
             "Invalid strategy interface type, should be subclass of 'TestTemplateStrategy' or "
-            "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy' or 'JobStatusRetrievalStrategy'."
+            "'ReportGenerationStrategy' or 'JobIdRetrievalStrategy' or 'JobStatusRetrievalStrategy' "
+            "or 'GradingStrategy'."
         )
         assert err in str(exc_info.value)
 


### PR DESCRIPTION
## Summary
Make `GradingStrategy` independent from `TestTemplateStrategy` because we don't need this relation.

## Test Plan
CI

## Additional Notes
—
