### PR TITLE
Add missing k8s package into package dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pandas==2.2.1",
   "tbparse==0.0.8",
   "toml==0.10.2",
+  "kubernetes==30.1.0",
 ]
 
 [build-system]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import toml
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,12 @@
+import toml
+
+
+def test_requirements():
+    """
+    Test that the requirements in the requirements.txt file are the same as the requirements in the pyproject.toml file.
+    """
+    with open("requirements.txt", "r") as f:
+        requirements_txt = sorted(f.read().splitlines())
+    with open("pyproject.toml", "r") as f:
+        requirements_toml = sorted(toml.load(f)["project"]["dependencies"])
+    assert requirements_txt == requirements_toml


### PR DESCRIPTION
## Summary
1. Without it, `kubernetes` package is missing after installation.
2. Added a test to make sure `requirements.txt` and `pyproject.toml` are aligned for dependencies list.

## Test Plan
CI

## Additional Notes
—
