### PR TITLE
DRAFT : Reservation with groups new

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -527,17 +527,17 @@ class SlurmSystem(BaseModel, System):
             grouped_nodes = {
                 SlurmNodeState.RESERVED: [],
                 }
-            for node in self.groups[partition_name][group_name]:
-                if node.state in grouped_nodes and node.name in reserved_nodes:
-                    grouped_nodes[node.state].append(node)
         else:
+            reserved_nodes = []
             grouped_nodes = {
                 SlurmNodeState.IDLE: [],
                 SlurmNodeState.COMPLETING: [],
                 SlurmNodeState.ALLOCATED: [],
             }
-            for node in self.groups[partition_name][group_name]:
-                if node.state in grouped_nodes:
+            
+        for node in self.groups[partition_name][group_name]:
+            if node.state in grouped_nodes:
+                if not reserved_nodes or node.name in reserved_nodes:
                     grouped_nodes[node.state].append(node)
 
         return grouped_nodes
@@ -745,6 +745,7 @@ class SlurmSystem(BaseModel, System):
         Returns:
             Dict[str, str]: A dictionary mapping node names to usernames.
         """
+        node_list = []
         for reservation in reservation_output.split("ReservationName"):
             if reservation_name in reservation:
                 nodes = reservation.split("Nodes=")[1].split(" ")[0]

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -519,15 +519,26 @@ class SlurmSystem(BaseModel, System):
         Returns:
             Dict[SlurmNodeState, List[SlurmNode]]: A dictionary grouping nodes by their state.
         """
-        grouped_nodes = {
-            SlurmNodeState.IDLE: [],
-            SlurmNodeState.COMPLETING: [],
-            SlurmNodeState.ALLOCATED: [],
-        }
-
-        for node in self.groups[partition_name][group_name]:
-            if node.state in grouped_nodes:
-                grouped_nodes[node.state].append(node)
+        if "reservation" in self.extra_srun_args:
+            reservation_key = "--reservation "
+            reservation_name = self.extra_srun_args.split(reservation_key, 1)[1].split(" ", 1)[0]
+            reservation_output = self.get_reservation()
+            reserved_nodes = self.parse_reservation_output(reservation_output, reservation_name)
+            grouped_nodes = {
+                SlurmNodeState.RESERVED: [],
+                }
+            for node in self.groups[partition_name][group_name]:
+                if node.state in grouped_nodes and node.name in reserved_nodes:
+                    grouped_nodes[node.state].append(node)
+        else:
+            grouped_nodes = {
+                SlurmNodeState.IDLE: [],
+                SlurmNodeState.COMPLETING: [],
+                SlurmNodeState.ALLOCATED: [],
+            }
+            for node in self.groups[partition_name][group_name]:
+                if node.state in grouped_nodes:
+                    grouped_nodes[node.state].append(node)
 
         return grouped_nodes
 
@@ -639,6 +650,15 @@ class SlurmSystem(BaseModel, System):
         sinfo_output, _ = self.fetch_command_output("sinfo")
         return sinfo_output
 
+    def get_reservation(self) -> str:
+        """
+        Fetch the output from the 'scontrol show reservation' command.
+        Returns
+            str: The stdout from the 'scontrol show reservation' command execution.
+        """
+        reservation_output, _ = self.fetch_command_output("scontrol show reservation")
+        return reservation_output
+
     def fetch_command_output(self, command: str) -> Tuple[str, str]:
         """
         Execute a system command and return its output.
@@ -714,6 +734,23 @@ class SlurmSystem(BaseModel, System):
                             node.state = state_enum
                             node.user = node_user_map.get(node_name, "N/A")
                             break
+                        
+    def parse_reservation_output(self, reservation_output: str, reservation_name) -> Dict[str, str]:
+        """
+        Parse the output from the 'scontrol show reservation' command to map nodes to users.
+        The expected format of scontrol show reservation is lines of 'node_spec|user', where node_spec can include comma-separated
+        node names or ranges.
+        Args:
+            scontrol show reservation (str): The raw output from the squeue command.
+        Returns:
+            Dict[str, str]: A dictionary mapping node names to usernames.
+        """
+        for reservation in reservation_output.split("ReservationName"):
+            if reservation_name in reservation:
+                nodes = reservation.split("Nodes=")[1].split(" ")[0]
+                node_list = self.parse_node_list(nodes)
+
+        return node_list
 
     def convert_state_to_enum(self, state_str: str) -> SlurmNodeState:
         """


### PR DESCRIPTION
##Summary
This PR is intended to enable reservation with group node selection (previously, reservation only worked when specifying node names)
This PR is based on this one which cleaned the slurm_system file : https://github.com/NVIDIA/cloudai/pull/167

##Test Plan
Tested with
extra_srun_args = "--reservation reservation_name" in system.toml

test scenario :
name = "gpt_175B"

[Tests]
[Tests.1]
name = "gpt_175B"
nodes = ['cluster:SU2:2', 'cluster:SU3:3', 'cluster:SU4:3']

$ python ./cloudaix.py --mode run --system-config ... --test-templates-dir conf/v0.6/general/test_template --tests-dir conf/v0.6/general/test --test-scenario conf/v0.6/general/test_scenario/gpt/gpt_175B.toml

...
Section Name: Tests.1
Test Name: gpt_175B
Description: gpt
No dependencies
[INFO] Initializing Runner
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
