### PR TITLE
Support NeMo Launcher in Kubernetes

### DIFF
--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -68,6 +68,7 @@ from .schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestS
 from .schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
 from .schema.test_template.nccl_test.template import NcclTest
 from .schema.test_template.nemo_launcher.grading_strategy import NeMoLauncherGradingStrategy
+from .schema.test_template.nemo_launcher.kubernetes_command_gen_strategy import NeMoLauncherKubernetesCommandGenStrategy
 from .schema.test_template.nemo_launcher.kubernetes_install_strategy import NeMoLauncherKubernetesInstallStrategy
 from .schema.test_template.nemo_launcher.report_generation_strategy import NeMoLauncherReportGenerationStrategy
 from .schema.test_template.nemo_launcher.slurm_command_gen_strategy import NeMoLauncherSlurmCommandGenStrategy
@@ -128,6 +129,9 @@ Registry().add_strategy(GradingStrategy, [SlurmSystem], [Sleep], SleepGradingStr
 Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxReportGenerationStrategy)
 Registry().add_strategy(JobIdRetrievalStrategy, [SlurmSystem], [NeMoLauncher], NeMoLauncherSlurmJobIdRetrievalStrategy)
 Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [NeMoLauncher], NeMoLauncherSlurmCommandGenStrategy)
+Registry().add_strategy(
+    CommandGenStrategy, [KubernetesSystem], [NeMoLauncher], NeMoLauncherKubernetesCommandGenStrategy
+)
 Registry().add_strategy(ReportGenerationStrategy, [SlurmSystem], [UCCTest], UCCTestReportGenerationStrategy)
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [NeMoLauncher], NeMoLauncherGradingStrategy)
 Registry().add_strategy(GradingStrategy, [SlurmSystem], [JaxToolbox], JaxToolboxGradingStrategy)

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -68,6 +68,7 @@ from .schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestS
 from .schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
 from .schema.test_template.nccl_test.template import NcclTest
 from .schema.test_template.nemo_launcher.grading_strategy import NeMoLauncherGradingStrategy
+from .schema.test_template.nemo_launcher.kubernetes_install_strategy import NeMoLauncherKubernetesInstallStrategy
 from .schema.test_template.nemo_launcher.report_generation_strategy import NeMoLauncherReportGenerationStrategy
 from .schema.test_template.nemo_launcher.slurm_command_gen_strategy import NeMoLauncherSlurmCommandGenStrategy
 from .schema.test_template.nemo_launcher.slurm_install_strategy import NeMoLauncherSlurmInstallStrategy
@@ -105,6 +106,7 @@ Registry().add_runner("standalone", StandaloneRunner)
 
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NcclTest], NcclTestSlurmInstallStrategy)
 Registry().add_strategy(InstallStrategy, [SlurmSystem], [NeMoLauncher], NeMoLauncherSlurmInstallStrategy)
+Registry().add_strategy(InstallStrategy, [KubernetesSystem], [NeMoLauncher], NeMoLauncherKubernetesInstallStrategy)
 Registry().add_strategy(
     ReportGenerationStrategy, [SlurmSystem, KubernetesSystem], [NcclTest], NcclTestReportGenerationStrategy
 )

--- a/src/cloudai/installer/kubernetes_installer.py
+++ b/src/cloudai/installer/kubernetes_installer.py
@@ -16,8 +16,7 @@
 
 import logging
 
-from kubernetes import client, config
-from kubernetes.client.rest import ApiException
+from kubernetes import config
 
 from cloudai import BaseInstaller, InstallStatusResult
 
@@ -57,67 +56,5 @@ class KubernetesInstaller(BaseInstaller):
             logging.error(message)
             return InstallStatusResult(False, message)
 
-        # Check MPIJob-related prerequisites
-        mpi_job_result = self._check_mpi_job_prerequisites()
-        if not mpi_job_result.success:
-            return mpi_job_result
-
         logging.info("All prerequisites are met. Proceeding with installation.")
-        return InstallStatusResult(True)
-
-    def _check_mpi_job_prerequisites(self) -> InstallStatusResult:
-        """
-        Check if the MPIJob CRD is installed and if MPIJob kind is supported in the Kubernetes cluster.
-
-        This ensures that the system is ready for MPI-based operations.
-
-        Returns
-            InstallStatusResult: Result containing the status of the MPIJob prerequisite check and any error message.
-        """
-        # Check if MPIJob CRD is installed
-        try:
-            custom_api = client.CustomObjectsApi()
-            custom_api.get_cluster_custom_object(group="kubeflow.org", version="v1", plural="mpijobs", name="mpijobs")
-        except ApiException as e:
-            if e.status == 404:
-                message = (
-                    "Installation failed during prerequisite checking stage because MPIJob CRD is not installed on "
-                    "this Kubernetes cluster. Please ensure that the MPI Operator is installed and MPIJob kind is "
-                    "supported. You can follow the instructions in the MPI Operator repository to install it: "
-                    "https://github.com/kubeflow/mpi-operator"
-                )
-                logging.error(message)
-                return InstallStatusResult(False, message)
-            else:
-                message = (
-                    f"Installation failed during prerequisite checking stage due to an error while checking for MPIJob "
-                    f"CRD. Original error: {str(e)}. Please ensure that the Kubernetes cluster is accessible and the "
-                    f"MPI Operator is correctly installed."
-                )
-                logging.error(message)
-                return InstallStatusResult(False, message)
-
-        # Check if MPIJob kind is supported
-        try:
-            api_resources = client.ApiextensionsV1Api().list_custom_resource_definition()
-            mpi_job_supported = any(item.metadata.name == "mpijobs.kubeflow.org" for item in api_resources.items)
-        except ApiException as e:
-            message = (
-                f"Installation failed during prerequisite checking stage due to an error while checking for MPIJob "
-                f"kind support. Original error: {str(e)}. Please ensure that the Kubernetes cluster is accessible and "
-                f"the MPI Operator is correctly installed."
-            )
-            logging.error(message)
-            return InstallStatusResult(False, message)
-
-        if not mpi_job_supported:
-            message = (
-                "Installation failed during prerequisite checking stage because MPIJob kind is not supported on this "
-                "Kubernetes cluster. Please ensure that the MPI Operator is installed and MPIJob kind is supported. "
-                "You can follow the instructions in the MPI Operator repository to install it: "
-                "https://github.com/kubeflow/mpi-operator"
-            )
-            logging.error(message)
-            return InstallStatusResult(False, message)
-
         return InstallStatusResult(True)

--- a/src/cloudai/schema/test_template/nemo_launcher/kubernetes_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/kubernetes_command_gen_strategy.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Dict, List
+
+from cloudai import CommandGenStrategy
+
+from .kubernetes_install_strategy import NeMoLauncherKubernetesInstallStrategy
+
+
+class NeMoLauncherKubernetesCommandGenStrategy(CommandGenStrategy):
+    """Command generation strategy for NeMo Megatron Launcher on Kubernetes systems."""
+
+    def gen_exec_command(
+        self,
+        cmd_args: Dict[str, str],
+        extra_env_vars: Dict[str, str],
+        extra_cmd_args: str,
+        output_path: Path,
+        num_nodes: int,
+        nodes: List[str],
+    ) -> str:
+        final_env_vars = {**self.system.global_env_vars, **extra_env_vars}
+
+        launcher_path = (
+            self.system.install_path
+            / NeMoLauncherKubernetesInstallStrategy.SUBDIR_PATH
+            / NeMoLauncherKubernetesInstallStrategy.REPOSITORY_NAME
+        )
+
+        self.final_cmd_args = {**self.default_cmd_args, **cmd_args}
+        self.final_cmd_args["launcher_scripts_path"] = str(launcher_path / "launcher_scripts")
+
+        self.final_cmd_args.update({f"env_vars.{key}": value for key, value in final_env_vars.items()})
+
+        self.final_cmd_args["cluster"] = self.final_cmd_args.pop("cluster.value", "")
+        self.final_cmd_args["training"] = self.final_cmd_args.pop("training.values", "")
+
+        for key in ["repository_url", "repository_commit_hash", "docker_image_url"]:
+            self.final_cmd_args.pop(key, None)
+
+        if self.final_cmd_args.get("data_dir") == "DATA_DIR":
+            raise ValueError(
+                "The 'data_dir' field of the NeMo launcher test contains the placeholder 'DATA_DIR'. "
+                "Please update the test schema TOML file with a valid path to the dataset."
+            )
+
+        cmd_args_str = self._generate_cmd_args_str(self.final_cmd_args)
+
+        full_cmd = f"python {launcher_path}/launcher_scripts/main.py {cmd_args_str}"
+
+        if extra_cmd_args:
+            full_cmd += f" {extra_cmd_args}"
+
+        env_vars_str = " ".join(f"{key}={value}" for key, value in final_env_vars.items())
+        return f"{env_vars_str} {full_cmd}".strip() if env_vars_str else full_cmd.strip()
+
+    def _generate_cmd_args_str(self, args: Dict[str, str]) -> str:
+        """
+        Generate a string of command-line arguments, wrapping values in quotes when necessary.
+
+        Args:
+            args (Dict[str, str]): The command-line arguments.
+
+        Returns:
+            str: A string of command-line arguments.
+        """
+        cmd_arg_str_parts = []
+        env_var_str_parts = []
+        special_chars = ["[", "]", "\\"]
+
+        for key, value in args.items():
+            if any(char in value for char in special_chars):
+                value = f'"{value}"'
+
+            if key.startswith("env_vars."):
+                env_var_str_parts.append(f"+{key}={value}")
+            else:
+                cmd_arg_str_parts.append(f"{key}={value}")
+
+        return " ".join(cmd_arg_str_parts + env_var_str_parts)

--- a/src/cloudai/schema/test_template/nemo_launcher/kubernetes_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/kubernetes_install_strategy.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+from cloudai import InstallStatusResult, InstallStrategy, System
+
+
+class NeMoLauncherKubernetesInstallStrategy(InstallStrategy):
+    """
+    Install strategy for NeMo-Launcher on Kubernetes systems.
+
+    Attributes
+        SUBDIR_PATH (str): Subdirectory within the system's install path where the NeMo-Launcher will be stored.
+        REPOSITORY_NAME (str): Name of the NeMo-Launcher repository.
+        repository_url (str): URL to the NeMo-Launcher Git repository.
+        repository_commit_hash (str): Specific commit hash to checkout after cloning the repository.
+    """
+
+    SUBDIR_PATH: str = "NeMo-Launcher"
+    REPOSITORY_NAME: str = "NeMo-Launcher"
+
+    def __init__(self, system: System, cmd_args: Dict[str, Any]) -> None:
+        """
+        Initialize the install strategy for NeMo-Launcher on Kubernetes systems.
+
+        Args:
+            system (System): The system where NeMo-Launcher will be installed.
+            cmd_args (Dict[str, Any]): Command-line arguments including repository URL and commit hash.
+        """
+        super().__init__(system, cmd_args)
+        self.system = system
+        self.repository_url: str = cmd_args["repository_url"]
+        self.repository_commit_hash: str = cmd_args["repository_commit_hash"]
+
+    def is_installed(self) -> InstallStatusResult:
+        """
+        Check if NeMo-Launcher is installed on the system.
+
+        Returns
+            InstallStatusResult: Status indicating whether NeMo-Launcher is installed.
+        """
+        subdir_path = self.system.install_path / self.SUBDIR_PATH
+        repo_path = subdir_path / self.REPOSITORY_NAME
+        repo_installed = repo_path.is_dir()
+
+        if repo_installed:
+            return InstallStatusResult(success=True)
+
+        missing_components = [
+            f"Repository at {repo_path} from {self.repository_url} " f"with commit hash {self.repository_commit_hash}"
+        ]
+        return InstallStatusResult(
+            success=False,
+            message="The following components are missing:\n"
+            + "\n".join(f"    - {item}" for item in missing_components),
+        )
+
+    def install(self) -> InstallStatusResult:
+        """
+        Installs NeMo-Launcher by cloning the repository and installing requirements.
+
+        Returns
+            InstallStatusResult: Status indicating whether the installation succeeded.
+        """
+        install_status = self.is_installed()
+        if install_status.success:
+            return InstallStatusResult(success=True, message="NeMo-Launcher is already installed.")
+
+        subdir_path = self.system.install_path / self.SUBDIR_PATH
+        subdir_path.mkdir(parents=True, exist_ok=True)
+
+        try:
+            self._clone_repository(subdir_path)
+            self._install_requirements(subdir_path)
+        except RuntimeError as e:
+            return InstallStatusResult(success=False, message=str(e))
+
+        return InstallStatusResult(success=True)
+
+    def uninstall(self) -> InstallStatusResult:
+        """
+        Uninstalls the NeMo-Launcher by removing its cloned repository.
+
+        Returns
+            InstallStatusResult: Status indicating whether the uninstallation succeeded.
+        """
+        subdir_path = self.system.install_path / self.SUBDIR_PATH
+        repo_path = subdir_path / self.REPOSITORY_NAME
+
+        if repo_path.exists():
+            logging.debug("Removing cloned repository at %s", repo_path)
+            try:
+                subprocess.run(["rm", "-rf", str(repo_path)], check=True)
+            except subprocess.CalledProcessError as e:
+                return InstallStatusResult(
+                    success=False,
+                    message=f"Failed to remove cloned repository. Command: 'rm -rf {repo_path}'. Error: {str(e)}.",
+                )
+        else:
+            logging.warning("Repository does not exist at %s", repo_path)
+
+        return InstallStatusResult(success=True, message="NeMo-Launcher repository removed successfully.")
+
+    def _clone_repository(self, subdir_path: Path) -> None:
+        """
+        Clones the NeMo-Launcher repository into the specified subdirectory path.
+
+        Args:
+            subdir_path (Path): Subdirectory path for installation.
+
+        Raises:
+            RuntimeError: If cloning or checking out the commit fails.
+        """
+        repo_path = subdir_path / self.REPOSITORY_NAME
+
+        if repo_path.exists():
+            logging.warning("Repository already exists at %s, clone skipped", repo_path)
+        else:
+            logging.debug("Cloning NeMo-Launcher repository into %s", repo_path)
+            clone_cmd = ["git", "clone", self.repository_url, str(repo_path)]
+            result = subprocess.run(clone_cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to clone NeMo-Launcher repository. Command: {' '.join(clone_cmd)}. "
+                    f"Error: {result.stderr}."
+                )
+
+        logging.debug("Checking out specific commit %s in repository", self.repository_commit_hash)
+        checkout_cmd = ["git", "checkout", self.repository_commit_hash]
+        result = subprocess.run(checkout_cmd, cwd=str(repo_path), capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to checkout commit {self.repository_commit_hash}. Command: {' '.join(checkout_cmd)}. "
+                f"Error: {result.stderr}."
+            )
+
+    def _install_requirements(self, subdir_path: Path) -> None:
+        """
+        Installs the required Python packages from the requirements.txt file in the cloned repository.
+
+        Args:
+            subdir_path (Path): Subdirectory path for installation.
+
+        Raises:
+            RuntimeError: If installing requirements fails.
+        """
+        repo_path = subdir_path / self.REPOSITORY_NAME
+        requirements_file = repo_path / "requirements.txt"
+
+        if requirements_file.is_file():
+            logging.debug("Installing requirements from %s", requirements_file)
+            install_cmd = ["pip", "install", "-r", str(requirements_file)]
+            result = subprocess.run(install_cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to install requirements for NeMo-Launcher. Command: {' '.join(install_cmd)}. "
+                    f"Error: {result.stderr}."
+                )
+        else:
+            logging.warning("requirements.txt not found in %s", repo_path)

--- a/src/cloudai/test_definitions/nemo_launcher.py
+++ b/src/cloudai/test_definitions/nemo_launcher.py
@@ -28,11 +28,35 @@ class NumaMapping(BaseModel):
     enable: bool = True
 
 
+class PersistentVolumeClaim(BaseModel):
+    """Persistent volume claim configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+    claim_name: str = "nemo-workspace"
+
+
+class ClusterWorkspace(BaseModel):
+    """Cluster workspace configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+    persistent_volume_claim: PersistentVolumeClaim = Field(default_factory=PersistentVolumeClaim)
+    mount_path: str = "/nemo-workspace"
+
+
+class ClusterVolume(BaseModel):
+    """Cluster volume configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+    workspace: ClusterWorkspace = Field(default_factory=ClusterWorkspace)
+
+
 class Cluster(BaseModel):
     """Cluster configuration."""
 
     model_config = ConfigDict(extra="forbid")
+    value: str = "k8s_v2"
     gpus_per_node: int = 8
+    volumes: ClusterVolume = Field(default_factory=ClusterVolume)
 
 
 class ExpManager(BaseModel):
@@ -50,6 +74,8 @@ class Trainer(BaseModel):
     val_check_interval: int = 100
     log_every_n_steps: Literal["1", "2"] = "1"
     enable_checkpointing: bool = False
+    num_nodes: int = 3
+    devices: int = 8
 
 
 class TrainingModelData(BaseModel):

--- a/tests/test_kubernetes_command_gen_strategy.py
+++ b/tests/test_kubernetes_command_gen_strategy.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+from cloudai.schema.test_template.nemo_launcher.kubernetes_command_gen_strategy import (
+    NeMoLauncherKubernetesCommandGenStrategy,
+)
+from cloudai.systems.kubernetes import KubernetesSystem
+
+
+@pytest.fixture
+def kube_config_tempfile():
+    kube_config_content = """
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        server: https://127.0.0.1:6443
+      name: local-cluster
+    contexts:
+    - context:
+        cluster: local-cluster
+        user: local-user
+      name: local-context
+    current-context: local-context
+    users:
+    - name: local-user
+      user:
+        token: fake-token
+    """
+
+    home_dir = Path.home()
+    kube_config_dir = home_dir / ".kube"
+    kube_config_path = kube_config_dir / "config"
+
+    kube_config_dir.mkdir(parents=True, exist_ok=True)
+
+    with kube_config_path.open("w") as config_file:
+        config_file.write(kube_config_content)
+
+    yield kube_config_path
+
+
+@pytest.fixture
+def k8s_system(kube_config_tempfile):
+    system_data = {
+        "name": "test-system",
+        "install_path": "/fake/install/path",
+        "output_path": "/fake/output/path",
+        "kube_config_path": kube_config_tempfile,
+        "default_namespace": "default",
+        "default_image": "test-image",
+        "scheduler": "kubernetes",
+        "global_env_vars": {},
+        "monitor_interval": 1,
+    }
+
+    k8s_system = KubernetesSystem(**system_data)
+    k8s_system.model_post_init(None)
+
+    validated_system = KubernetesSystem.model_validate(system_data)
+
+    yield validated_system
+
+
+class TestNeMoLauncherKubernetesCommandGenStrategy__GenExecCommand:
+    @pytest.fixture
+    def nemo_cmd_gen(self, k8s_system: KubernetesSystem) -> NeMoLauncherKubernetesCommandGenStrategy:
+        cmd_args = {"test_arg": "test_value"}
+        strategy = NeMoLauncherKubernetesCommandGenStrategy(k8s_system, cmd_args)
+        strategy.system = k8s_system
+        strategy.default_cmd_args = {
+            "repository_url": "mock_repo_url",
+            "repository_commit_hash": "mock_commit_hash",
+            "docker_image_url": "mock_docker_image",
+            "data_dir": "mock_data_dir",
+            "training.values": "mock_training_values",
+            "training.model.data.data_prefix": "\\mock_prefix",
+        }
+        return strategy
+
+    def test_custom_gen_exec_command(self, nemo_cmd_gen: NeMoLauncherKubernetesCommandGenStrategy):
+        extra_env_vars = {}
+        cmd_args = {
+            "launcher_scripts_path": "/fake/install/path/NeMoLauncherKubernetesInstallStrategy/launcher_scripts",
+            "data_dir": "/nemo-workspace/pile",
+            "cluster.value": "k8s_v2",
+            "cluster.volumes.workspace.persistent_volume_claim.claim_name": "nemo-workspace",
+            "cluster.volumes.workspace.mount_path": "/nemo-workspace",
+            "stages": "[training]",
+            "training.values": "gpt3/1b",
+            "training.exp_manager.explicit_log_dir": "/nemo-workspace/gpt3/1b/training_gpt3/1b/results",
+            "training.model.data.data_prefix": "[0.5,/nemo-workspace/pile/my-gpt3_00_text_document]",
+            "training.trainer.num_nodes": "3",
+            "training.trainer.devices": "8",
+            "training.trainer.max_steps": "1000",
+            "training.trainer.val_check_interval": "100",
+            "training.model.global_batch_size": "48",
+        }
+
+        cmd = nemo_cmd_gen.gen_exec_command(
+            cmd_args=cmd_args,
+            extra_env_vars=extra_env_vars,
+            extra_cmd_args="",
+            output_path=Path("/fake/output/path"),
+            num_nodes=3,
+            nodes=["node1", "node2", "node3"],
+        )
+
+        expected_parts = [
+            "python /fake/install/path/NeMo-Launcher/NeMo-Launcher/launcher_scripts/main.py",
+            "data_dir=/nemo-workspace/pile",
+            'training.model.data.data_prefix="[0.5,/nemo-workspace/pile/my-gpt3_00_text_document]"',
+            "launcher_scripts_path=/fake/install/path/NeMo-Launcher/NeMo-Launcher/launcher_scripts",
+            "cluster=k8s_v2",
+            "cluster.volumes.workspace.persistent_volume_claim.claim_name=nemo-workspace",
+            "cluster.volumes.workspace.mount_path=/nemo-workspace",
+            'stages="[training]"',
+            "training.exp_manager.explicit_log_dir=/nemo-workspace/gpt3/1b/training_gpt3/1b/results",
+            "training.trainer.num_nodes=3",
+            "training.trainer.devices=8",
+            "training.trainer.max_steps=1000",
+            "training.trainer.val_check_interval=100",
+            "training.model.global_batch_size=48",
+            "training=gpt3/1b",
+        ]
+
+        for part in expected_parts:
+            assert part in cmd, f"Part '{part}' was not found in the generated command."


### PR DESCRIPTION
## Summary
Support NeMo Launcher in Kubernetes

## Test Plan
1. CI passes
2. Run on a server
```
$ cloudai --mode install --system-config conf/common/system/kubernetes_cluster.toml --tests-dir conf/common/test
/root/theo/venv/lib/python3.10/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
[INFO] System configuration file: conf/common/system/kubernetes_cluster.toml
[INFO] Tests directory: conf/common/test
[INFO] Test scenario file: None
[INFO] Output directory: None
[WARNING] No JsonGenStrategy found for TestParser and KubernetesSystem
[WARNING] No JobIdRetrievalStrategy found for TestParser and KubernetesSystem
[WARNING] No JobStatusRetrievalStrategy found for TestParser and KubernetesSystem
[WARNING] No ReportGenerationStrategy found for TestParser and KubernetesSystem
[WARNING] No GradingStrategy found for TestParser and KubernetesSystem
[INFO] System Name: kubernetes-cluster
[INFO] Scheduler: kubernetes
[INFO] CloudAI is already installed.
```