### PR TITLE
Remove Unused env_vars From Initialization Code

### DIFF
--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -31,7 +31,6 @@ class CommandGenStrategy(TestTemplateStrategy):
     @abstractmethod
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -43,7 +42,6 @@ class CommandGenStrategy(TestTemplateStrategy):
         Generate the execution command for a test based on the given parameters.
 
         Args:
-            env_vars (Dict[str, str]): Environment variables for the test.
             cmd_args (Dict[str, str]): Command-line arguments for the test.
             extra_env_vars (Dict[str, str]): Additional environment variables.
             extra_cmd_args (str): Additional command-line arguments.

--- a/src/cloudai/_core/json_gen_strategy.py
+++ b/src/cloudai/_core/json_gen_strategy.py
@@ -31,7 +31,6 @@ class JsonGenStrategy(TestTemplateStrategy):
     @abstractmethod
     def gen_json(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -44,7 +43,6 @@ class JsonGenStrategy(TestTemplateStrategy):
         Generate the Kubernetes job specification based on the given parameters.
 
         Args:
-            env_vars (Dict[str, str]): Environment variables for the job.
             cmd_args (Dict[str, str]): Command-line arguments for the job.
             extra_env_vars (Dict[str, str]): Additional environment variables.
             extra_cmd_args (str): Additional command-line arguments.

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -34,7 +34,6 @@ class Test:
         name: str,
         description: str,
         test_template: TestTemplate,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -52,7 +51,6 @@ class Test:
             name (str): Name of the test.
             description (str): Description of the test.
             test_template (TestTemplate): Test template object.
-            env_vars (Dict[str, str]): Environment variables for the test.
             cmd_args (Dict[str, str]): Command-line arguments for the test.
             extra_env_vars (Dict[str, str]): Extra environment variables.
             extra_cmd_args (str): Extra command-line arguments.
@@ -67,7 +65,6 @@ class Test:
         self.name = name
         self.description = description
         self.test_template = test_template
-        self.env_vars = env_vars
         self.cmd_args = cmd_args
         self.extra_env_vars = extra_env_vars
         self.extra_cmd_args = extra_cmd_args
@@ -89,7 +86,6 @@ class Test:
         return (
             f"Test(name={self.name}, description={self.description}, "
             f"test_template={self.test_template.name}, "
-            f"env_vars={self.env_vars}, "
             f"cmd_args={self.cmd_args}, "
             f"extra_env_vars={self.extra_env_vars}, "
             f"extra_cmd_args={self.extra_cmd_args}, "
@@ -118,7 +114,6 @@ class Test:
             nodes = []
 
         return self.test_template.gen_exec_command(
-            self.env_vars,
             self.cmd_args,
             self.extra_env_vars,
             self.extra_cmd_args,
@@ -154,7 +149,6 @@ class Test:
             nodes = []
 
         return self.test_template.gen_json(
-            self.env_vars,
             self.cmd_args,
             self.extra_env_vars,
             self.extra_cmd_args,

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -137,7 +137,6 @@ class TestScenarioParser:
             name=original_test.name,
             description=original_test.description,
             test_template=original_test.test_template,
-            env_vars=copy.deepcopy(original_test.env_vars),
             cmd_args=copy.deepcopy(original_test.cmd_args),
             extra_env_vars=copy.deepcopy(original_test.extra_env_vars),
             extra_cmd_args=original_test.extra_cmd_args,

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -38,7 +38,6 @@ class TestTemplate:
 
     Attributes
         name (str): Unique name of the test template.
-        env_vars (Dict[str, Any]): Default environment variables.
         cmd_args (Dict[str, Any]): Default command-line arguments.
         logger (logging.Logger): Logger for the test template.
         install_strategy (InstallStrategy): Strategy for installing test prerequisites.
@@ -56,7 +55,6 @@ class TestTemplate:
         self,
         system: System,
         name: str,
-        env_vars: Dict[str, Any],
         cmd_args: Dict[str, Any],
     ) -> None:
         """
@@ -65,12 +63,10 @@ class TestTemplate:
         Args:
             system (System): System configuration for the test template.
             name (str): Name of the test template.
-            env_vars (Dict[str, Any]): Environment variables.
             cmd_args (Dict[str, Any]): Command-line arguments.
         """
         self.system = system
         self.name = name
-        self.env_vars = env_vars
         self.cmd_args = cmd_args
         self.install_strategy: Optional[InstallStrategy] = None
         self.command_gen_strategy: Optional[CommandGenStrategy] = None
@@ -127,7 +123,6 @@ class TestTemplate:
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -141,7 +136,6 @@ class TestTemplate:
         This method must be implemented by subclasses.
 
         Args:
-            env_vars (Dict[str, str]): Environment variables for the test.
             cmd_args (Dict[str, str]): Command-line arguments for the test.
             extra_env_vars (Dict[str, str]): Extra environment variables.
             extra_cmd_args (str): Extra command-line arguments.
@@ -160,7 +154,6 @@ class TestTemplate:
                 "by calling the appropriate registration function for the system type."
             )
         return self.command_gen_strategy.gen_exec_command(
-            env_vars,
             cmd_args,
             extra_env_vars,
             extra_cmd_args,
@@ -171,7 +164,6 @@ class TestTemplate:
 
     def gen_json(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -184,7 +176,6 @@ class TestTemplate:
         Generate a JSON string representing the Kubernetes job specification for this test using this template.
 
         Args:
-            env_vars (Dict[str, str]): Environment variables for the test.
             cmd_args (Dict[str, str]): Command-line arguments for the test.
             extra_env_vars (Dict[str, str]): Extra environment variables.
             extra_cmd_args (str): Extra command-line arguments.
@@ -204,7 +195,6 @@ class TestTemplate:
                 "by calling the appropriate registration function for the system type."
             )
         return self.json_gen_strategy.gen_json(
-            env_vars,
             cmd_args,
             extra_env_vars,
             extra_cmd_args,

--- a/src/cloudai/_core/test_template_strategy.py
+++ b/src/cloudai/_core/test_template_strategy.py
@@ -30,7 +30,6 @@ class TestTemplateStrategy:
         system (System): The system schema object.
         install_path (str): Path where the benchmarks are to be installed.
         cmd_args (Dict[str, Any]): Default command-line arguments.
-        default_env_vars (Dict[str, str]): Constructed default environment variables.
         default_cmd_args (Dict[str, str]): Constructed default command-line arguments.
     """
 
@@ -47,9 +46,7 @@ class TestTemplateStrategy:
         self.system = system
         self.install_path = ""
         self.cmd_args = cmd_args
-        self.default_env_vars = {}
         self.default_cmd_args = self._construct_default_cmd_args()
-        self.default_env_vars.update(system.global_env_vars)
 
     def _construct_default_cmd_args(self) -> Dict[str, str]:
         """

--- a/src/cloudai/_core/test_template_strategy.py
+++ b/src/cloudai/_core/test_template_strategy.py
@@ -29,7 +29,6 @@ class TestTemplateStrategy:
     Attributes
         system (System): The system schema object.
         install_path (str): Path where the benchmarks are to be installed.
-        env_vars (Dict[str, Any]): Default environment variables.
         cmd_args (Dict[str, Any]): Default command-line arguments.
         default_env_vars (Dict[str, str]): Constructed default environment variables.
         default_cmd_args (Dict[str, str]): Constructed default command-line arguments.
@@ -37,35 +36,20 @@ class TestTemplateStrategy:
 
     __test__ = False
 
-    def __init__(self, system: System, env_vars: Dict[str, Any], cmd_args: Dict[str, Any]) -> None:
+    def __init__(self, system: System, cmd_args: Dict[str, Any]) -> None:
         """
         Initialize a TestTemplateStrategy instance with system configuration, env variables, and command-line arguments.
 
         Args:
             system (System): The system configuration for the test.
-            env_vars (Dict[str, Any]): Default environment variables.
             cmd_args (Dict[str, Any]): Default command-line arguments.
         """
         self.system = system
         self.install_path = ""
-        self.env_vars = env_vars
         self.cmd_args = cmd_args
-        self.default_env_vars = self._construct_default_env_vars()
+        self.default_env_vars = {}
         self.default_cmd_args = self._construct_default_cmd_args()
         self.default_env_vars.update(system.global_env_vars)
-
-    def _construct_default_env_vars(self) -> Dict[str, str]:
-        """
-        Construct the default environment variables for the test template.
-
-        Returns
-            Dict[str, str]: A dictionary containing the default environment variables.
-        """
-        return {
-            key: value["default"]
-            for key, value in self.env_vars.items()
-            if isinstance(value, dict) and "default" in value
-        }
 
     def _construct_default_cmd_args(self) -> Dict[str, str]:
         """

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -25,7 +25,6 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -33,8 +32,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -32,7 +32,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -61,7 +61,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         """
         self.test_name = self._extract_test_name(cmd_args)
 
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
         cmd_args["output_path"] = str(output_path)
 
         combine_threshold_bytes = int(final_env_vars["COMBINE_THRESHOLD"])

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -27,13 +27,12 @@ from .slurm_install_strategy import JaxToolboxSlurmInstallStrategy
 class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for JaxToolbox tests on Slurm systems."""
 
-    def __init__(self, system: SlurmSystem, env_vars: Dict[str, Any], cmd_args: Dict[str, Any]) -> None:
-        super().__init__(system, env_vars, cmd_args)
+    def __init__(self, system: SlurmSystem, cmd_args: Dict[str, Any]) -> None:
+        super().__init__(system, cmd_args)
         self.test_name = ""
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -50,7 +49,6 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         the appropriate strategy for handling thresholds.
 
         Args:
-            env_vars (Dict[str, str]): Environment variables for the job.
             cmd_args (Dict[str, str]): Command-line arguments for the job.
             extra_env_vars (Dict[str, str]): Additional environment variables.
             extra_cmd_args (str): Additional command arguments.
@@ -63,8 +61,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         """
         self.test_name = self._extract_test_name(cmd_args)
 
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
         cmd_args["output_path"] = str(output_path)
 
         combine_threshold_bytes = int(final_env_vars["COMBINE_THRESHOLD"])

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
@@ -33,7 +33,7 @@ class NcclTestKubernetesJsonGenStrategy(JsonGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> Dict[Any, Any]:
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         final_num_nodes = self._determine_num_nodes(num_nodes, nodes)
         job_spec = self._create_job_spec(

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
@@ -25,7 +25,6 @@ class NcclTestKubernetesJsonGenStrategy(JsonGenStrategy):
 
     def gen_json(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -34,8 +33,7 @@ class NcclTestKubernetesJsonGenStrategy(JsonGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> Dict[Any, Any]:
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         final_num_nodes = self._determine_num_nodes(num_nodes, nodes)
         job_spec = self._create_job_spec(

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -34,7 +34,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -27,7 +27,6 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -35,8 +34,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -32,7 +32,6 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -40,8 +39,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
 
         launcher_path = (
             self.install_path

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -39,7 +39,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
 
         launcher_path = (
             self.install_path

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -58,8 +58,8 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
     REPOSITORY_NAME = "NeMo-Launcher"
     DOCKER_IMAGE_FILENAME = "nemo_launcher.sqsh"
 
-    def __init__(self, system: System, env_vars: Dict[str, Any], cmd_args: Dict[str, Any]) -> None:
-        super().__init__(system, env_vars, cmd_args)
+    def __init__(self, system: System, cmd_args: Dict[str, Any]) -> None:
+        super().__init__(system, cmd_args)
         self.repository_url = cmd_args["repository_url"]
         self.repository_commit_hash = cmd_args["repository_commit_hash"]
         self.docker_image_url = cmd_args["docker_image_url"]

--- a/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
@@ -26,7 +26,6 @@ class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
 
     def gen_json(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -25,7 +25,6 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -33,8 +32,7 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -32,7 +32,7 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/standalone_command_gen_strategy.py
@@ -29,7 +29,6 @@ class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -35,7 +35,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -28,7 +28,6 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
     def gen_exec_command(
         self,
-        env_vars: Dict[str, str],
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
@@ -36,8 +35,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         num_nodes: int,
         nodes: List[str],
     ) -> str:
-        final_env_vars = self._override_env_vars(self.default_env_vars, env_vars)
-        final_env_vars = self._override_env_vars(final_env_vars, extra_env_vars)
+        final_env_vars = self._override_env_vars(self.default_env_vars, extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -32,16 +32,15 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             properties and methods.
     """
 
-    def __init__(self, system: SlurmSystem, env_vars: Dict[str, Any], cmd_args: Dict[str, Any]) -> None:
+    def __init__(self, system: SlurmSystem, cmd_args: Dict[str, Any]) -> None:
         """
         Initialize a new SlurmCommandGenStrategy instance.
 
         Args:
             system (SlurmSystem): The system schema object.
-            env_vars (Dict[str, Any]): Environment variables.
             cmd_args (Dict[str, Any]): Command-line arguments.
         """
-        super().__init__(system, env_vars, cmd_args)
+        super().__init__(system, cmd_args)
         self.slurm_system = system
         if not self.slurm_system.default_partition:
             raise ValueError("Partition not specified in the system configuration.")

--- a/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
@@ -35,10 +35,9 @@ class SlurmInstallStrategy(InstallStrategy):
     def __init__(
         self,
         system: System,
-        env_vars: Dict[str, Any],
         cmd_args: Dict[str, Any],
     ) -> None:
-        super().__init__(system, env_vars, cmd_args)
+        super().__init__(system, cmd_args)
         self.slurm_system = cast(SlurmSystem, self.system)
         self.install_path = self.slurm_system.install_path
         self.docker_image_cache_manager = DockerImageCacheManager(

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -68,7 +68,6 @@ def jax_strategy_fixture() -> JaxToolboxSlurmCommandGenStrategy:
         strategy = JaxToolboxSlurmCommandGenStrategy(mock_slurm_system, cmd_args)
         # Manually set attributes needed for the tests
         strategy.cmd_args = cmd_args
-        strategy.default_env_vars = {}
         strategy.default_cmd_args = cmd_args
         return strategy
 

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -52,9 +52,8 @@ def slurm_system(tmp_path: Path) -> SlurmSystem:
 
 @pytest.fixture
 def slurm_install_strategy(slurm_system: SlurmSystem) -> SlurmInstallStrategy:
-    env_vars = {"TEST_VAR": "VALUE"}
     cmd_args = {"docker_image_url": {"default": "http://example.com/docker_image"}}
-    strategy = SlurmInstallStrategy(slurm_system, env_vars, cmd_args)
+    strategy = SlurmInstallStrategy(slurm_system, cmd_args)
     return strategy
 
 
@@ -76,7 +75,7 @@ def mock_docker_image_cache_manager(slurm_system: SlurmSystem):
 class TestNcclTestSlurmInstallStrategy:
     @pytest.fixture
     def strategy(self, slurm_system, mock_docker_image_cache_manager) -> NcclTestSlurmInstallStrategy:
-        strategy = NcclTestSlurmInstallStrategy(slurm_system, {}, {})
+        strategy = NcclTestSlurmInstallStrategy(slurm_system, {})
         strategy.docker_image_cache_manager = mock_docker_image_cache_manager
         return strategy
 
@@ -122,7 +121,6 @@ class TestNeMoLauncherSlurmInstallStrategy:
     def strategy(self, slurm_system, mock_docker_image_cache_manager) -> NeMoLauncherSlurmInstallStrategy:
         strategy = NeMoLauncherSlurmInstallStrategy(
             slurm_system,
-            {},
             {
                 "repository_url": {"default": "https://github.com/NVIDIA/NeMo-Framework-Launcher.git"},
                 "repository_commit_hash": {"default": "cf411a9ede3b466677df8ee672bcc6c396e71e1a"},
@@ -204,7 +202,7 @@ class TestNeMoLauncherSlurmInstallStrategy:
 class TestUCCTestSlurmInstallStrategy:
     @pytest.fixture
     def strategy(self, slurm_system, mock_docker_image_cache_manager) -> UCCTestSlurmInstallStrategy:
-        strategy = UCCTestSlurmInstallStrategy(slurm_system, {}, {})
+        strategy = UCCTestSlurmInstallStrategy(slurm_system, {})
         strategy.docker_image_cache_manager = mock_docker_image_cache_manager
         return strategy
 


### PR DESCRIPTION
## Summary
Remove unused env_vars from the initialization code.

env_vars for test templates and their strategies are initialized in the test parser class, as shown below:
```
    def _parse_data(self, data: Dict[str, Any]) -> Test:
        test_def = self.load_test_definition(data)

        env_vars = {}  # this field doesn't exist in Test or TestTemplate TOMLs
...

        test_template_name = data.get("test_template_name", "")
        test_template = self._get_test_template(test_template_name, env_vars, cmd_args)

...

        return Test(
            name=test_def.name,
            description=data.get("description", ""),
            test_template=test_template,
            env_vars=env_vars,
            cmd_args=cmd_args,
            extra_env_vars=extra_env_vars,
            extra_cmd_args=extra_cmd_args,
        )
```
As you can see, env_vars is empty by default. Therefore, there is no need to pass env_vars initially. This PR removes all env_vars arguments in the initialization logic.

## Test Plan
CI passes
