### PR TITLE
Unset argument in NeMo launcher when its value is ~

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -154,7 +154,10 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                     value = f"\\'{value}\\'"
                 env_var_str_parts.append(f"+{key}={value}")
             else:
-                cmd_arg_str_parts.append(f"{key}={value}")
+                if value == "~":
+                    cmd_arg_str_parts.append(f"~{key}=null")
+                else:
+                    cmd_arg_str_parts.append(f"{key}={value}")
 
         if nodes:
             nodes_str = ",".join(nodes)

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -398,6 +398,25 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
                 nodes=[],
             )
 
+    def test_argument_with_tilde_value(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
+        extra_env_vars = {"TEST_VAR_1": "value1"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+            "training.model.optim.bucket_cap_mb": "~",
+        }
+
+        cmd = nemo_cmd_gen.gen_exec_command(
+            cmd_args=cmd_args,
+            extra_env_vars=extra_env_vars,
+            extra_cmd_args="",
+            output_path=Path(""),
+            num_nodes=1,
+            nodes=[],
+        )
+        assert "~training.model.optim.bucket_cap_mb=null" in cmd
+
 
 class TestWriteSbatchScript:
     MANDATORY_ARGS = {


### PR DESCRIPTION
## Summary
It is essential to support removing keys. Hydra allows users to remove keys with `~`, and it should be supported. Once `~` is found in the value, the key is removed. This is necessary for some test scenarios.

## Test Plan
* CI passes. Added a unit test.
* It works on a server with additional commits as shown at [here](https://github.com/Mellanox/cloudaix/pull/54)