### PR TITLE
Remove Dead Code by Eliminating Unused `install_path`

### DIFF
--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -45,8 +45,6 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         if not self.slurm_system.default_partition:
             raise ValueError("Partition not specified in the system configuration.")
 
-        self.install_path = self.slurm_system.install_path
-
         self.docker_image_cache_manager = DockerImageCacheManager(
             self.slurm_system.install_path,
             self.slurm_system.cache_docker_images_locally,


### PR DESCRIPTION
## Summary
Remove dead code by eliminating the unused install_path variable. If the variable had been used, ruff would have detected it.

## Test Plan
CI passes.