### PR TITLE
Generate Bash script during Nemo Launcher

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -72,6 +72,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = " ".join(f"{key}={value}" for key, value in self.final_env_vars.items())
         full_cmd = f"{env_vars_str} {full_cmd}" if env_vars_str else full_cmd
 
+        # Log the generated command to a bash file
+        self._log_command_to_file(full_cmd, output_path)
+
         return full_cmd.strip()
 
     def _prepare_environment(self, cmd_args: Dict[str, str], extra_env_vars: Dict[str, str], output_path: Path) -> None:
@@ -128,12 +131,6 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             / NeMoLauncherSlurmInstallStrategy.SUBDIR_PATH
             / NeMoLauncherSlurmInstallStrategy.REPOSITORY_NAME
         ).absolute()
-
-
-        # Log the generated command to a bash file
-        self._log_command_to_file(full_cmd, output_path)
-
-        return full_cmd.strip()
 
     def _set_node_config(self, nodes: List[str], num_nodes: int) -> None:
         """
@@ -220,7 +217,6 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return " ".join(cmd_arg_str_parts + env_var_str_parts)
 
-
     def _log_command_to_file(self, command: str, output_path: Path):
         """Log the generated command to a bash file in the specified output path."""
         log_file = output_path / "generated_command.sh"
@@ -250,4 +246,3 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             return value.replace("\\", "")
 
         return value
-

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -113,6 +113,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = " ".join(f"{key}={value}" for key, value in final_env_vars.items())
         full_cmd = f"{env_vars_str} {full_cmd}" if env_vars_str else full_cmd
 
+        # Log the generated command to a bash file
+        self._log_command_to_file(full_cmd, output_path)
+
         return full_cmd.strip()
 
     def _handle_special_keys(self, key: str, value: Any, launcher_path: str, output_path: str) -> Any:
@@ -157,6 +160,18 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         if nodes:
             nodes_str = ",".join(nodes)
-            cmd_arg_str_parts.append(f"+cluster.nodelist=\\'{nodes_str}\\'")
+            cmd_arg_str_parts.append(f"+cluster.nodelist=\\'{nodes_str}\\'\n")
 
         return " ".join(cmd_arg_str_parts + env_var_str_parts)
+
+    def _log_command_to_file(self, command: str, output_path: Path):
+        """Log the generated command to a bash file in the specified output path."""
+        log_file = output_path / "generated_command.sh"
+
+        # Ensure the output path exists
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+
+        command_with_line_breaks = command.replace(" ", " \\\n ")
+
+        with log_file.open("a") as f:
+            f.write(f"{command_with_line_breaks}\n\n")

--- a/src/cloudai/test_definitions/nemo_launcher.py
+++ b/src/cloudai/test_definitions/nemo_launcher.py
@@ -95,7 +95,7 @@ class NeMoLauncherCmdArgs(CmdArgs):
 
     repository_url: str = "https://github.com/NVIDIA/NeMo-Framework-Launcher.git"
     repository_commit_hash: str = "cf411a9ede3b466677df8ee672bcc6c396e71e1a"
-    docker_image_url: str = "nvcr.io/nvidia/nemo:24.05.01"
+    docker_image_url: str = "nvcr.io/nvidia/nemo:24.01.01"
     stages: str = '["training"]'
     data_dir: str = "~"
     numa_mapping: NumaMapping = Field(default_factory=NumaMapping)

--- a/src/cloudai/test_definitions/nemo_launcher.py
+++ b/src/cloudai/test_definitions/nemo_launcher.py
@@ -94,9 +94,8 @@ class NeMoLauncherCmdArgs(CmdArgs):
 
     repository_url: str = "https://github.com/NVIDIA/NeMo-Framework-Launcher.git"
     repository_commit_hash: str = "cf411a9ede3b466677df8ee672bcc6c396e71e1a"
-    docker_image_url: str = "nvcr.io/nvidian/nemofw-training:24.01.01"
+    docker_image_url: str = "nvcr.io/nvidia/nemo:24.05.01"
     stages: str = '["training"]'
-    data_dir: str = "DATA_DIR"
     numa_mapping: NumaMapping = Field(default_factory=NumaMapping)
     cluster: Cluster = Field(default_factory=Cluster)
     training: Training = Field(default_factory=Training)

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -423,10 +423,6 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             nodes=[],
         )
 
-        # Check that the logging function is called with the correct path
-        log_file_path = output_path / "generated_command.sh"
-        mock_file.assert_called_with("a")
-
         # Retrieve the actual written command from the mock file handler
         written_content = mock_file().write.call_args[0][0]
 

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -473,6 +473,9 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_impl": "not_mock",
+            "data_dir": "/fake/data_dir",
+            "data_prefix": "[]",
         }
 
         # Define the output path
@@ -507,8 +510,10 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_impl": "not_mock",
+            "data_dir": "/fake/data_dir",
+            "data_prefix": "[]",
         }
-
         # Define the output path
         output_path = tmp_path / "output_dir"
         output_path.mkdir()

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -16,7 +16,7 @@
 
 from pathlib import Path
 from typing import Optional
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 from cloudai.schema.test_template.jax_toolbox.slurm_command_gen_strategy import JaxToolboxSlurmCommandGenStrategy
@@ -392,6 +392,72 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
                 num_nodes=1,
                 nodes=[],
             )
+
+    @patch("pathlib.Path.open", new_callable=mock_open)
+    def test_log_command_to_file(self, mock_file, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy, tmp_path: Path):
+        """Test that the command is correctly logged with line breaks."""
+        # Define the command arguments
+        extra_env_vars = {"TEST_VAR_1": "value1"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+        }
+
+        # Define the output path
+        output_path = tmp_path / "output_dir"
+        output_path.mkdir()
+
+        # Generate the command and trigger the logging without assigning to a variable
+        nemo_cmd_gen.gen_exec_command(
+            cmd_args=cmd_args,
+            extra_env_vars=extra_env_vars,
+            extra_cmd_args="",
+            output_path=output_path,
+            num_nodes=1,
+            nodes=[],
+        )
+
+        # Check that the logging function is called with the correct path
+        log_file_path = output_path / "generated_command.sh"
+        mock_file.assert_called_with("a")
+
+        # Retrieve the actual written command from the mock file handler
+        written_content = mock_file().write.call_args[0][0]
+
+        # Ensure that the logged command has line breaks for readability
+        assert " \\\n " in written_content, "Command should contain line breaks when written to the file"
+        assert "python" in written_content, "Logged command should start with 'python'"
+        assert "TEST_VAR_1=value1" in written_content, "Logged command should contain environment variables"
+        assert "training.trainer.num_nodes=1" in written_content, "Command should contain the number of nodes"
+
+    def test_no_line_breaks_in_executed_command(
+        self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy, tmp_path: Path
+    ):
+        """Test that the command used for execution has no line breaks."""
+        extra_env_vars = {"TEST_VAR_1": "value1"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+        }
+
+        # Define the output path
+        output_path = tmp_path / "output_dir"
+        output_path.mkdir()
+
+        # Generate the command
+        cmd = nemo_cmd_gen.gen_exec_command(
+            cmd_args=cmd_args,
+            extra_env_vars=extra_env_vars,
+            extra_cmd_args="",
+            output_path=output_path,
+            num_nodes=1,
+            nodes=[],
+        )
+
+        # Assert that there are no line breaks in the executed command
+        assert "\n" not in cmd, "Executed command should not contain line breaks"
 
 
 class TestWriteSbatchScript:


### PR DESCRIPTION
## Summary
The current Nemo launcher in CloudAI generates the command and writes out the command in stdout. This PR logs the generated command into a readable bash script. This is consistent with how other frameworks implement the command generation logic in CloudAI.

## Test Plan
CI/CD- Added two new unit tests 
Tested on CW.

```
(venv) srivatsank@cw-dfw-cs-001-dc-01:/lustre/fsw/portfolios/coreai/users/srivatsank/workspace/dev/cloudaix$ python cloudaix.py --mode run --system-config conf/common/system/coreweave.toml  --tests-dir conf/staging/gca_e2e/test --test-scenario conf/staging/gca_e2e/test_scenario/nemo_proxy/test_scenario_cw.toml                                                                                          
/lustre/fsw/portfolios/coreai/users/srivatsank/workspace/dev/cloudaix/venv/lib/python3.10/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.12) doesn't match a supported version!                                                                                                                                                 
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "                                                                                                                                                                                                                                                                                                                
[INFO] System configuration file: conf/common/system/coreweave.toml                                                                                                                                                                                                                                                                                                                                              
[INFO] Tests directory: conf/staging/gca_e2e/test                                                                                                                                                                                                                                                                                                                                                                
[INFO] Test scenario file: conf/staging/gca_e2e/test_scenario/nemo_proxy/test_scenario_cw.toml                                                                                                                                                                                                                                                                                                                   
[INFO] Output directory: None                                                                                                                                                                                                                                                                                                                                                                                    
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem                                                                                                                                                                                                                                                                                                                                                
[WARNING] No JsonGenStrategy found for TestParser and SlurmSystem
[INFO] System Name: coreweave                                                                       
[INFO] Scheduler: slurm                                                                             
[INFO] Test Scenario Name: Nemo-Launcher                                                            
[INFO] Checking if test templates are installed.                                                    
[INFO] Test Scenario: Nemo-Launcher                                                                 

Section Name: Tests.1                                                                               
  Test Name: sanity_bf16_grok1_64_nemo                                                              
  Description: sanity_bf16_grok1_64_nemo                                                            
  No dependencies                                                                                   
[INFO] Initializing Runner [RUN] mode                                                               
[INFO] Creating SlurmRunner                                                                         
[INFO] Starting test scenario execution.                                                            
[INFO] Starting test: Tests.1                                                                       
[INFO] Running test: Tests.1                                                                        

```

Generated Bash script

```
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
 NCCL_NVLS_ENABLE=0 \
 NCCL_IB_SL=0 \
 NCCL_PROTO=LL128 \
 HYDRA_FULL_ERROR=1 \
 python \
 install/NeMo-Launcher/NeMo-Launcher/launcher_scripts/main.py \
 stages=["training"] \
 numa_mapping.enable=True \
 cluster.gpus_per_node=8 \
 training.exp_manager.create_checkpoint_callback=False \
 training.trainer.max_steps=xx \
 training.trainer.val_check_interval=xx \
 training.trainer.log_every_n_steps=xx \
 training.trainer.enable_checkpointing=xx \
 training.model.global_batch_size=xx \
 training.model.micro_batch_size=xxx \
 training.model.tensor_model_parallel_size=xx \
 training.model.pipeline_model_parallel_size=xx\
 training.model.data.data_prefix=["1.0",'${data_dir}/xxxx] \
 training.run.time_limit=3:00:00 \
 training.run.name=run \
 time_limit=00:50:00 \
 base_results_dir=xxxx \
 training.model.data.index_mapping_dir=xxxx \
 launcher_scripts_path=install/NeMo-Launcher/NeMo-Launcher/launcher_scripts \
 training=xxx/xxx \
 cluster.partition=xx \
 training.trainer.num_nodes=xx \
 container=xxx \
 cluster.account=xxxx \
 cluster.job_name_prefix=xxxx-cloudai.nemo: \
 +env_vars.CUDA_VISIBLE_DEVICES=\'0,1,2,3,4,5,6,7\' \
 training.run.time_limit=01:00:00 \
 training.trainer.max_time=00:04:00:00 \
 training.model.data.data_impl=mock \
 training.model.data.data_prefix=[] \
 training.model.data.index_mapping_dir \
 training.model.optim.grad_sync_dtype=xx \
 training.model.sequence_parallel=xx \
 training.trainer.num_nodes=xx \
 training.model.tensor_model_parallel_size=xx\
 training.model.pipeline_model_parallel_size=x\
 training.model.virtual_pipeline_model_parallel_size=xx\
 training.model.context_parallel_size=xx\
 training.model.gradient_accumulation_fusion=xx \
 training.model.moe_grouped_gemm=xx \
 training.model.overlap_p2p_comm=xx \
 training.model.batch_p2p_comm=xx \
 training.exp_manager.resume_if_exists=xx \
 training.model.nsys_profile.enabled=xx \
 training.model.nsys_profile.start_step=xx \
 training.model.nsys_profile.end_step=xx \
 training.model.nsys_profile.gen_shape=xx \
 training.model.nsys_profile.ranks=[x] \
 training.model.nsys_profile.trace=[xxx]
```           

