### PR TITLE
Replace 'training.values' Key with 'training' in final_cmd_args

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -60,6 +60,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         for key, value in final_env_vars.items():
             self.final_cmd_args[f"env_vars.{key}"] = value
 
+        if "training.values" in self.final_cmd_args:
+            self.final_cmd_args["training"] = self.final_cmd_args.pop("training.values")
+
         self.final_cmd_args["cluster.partition"] = self.slurm_system.default_partition
         reservation_key = "--reservation "
         if self.slurm_system.extra_srun_args and reservation_key in self.slurm_system.extra_srun_args:


### PR DESCRIPTION
## Summary
Replace the 'training.values' key with 'training' in final_cmd_args​. In the NeMo launcher, the model to run should be passed to 'training,' not 'training.values.' CloudAI has to rely on an arbitrary key called 'values' because Pydantic and TOML do not allow having a value and nested arguments simultaneously.

## Test Plan
1. CI passes
2. Ran on a server - Confirmed that the training arg has a correct value.