### PR TITLE
Remove unnecessary permission checks and exception handling in NeMoLauncherSlurmInstallStrategy

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_install_strategy.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import logging
-import os
 import subprocess
 from pathlib import Path
 from typing import Any, Dict
@@ -81,11 +80,6 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
         if install_status.success:
             return InstallStatusResult(success=True, message="NeMo-Launcher is already installed.")
 
-        try:
-            self._check_install_path_access()
-        except PermissionError as e:
-            return InstallStatusResult(success=False, message=str(e))
-
         subdir_path = self.system.install_path / self.SUBDIR_PATH
         subdir_path.mkdir(parents=True, exist_ok=True)
 
@@ -118,19 +112,6 @@ class NeMoLauncherSlurmInstallStrategy(SlurmInstallStrategy):
             )
 
         return InstallStatusResult(success=True)
-
-    def _check_install_path_access(self):
-        """
-        Check if the install path exists and if there is permission to create a directory or file in the path.
-
-        Raises
-            PermissionError: If the install path does not exist or if there is no permission to create directories and
-                files.
-        """
-        if not self.system.install_path.exists():
-            raise PermissionError(f"Install path {self.system.install_path} does not exist.")
-        if not self.system.install_path.is_dir() or not os.access(self.system.install_path, os.W_OK):
-            raise PermissionError(f"No permission to write in install path {self.system.install_path}.")
 
     def _clone_repository(self, subdir_path: Path) -> None:
         """


### PR DESCRIPTION
## Summary
Remove unnecessary permission checks and exception handling in NeMoLauncherSlurmInstallStrategy. When the path does not exist or permission is insufficient, other APIs will raise exceptions, and these exceptions will be propagated accordingly. There is no reason to check these edge cases manually if there are no additional benefits.

## Test Plan
CI passes