### PR TITLE
Resolve K8s Comments (Part 1)

### DIFF
--- a/conf/common/system/kubernetes_cluster.toml
+++ b/conf/common/system/kubernetes_cluster.toml
@@ -22,6 +22,7 @@ install_path = "./install"
 output_path = "./results"
 default_image = "ubuntu:22.04"
 default_namespace = "default"
+monitor_interval = 1
 
 [global_env_vars]
 NCCL_IB_GID_INDEX = "3"

--- a/conf/common/system/kubernetes_cluster.toml
+++ b/conf/common/system/kubernetes_cluster.toml
@@ -20,7 +20,6 @@ kube_config_path = ""
 
 install_path = "./install"
 output_path = "./results"
-default_image = "ubuntu:22.04"
 default_namespace = "default"
 monitor_interval = 1
 

--- a/conf/common/test_template/sleep.toml
+++ b/conf/common/test_template/sleep.toml
@@ -20,3 +20,7 @@ name = "Sleep"
   [cmd_args.seconds]
   type = "int"
   default = "5"
+
+  [cmd_args.docker_image_url]
+  type = "str"
+  default = "ubuntu:22.04"

--- a/src/cloudai/runner/kubernetes/kubernetes_job.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_job.py
@@ -28,15 +28,12 @@ class KubernetesJob(BaseJob):
         mode (str): The mode of the job (e.g., 'run', 'dry-run').
         system (System): The system in which the job is running.
         test_run (TestRun): The test instance associated with this job.
-        namespace (str): The namespace of the job.
         name (str): The name of the job.
         kind (str): The kind of the job.
         output_path (Path): The path where the job's output is stored.
     """
 
-    def __init__(
-        self, mode: str, system: System, test_run: TestRun, namespace: str, name: str, kind: str, output_path: Path
-    ):
+    def __init__(self, mode: str, system: System, test_run: TestRun, name: str, kind: str, output_path: Path):
         """
         Initialize a KubernetesJob instance.
 
@@ -44,14 +41,12 @@ class KubernetesJob(BaseJob):
             mode (str): The mode of the job (e.g., 'run', 'dry-run').
             system (System): The system in which the job is running.
             test_run (TestRun): The test instance associated with this job.
-            namespace (str): The namespace of the job.
             name (str): The name of the job.
             kind (str): The kind of the job.
             output_path (Path): The path where the job's output is stored.
         """
         super().__init__(mode, system, test_run, output_path)
         self.id = name
-        self.namespace = namespace
         self.name = name
         self.kind = kind
 
@@ -62,7 +57,4 @@ class KubernetesJob(BaseJob):
         Returns
             str: String representation of the job.
         """
-        return (
-            f"KubernetesJob(name={self.name}, namespace={self.namespace}, test={self.test_run.test.name}, "
-            f"kind={self.kind})"
-        )
+        return f"KubernetesJob(name={self.name}, test={self.test_run.test.name}, kind={self.kind})"

--- a/src/cloudai/runner/kubernetes/kubernetes_runner.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_runner.py
@@ -42,13 +42,12 @@ class KubernetesRunner(BaseRunner):
         job_spec = tr.test.gen_json(job_output_path, job_name, tr.time_limit, tr.num_nodes, tr.nodes)
         job_kind = job_spec.get("kind", "").lower()
         logging.info(f"Generated JSON string for test {tr.test.section_name}: {job_spec}")
-        job_namespace = ""
 
         if self.mode == "run":
             k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
-            job_name, job_namespace = k8s_system.create_job(job_spec)
+            job_name = k8s_system.create_job(job_spec)
 
-        return KubernetesJob(self.mode, self.system, tr, job_namespace, job_name, job_kind, job_output_path)
+        return KubernetesJob(self.mode, self.system, tr, job_name, job_kind, job_output_path)
 
     async def job_completion_callback(self, job: BaseJob) -> None:
         """
@@ -59,8 +58,8 @@ class KubernetesRunner(BaseRunner):
         """
         k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
         k_job = cast(KubernetesJob, job)
-        k8s_system.store_logs_for_job(k_job.namespace, k_job.name, k_job.output_path)
-        k8s_system.delete_job(k_job.namespace, k_job.name, k_job.kind)
+        k8s_system.store_logs_for_job(k_job.name, k_job.output_path)
+        k8s_system.delete_job(k_job.name, k_job.kind)
 
     def kill_job(self, job: BaseJob) -> None:
         """
@@ -71,5 +70,5 @@ class KubernetesRunner(BaseRunner):
         """
         k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
         k_job = cast(KubernetesJob, job)
-        k8s_system.store_logs_for_job(k_job.namespace, k_job.name, k_job.output_path)
-        k8s_system.delete_job(k_job.namespace, k_job.name, k_job.kind)
+        k8s_system.store_logs_for_job(k_job.name, k_job.output_path)
+        k8s_system.delete_job(k_job.name, k_job.kind)

--- a/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
@@ -52,7 +52,7 @@ class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
                             {
                                 "args": ["sleep " + sec],
                                 "command": ["/bin/bash", "-c"],
-                                "image": kubernetes_system.default_image,
+                                "image": self.final_cmd_args["docker_image_url"],
                                 "name": "task",
                             }
                         ],

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -17,7 +17,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, cast
 
 from kubernetes import client, config
 from kubernetes.client import ApiException, CustomObjectsApi, V1DeleteOptions, V1Job
@@ -139,7 +139,7 @@ class KubernetesSystem(BaseModel, System):
             bool: True if the job is running, False otherwise.
         """
         k_job: KubernetesJob = cast(KubernetesJob, job)
-        return self._is_job_running(k_job.namespace, k_job.name, k_job.kind)
+        return self._is_job_running(k_job.name, k_job.kind)
 
     def is_job_completed(self, job: BaseJob) -> bool:
         """
@@ -152,29 +152,25 @@ class KubernetesSystem(BaseModel, System):
             bool: True if the job is completed, False otherwise.
         """
         k_job: KubernetesJob = cast(KubernetesJob, job)
-        return not self._is_job_running(k_job.namespace, k_job.name, k_job.kind)
+        return not self._is_job_running(k_job.name, k_job.kind)
 
-    def _is_job_running(self, job_namespace: str, job_name: str, job_kind: str) -> bool:
+    def _is_job_running(self, job_name: str, job_kind: str) -> bool:
         """
         Check if a job is currently running.
 
         Args:
-            job_namespace (str): The namespace of the job.
             job_name (str): The name of the job.
             job_kind (str): The kind of the job ('MPIJob' or 'Job').
 
         Returns:
             bool: True if the job is running, False if the job has completed or is not found.
         """
-        logging.debug(
-            f"Checking for job '{job_name}' of kind '{job_kind}' in namespace '{job_namespace}' to determine if "
-            "it is running."
-        )
+        logging.debug(f"Checking for job '{job_name}' of kind '{job_kind}' to determine if it is running.")
 
         if "mpijob" in job_kind.lower():
-            return self._is_mpijob_running(job_namespace, job_name)
+            return self._is_mpijob_running(job_name)
         elif "job" in job_kind.lower():
-            return self._is_batch_job_running(job_namespace, job_name)
+            return self._is_batch_job_running(job_name)
         else:
             error_message = (
                 f"Unsupported job kind: '{job_kind}'. Supported kinds are 'MPIJob' for MPI workloads and 'Job' for "
@@ -183,12 +179,11 @@ class KubernetesSystem(BaseModel, System):
             logging.error(error_message)
             raise ValueError(error_message)
 
-    def _is_mpijob_running(self, job_namespace: str, job_name: str) -> bool:
+    def _is_mpijob_running(self, job_name: str) -> bool:
         """
         Check if an MPIJob is currently running.
 
         Args:
-            job_namespace (str): The namespace of the MPIJob.
             job_name (str): The name of the MPIJob.
 
         Returns:
@@ -196,7 +191,11 @@ class KubernetesSystem(BaseModel, System):
         """
         try:
             mpijob = self.custom_objects_api.get_namespaced_custom_object(
-                group="kubeflow.org", version="v2beta1", namespace=job_namespace, plural="mpijobs", name=job_name
+                group="kubeflow.org",
+                version="v2beta1",
+                namespace=self.default_namespace,
+                plural="mpijobs",
+                name=job_name,
             )
 
             assert isinstance(mpijob, dict)
@@ -221,38 +220,32 @@ class KubernetesSystem(BaseModel, System):
 
         except ApiException as e:
             if e.status == 404:
-                logging.debug(
-                    f"MPIJob '{job_name}' not found in namespace '{job_namespace}'. It may have completed and been "
-                    "removed from the system."
-                )
+                logging.debug(f"MPIJob '{job_name}' not found. It may have completed and been removed from the system.")
                 return False
             else:
                 error_message = (
-                    f"Error occurred while retrieving status for MPIJob '{job_name}' in namespace '{job_namespace}'. "
+                    f"Error occurred while retrieving status for MPIJob '{job_name}'. "
                     f"Error code: {e.status}. Message: {e.reason}. Please check the job name, namespace, and "
                     "Kubernetes API server."
                 )
                 logging.error(error_message)
                 raise
 
-    def _is_batch_job_running(self, job_namespace: str, job_name: str) -> bool:
+    def _is_batch_job_running(self, job_name: str) -> bool:
         """
         Check if a batch job is currently running.
 
         Args:
-            job_namespace (str): The namespace of the batch job.
             job_name (str): The name of the batch job.
 
         Returns:
             bool: True if the batch job is running, False if the job has completed or is not found.
         """
         try:
-            k8s_job: Any = self.batch_v1.read_namespaced_job_status(name=job_name, namespace=job_namespace)
+            k8s_job: Any = self.batch_v1.read_namespaced_job_status(name=job_name, namespace=self.default_namespace)
 
             if not (hasattr(k8s_job, "status") and hasattr(k8s_job.status, "conditions")):
-                logging.debug(
-                    f"Job '{job_name}' in namespace '{job_namespace}' does not have expected status attributes."
-                )
+                logging.debug(f"Job '{job_name}' does not have expected status attributes.")
                 return False
 
             conditions = k8s_job.status.conditions or []
@@ -272,14 +265,12 @@ class KubernetesSystem(BaseModel, System):
         except ApiException as e:
             if e.status == 404:
                 logging.debug(
-                    f"Batch job '{job_name}' not found in namespace '{job_namespace}'."
-                    "It may have completed and been removed from the system."
+                    f"Batch job '{job_name}' not found." "It may have completed and been removed from the system."
                 )
                 return False
             else:
                 logging.error(
-                    f"Error occurred while retrieving status for batch job '{job_name}' in namespace "
-                    "'{job_namespace}'."
+                    f"Error occurred while retrieving status for batch job '{job_name}' "
                     f"Error code: {e.status}. Message: {e.reason}. Please check the job name, namespace, "
                     "and Kubernetes API server."
                 )
@@ -293,21 +284,20 @@ class KubernetesSystem(BaseModel, System):
             job (BaseJob): The job to be terminated.
         """
         k_job: KubernetesJob = cast(KubernetesJob, job)
-        self.delete_job(k_job.namespace, k_job.name, k_job.kind)
+        self.delete_job(k_job.name, k_job.kind)
 
-    def delete_job(self, namespace: str, job_name: str, job_kind: str) -> None:
+    def delete_job(self, job_name: str, job_kind: str) -> None:
         """
-        Delete a job in the specified namespace.
+        Delete a job.
 
         Args:
-            namespace (str): The namespace of the job.
             job_name (str): The name of the job.
             job_kind (str): The kind of the job ('MPIJob' or 'Job').
         """
         if "mpijob" in job_kind.lower():
-            self._delete_mpi_job(namespace, job_name)
+            self._delete_mpi_job(job_name)
         elif "job" in job_kind.lower():
-            self._delete_batch_job(namespace, job_name)
+            self._delete_batch_job(job_name)
         else:
             error_message = (
                 f"Unsupported job kind: '{job_kind}'. Supported kinds are 'MPIJob' for MPI workloads and 'Job' for "
@@ -316,57 +306,53 @@ class KubernetesSystem(BaseModel, System):
             logging.error(error_message)
             raise ValueError(error_message)
 
-    def _delete_mpi_job(self, namespace: str, job_name: str) -> None:
+    def _delete_mpi_job(self, job_name: str) -> None:
         """
-        Delete an MPIJob in the specified namespace.
+        Delete an MPIJob.
 
         Args:
-            namespace (str): The namespace of the job.
             job_name (str): The name of the job.
         """
-        logging.debug(f"Deleting MPIJob '{job_name}' in namespace '{namespace}'")
+        logging.debug(f"Deleting MPIJob '{job_name}'")
         try:
             self.custom_objects_api.delete_namespaced_custom_object(
                 group="kubeflow.org",
                 version="v2beta1",
-                namespace=namespace,
+                namespace=self.default_namespace,
                 plural="mpijobs",
                 name=job_name,
                 body=V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
             )
-            logging.debug(f"MPIJob '{job_name}' deleted successfully in namespace '{namespace}'")
+            logging.debug(f"MPIJob '{job_name}' deleted successfully")
         except ApiException as e:
             if e.status == 404:
-                logging.debug(
-                    f"MPIJob '{job_name}' not found in namespace '{namespace}'. " "It may have already been deleted."
-                )
+                logging.debug(f"MPIJob '{job_name}' not found. " "It may have already been deleted.")
             else:
                 logging.error(
-                    f"An error occurred while attempting to delete MPIJob '{job_name}' in namespace '{namespace}'. "
+                    f"An error occurred while attempting to delete MPIJob '{job_name}'. "
                     f"Error code: {e.status}. Message: {e.reason}. Please verify the job name, namespace, "
                     "and Kubernetes API server."
                 )
                 raise
 
-    def _delete_batch_job(self, namespace: str, job_name: str) -> None:
+    def _delete_batch_job(self, job_name: str) -> None:
         """
-        Delete a batch job in the specified namespace.
+        Delete a batch job.
 
         Args:
-            namespace (str): The namespace of the job.
             job_name (str): The name of the job.
         """
-        logging.debug(f"Deleting batch job '{job_name}' in namespace '{namespace}'")
+        logging.debug(f"Deleting batch job '{job_name}'")
         api_response = self.batch_v1.delete_namespaced_job(
             name=job_name,
-            namespace=namespace,
+            namespace=self.default_namespace,
             body=V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
         )
         api_response = cast(V1Job, api_response)
 
         logging.debug(f"Batch job '{job_name}' deleted with status: {api_response.status}")
 
-    def create_job(self, job_spec: Dict[Any, Any], timeout: int = 60, interval: int = 1) -> Tuple[str, str]:
+    def create_job(self, job_spec: Dict[Any, Any], timeout: int = 60, interval: int = 1) -> str:
         """
         Create a job in the Kubernetes system in a blocking manner.
 
@@ -376,36 +362,35 @@ class KubernetesSystem(BaseModel, System):
             interval (int): The time to wait between checks, in seconds.
 
         Returns:
-            Tuple[str, str]: The job name and namespace.
+            str: The job name.
 
         Raises:
             ValueError: If the job specification does not contain a valid 'kind' field.
             TimeoutError: If the job is not observable within the timeout period.
         """
         logging.debug(f"Creating job with spec: {job_spec}")
-        job_name, namespace = self._create_job(self.default_namespace, job_spec)
+        job_name = self._create_job(job_spec)
 
         # Wait for the job to be observable by Kubernetes
         start_time = time.time()
         while time.time() - start_time < timeout:
-            if self._is_job_observable(namespace, job_name, job_spec.get("kind", "")):
-                logging.debug(f"Job '{job_name}' is now observable in namespace '{namespace}'.")
-                return job_name, namespace
-            logging.debug(f"Waiting for job '{job_name}' to become observable in namespace '{namespace}'...")
+            if self._is_job_observable(job_name, job_spec.get("kind", "")):
+                logging.debug(f"Job '{job_name}' is now observable.")
+                return job_name
+            logging.debug(f"Waiting for job '{job_name}' to become observable...")
             time.sleep(interval)
 
-        raise TimeoutError(f"Job '{job_name}' in namespace '{namespace}' was not observable within {timeout} seconds.")
+        raise TimeoutError(f"Job '{job_name}' was not observable within {timeout} seconds.")
 
-    def _create_job(self, namespace: str, job_spec: Dict[Any, Any]) -> Tuple[str, str]:
+    def _create_job(self, job_spec: Dict[Any, Any]) -> str:
         """
-        Submit a job to the specified namespace.
+        Submit a job.
 
         Args:
-            namespace (str): The namespace where the job will be created.
             job_spec (Dict[Any, Any]): The job specification.
 
         Returns:
-            Tuple[str, str]: The job name and namespace.
+            str: The job name.
 
         Raises:
             ValueError: If the job specification does not contain a valid 'kind' field.
@@ -414,9 +399,9 @@ class KubernetesSystem(BaseModel, System):
         kind = job_spec.get("kind", "").lower()
 
         if "mpijob" in kind:
-            return self._create_mpi_job(namespace, job_spec)
+            return self._create_mpi_job(job_spec)
         elif ("batch" in api_version) and ("job" in kind):
-            return self._create_batch_job(namespace, job_spec)
+            return self._create_batch_job(job_spec)
         else:
             error_message = (
                 f"Unsupported job kind: '{job_spec.get('kind')}'.\n"
@@ -427,105 +412,99 @@ class KubernetesSystem(BaseModel, System):
             logging.error(error_message)
             raise ValueError(error_message)
 
-    def _create_batch_job(self, namespace: str, job_spec: Dict[Any, Any]) -> Tuple[str, str]:
+    def _create_batch_job(self, job_spec: Dict[Any, Any]) -> str:
         """
-        Submit a batch job to the specified namespace.
+        Submit a batch job.
 
         Args:
-            namespace (str): The namespace where the job will be created.
             job_spec (Dict[Any, Any]): The job specification.
 
         Returns:
-            Tuple[str, str]: The job name and namespace.
+            str: The job name.
         """
-        logging.debug(f"Creating job in namespace '{namespace}'")
-        api_response = self.batch_v1.create_namespaced_job(body=job_spec, namespace=namespace)
+        logging.debug("Creating job")
+        api_response = self.batch_v1.create_namespaced_job(body=job_spec, namespace=self.default_namespace)
 
         if not isinstance(api_response, V1Job) or api_response.metadata is None:
             raise ValueError("Job creation failed or returned an unexpected type")
 
         job_name: str = api_response.metadata.name
-        job_namespace: str = api_response.metadata.namespace
         logging.debug(f"Job '{job_name}' created with status: {api_response.status}")
-        return job_name, job_namespace
+        return job_name
 
-    def _create_mpi_job(self, namespace: str, job_spec: Dict[Any, Any]) -> Tuple[str, str]:
+    def _create_mpi_job(self, job_spec: Dict[Any, Any]) -> str:
         """
-        Submit an MPIJob to the specified namespace.
+        Submit an MPIJob.
 
         Args:
-            namespace (str): The namespace where the MPIJob will be created.
             job_spec (Dict[Any, Any]): The MPIJob specification.
 
         Returns:
-            Tuple[str, str]: The job name and namespace.
+            str: The job name.
         """
-        logging.debug(f"Creating MPIJob in namespace '{namespace}'")
+        logging.debug("Creating MPIJob")
         api_response = self.custom_objects_api.create_namespaced_custom_object(
             group="kubeflow.org",
             version="v2beta1",
-            namespace=namespace,
+            namespace=self.default_namespace,
             plural="mpijobs",
             body=job_spec,
         )
 
         job_name: str = api_response["metadata"]["name"]
-        job_namespace: str = api_response["metadata"]["namespace"]
         logging.debug(f"MPIJob '{job_name}' created with status: {api_response.get('status')}")
-        return job_name, job_namespace
+        return job_name
 
-    def _is_job_observable(self, namespace: str, job_name: str, job_kind: str) -> bool:
+    def _is_job_observable(self, job_name: str, job_kind: str) -> bool:
         """
         Check if a job is observable by the Kubernetes client.
 
         Args:
-            namespace (str): The namespace of the job.
             job_name (str): The name of the job.
             job_kind (str): The kind of the job (e.g., 'Job', 'MPIJob').
 
         Returns:
             bool: True if the job is observable, False otherwise.
         """
-        logging.debug(f"Checking if job '{job_name}' of kind '{job_kind}' in namespace '{namespace}' is observable.")
+        logging.debug(f"Checking if job '{job_name}' of kind '{job_kind}' is observable.")
 
         if "mpijob" in job_kind.lower():
-            return self._is_mpijob_observable(namespace, job_name)
+            return self._is_mpijob_observable(job_name)
         elif "job" in job_kind.lower():
-            return self._is_batch_job_observable(namespace, job_name)
+            return self._is_batch_job_observable(job_name)
         else:
             logging.error(f"Unsupported job kind: '{job_kind}'")
             return False
 
-    def _is_mpijob_observable(self, namespace: str, job_name: str) -> bool:
+    def _is_mpijob_observable(self, job_name: str) -> bool:
         """
         Check if an MPIJob is observable by the Kubernetes client.
 
         Args:
-            namespace (str): The namespace of the MPIJob.
             job_name (str): The name of the MPIJob.
 
         Returns:
             bool: True if the MPIJob is observable, False otherwise.
         """
-        logging.debug(f"Attempting to observe MPIJob '{job_name}' in namespace '{namespace}'.")
+        logging.debug(f"Attempting to observe MPIJob '{job_name}'.")
         try:
             api_instance = CustomObjectsApi()
             mpijob = api_instance.get_namespaced_custom_object(
                 group="kubeflow.org",
                 version="v2beta1",
-                namespace=namespace,
+                namespace=self.default_namespace,
                 plural="mpijobs",
                 name=job_name,
             )
             if mpijob:
-                logging.debug(f"MPIJob '{job_name}' found in namespace '{namespace}' with details: {mpijob}.")
+                logging.debug(f"MPIJob '{job_name}' found with details: {mpijob}.")
                 return True
             else:
-                logging.debug(f"MPIJob '{job_name}' in namespace '{namespace}' is not yet observable.")
+                logging.debug(f"MPIJob '{job_name}' is not yet observable.")
                 return False
         except ApiException as e:
             if e.status == 404:
-                logging.debug(f"MPIJob '{job_name}' not found in namespace '{namespace}'.")
+                logging.debug(f"MPIJob '{job_name}' not found.")
                 return False
             else:
                 logging.error(
@@ -534,23 +513,22 @@ class KubernetesSystem(BaseModel, System):
                 )
                 raise
 
-    def _is_batch_job_observable(self, namespace: str, job_name: str) -> bool:
+    def _is_batch_job_observable(self, job_name: str) -> bool:
         """
         Check if a batch job is observable by the Kubernetes client.
 
         Args:
-            namespace (str): The namespace of the batch job.
             job_name (str): The name of the batch job.
 
         Returns:
             bool: True if the batch job is observable, False otherwise.
         """
-        logging.debug(f"Attempting to observe batch job '{job_name}' in namespace '{namespace}'.")
+        logging.debug(f"Attempting to observe batch job '{job_name}'.")
         try:
-            return self.batch_v1.read_namespaced_job_status(name=job_name, namespace=namespace) is not None
+            return self.batch_v1.read_namespaced_job_status(name=job_name, namespace=self.default_namespace) is not None
         except ApiException as e:
             if e.status == 404:
-                logging.debug(f"Batch job '{job_name}' not found in namespace '{namespace}'.")
+                logging.debug(f"Batch job '{job_name}' not found.")
                 return False
             else:
                 logging.error(
@@ -614,18 +592,17 @@ class KubernetesSystem(BaseModel, System):
         namespaces = self.core_v1.list_namespace().items
         return [ns.metadata.name for ns in namespaces]
 
-    def store_logs_for_job(self, namespace: str, job_name: str, output_dir: Path) -> None:
+    def store_logs_for_job(self, job_name: str, output_dir: Path) -> None:
         """
         Retrieve and store logs for all pods associated with a given job.
 
         Args:
-            namespace (str): The namespace where the job is running.
             job_name (str): The name of the job.
             output_dir (Path): The directory where logs will be saved.
         """
-        pod_names = self.get_pod_names_for_job(namespace, job_name)
+        pod_names = self.get_pod_names_for_job(self.default_namespace, job_name)
         if not pod_names:
-            logging.warning(f"No pods found for job '{job_name}' in namespace '{namespace}'")
+            logging.warning(f"No pods found for job '{job_name}' in namespace '{self.default_namespace}'")
             return
 
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -635,7 +612,7 @@ class KubernetesSystem(BaseModel, System):
         with stdout_file_path.open("w") as stdout_file:
             for pod_name in pod_names:
                 try:
-                    logs = self.core_v1.read_namespaced_pod_log(name=pod_name, namespace=namespace)
+                    logs = self.core_v1.read_namespaced_pod_log(name=pod_name, namespace=self.default_namespace)
 
                     log_file_path = output_dir / f"{pod_name}.txt"
                     with log_file_path.open("w") as log_file:
@@ -645,7 +622,7 @@ class KubernetesSystem(BaseModel, System):
                     stdout_file.write(logs + "\n")
 
                 except client.ApiException as e:
-                    logging.error(f"Error retrieving logs for pod '{pod_name}' in namespace '{namespace}': {e}")
+                    logging.error(f"Error retrieving logs for pod '{pod_name}': {e}")
 
         logging.info(f"All logs concatenated and saved to '{stdout_file_path}'")
 

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -53,7 +53,6 @@ class KubernetesSystem(BaseModel, System):
     output_path: Path
     kube_config_path: Path
     default_namespace: str
-    default_image: str
     scheduler: str = "kubernetes"
     global_env_vars: Dict[str, Any] = {}
     monitor_interval: int = 1
@@ -116,8 +115,7 @@ class KubernetesSystem(BaseModel, System):
             f"System Name: {self.name}\n"
             f"Scheduler Type: {self.scheduler}\n"
             f"Kube Config Path: {self.kube_config_path}\n"
-            f"Default Namespace: {self.default_namespace}\n"
-            f"Default Docker Image: {self.default_image}"
+            f"Default Namespace: {self.default_namespace}"
         )
 
     def update(self) -> None:

--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -32,9 +32,18 @@ class KubernetesSystem(BaseModel, System):
     Represents a Kubernetes system.
 
     Attributes
+        name (str): The name of the Kubernetes system.
+        install_path (Path): Path to the installation directory.
+        output_path (Path): Path to the output directory.
         kube_config_path (Path): Path to the Kubernetes config file.
         default_namespace (str): The default Kubernetes namespace for jobs.
         default_image (str): Default Docker image to be used for jobs.
+        scheduler (str): The scheduler type, default is "kubernetes".
+        global_env_vars (Dict[str, Any]): Global environment variables to be passed to jobs.
+        monitor_interval (int): Time interval to monitor jobs, in seconds.
+        _core_v1 (client.CoreV1Api): Kubernetes Core V1 API client instance.
+        _batch_v1 (client.BatchV1Api): Kubernetes Batch V1 API client instance.
+        _custom_objects_api (CustomObjectsApi): Kubernetes Custom Objects API client instance.
     """
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -47,43 +56,53 @@ class KubernetesSystem(BaseModel, System):
     default_image: str
     scheduler: str = "kubernetes"
     global_env_vars: Dict[str, Any] = {}
+    monitor_interval: int = 1
     _core_v1: client.CoreV1Api
     _batch_v1: client.BatchV1Api
     _custom_objects_api: CustomObjectsApi
 
-    def __post_init__(self) -> None:
+    def __init__(self, **data):
         """Initialize the KubernetesSystem instance."""
-        # Load the Kubernetes configuration
-        if not self.kube_config_path.exists():
+        super().__init__(**data)
+
+        kube_config_path = self.kube_config_path
+        if not kube_config_path.is_file():
+            home_directory = Path.home()
+            kube_config_path = home_directory / ".kube" / "config"
+        else:
+            kube_config_path = kube_config_path.resolve()
+
+        if not kube_config_path.exists():
             error_message = (
-                f"Kube config file '{self.kube_config_path}' not found. This file is required to configure the "
+                f"Kube config file '{kube_config_path}' not found. This file is required to configure the "
                 f"Kubernetes environment. Please verify that the file exists at the specified path."
             )
             logging.error(error_message)
             raise FileNotFoundError(error_message)
 
         # Instantiate Kubernetes APIs
-        logging.debug(f"Loading kube config from: {self.kube_config_path}")
-        config.load_kube_config(config_file=str(self.kube_config_path))
+        logging.debug(f"Loading kube config from: {kube_config_path}")
+        config.load_kube_config(config_file=str(kube_config_path))
+
+        self._core_v1 = client.CoreV1Api()
+        self._batch_v1 = client.BatchV1Api()
+        self._custom_objects_api = CustomObjectsApi()
 
         logging.debug(f"{self.__class__.__name__} initialized")
 
     @property
     def core_v1(self) -> client.CoreV1Api:
-        if self._core_v1 is None:
-            self._core_v1 = client.CoreV1Api()
+        """Returns the Kubernetes Core V1 API client."""
         return self._core_v1
 
     @property
     def batch_v1(self) -> client.BatchV1Api:
-        if self._batch_v1 is None:
-            self._batch_v1 = client.BatchV1Api()
+        """Returns the Kubernetes Batch V1 API client."""
         return self._batch_v1
 
     @property
     def custom_objects_api(self) -> CustomObjectsApi:
-        if self._custom_objects_api is None:
-            self._custom_objects_api = CustomObjectsApi()
+        """Returns the Kubernetes Custom Objects API client."""
         return self._custom_objects_api
 
     def __repr__(self) -> str:
@@ -91,7 +110,7 @@ class KubernetesSystem(BaseModel, System):
         Provide a structured string representation of the system.
 
         Returns
-            str: A string that contains the system name and scheduler type.
+            str: A string that contains the system name, scheduler type, kube config path, namespace, and image.
         """
         return (
             f"System Name: {self.name}\n"

--- a/tests/test_toml_files.py
+++ b/tests/test_toml_files.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import toml
@@ -39,12 +40,15 @@ ALL_SYSTEMS = [p for p in Path("conf/").glob("**/*.toml") if "scheduler =" in p.
 
 
 @pytest.mark.parametrize("system_file", ALL_SYSTEMS, ids=lambda x: str(x))
-def test_systems(system_file: Path):
+@patch("kubernetes.config.load_kube_config")
+@patch("pathlib.Path.exists", return_value=True)
+def test_systems(mock_exists, mock_load_kube_config, system_file: Path):
     """
     Validate the syntax of a system configuration file.
 
     Args:
         system_file (Path): The path to the system configuration file to validate.
     """
+    mock_load_kube_config.return_value = None
     system = Parser(system_file, Path("conf/test_template")).parse_system(system_file)
     assert system is not None


### PR DESCRIPTION
## Summary
Resolve K8s comments in https://github.com/NVIDIA/cloudai/pull/180
* https://github.com/NVIDIA/cloudai/pull/180#discussion_r1738545435
* https://github.com/NVIDIA/cloudai/pull/180#discussion_r1739006879

## Test Plan
1. CI passes
2. Tested on a K8s system
```
$ python cloudaix.py --mode run --system-config ../cloudai/conf/common/system/kubernetes_cluster.toml --test-templates-dir conf/staging/kubernetes/test_template/ --tests-dir conf/staging/kubernetes/test --test-scenario conf/staging/kubernetes/test_scenario/nccl_test.toml
[INFO] System configuration file: ../cloudai/conf/common/system/kubernetes_cluster.toml
[INFO] Test templates directory: conf/staging/kubernetes/test_template
[INFO] Tests directory: conf/staging/kubernetes/test
...
[INFO] Logs for pod 'tests-1-launcher-cjcpq' saved to 'results/nccl-test_2024-09-17_14-34-17/Tests.1/0/tests-1-launcher-cjcpq.txt'
[INFO] Logs for pod 'tests-1-worker-0' saved to 'results/nccl-test_2024-09-17_14-34-17/Tests.1/0/tests-1-worker-0.txt'
[INFO] Logs for pod 'tests-1-worker-1' saved to 'results/nccl-test_2024-09-17_14-34-17/Tests.1/0/tests-1-worker-1.txt'
[INFO] All logs concatenated and saved to 'results/nccl-test_2024-09-17_14-34-17/Tests.1/0/stdout.txt'
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: results/nccl-test_2024-09-17_14-34-17
```
