### PR TITLE
Extend CI for high level use cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,21 @@ jobs:
 
       - name: Run pytest
         run: pytest -vv --cov
+
+      - name: Test local installation
+        run: |
+          set -eE
+          set -o pipefail
+
+          pip install .
+          pip uninstall -y cloudai
+          pip install -e .
+
+      - name: Test commands
+        run: |
+          set -eE
+          set -o pipefail
+
+          cloudai --help
+          cloudai --mode verify-systems --tests-dir conf/common/test --system-config conf/common/system
+          cloudai --mode verify-tests --system-config conf/common/system/standalone_system.toml --tests-dir conf/common/test


### PR DESCRIPTION
## Summary
Extend CI for high level use cases

1. Local installation, both editable and default.
2. Run `--mode verify-systems`
3. Run `--mode verify-tests`

## Test Plan
CI

## Additional Notes
—
