### PR TITLE
Use absolute paths in NeMo launcher

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -40,14 +40,15 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             self.system.install_path
             / NeMoLauncherSlurmInstallStrategy.SUBDIR_PATH
             / NeMoLauncherSlurmInstallStrategy.REPOSITORY_NAME
-        )
+        ).absolute()
+        output_path_abs = output_path.absolute()
         overriden_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
         self.final_cmd_args = {
-            k: self._handle_special_keys(k, v, str(launcher_path), str(output_path))
+            k: self._handle_special_keys(k, v, str(launcher_path), str(output_path_abs))
             for k, v in overriden_cmd_args.items()
         }
-        self.final_cmd_args["base_results_dir"] = str(output_path)
-        self.final_cmd_args["training.model.data.index_mapping_dir"] = str(output_path)
+        self.final_cmd_args["base_results_dir"] = str(output_path_abs)
+        self.final_cmd_args["training.model.data.index_mapping_dir"] = str(output_path_abs)
         self.final_cmd_args["launcher_scripts_path"] = str(launcher_path / "launcher_scripts")
 
         for key, value in final_env_vars.items():


### PR DESCRIPTION
## Summary
CloudAI team found that absolute paths should be passed to NeMo launcher arguments. Otherwise, there can be an error because a Slurm system may not allow relative paths in container-mounts.

## Test Plan
1. CI passes
2. [Ran on a server](https://github.com/Mellanox/cloudaix/pull/54)