### PR TITLE
Use mock data by default in NeMo launcher

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -59,6 +59,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         self._validate_data_config()
 
+        if self.final_cmd_args.get("training.model.data.data_impl") == "mock":
+            self.final_cmd_args.pop("data_dir", None)
+
         cmd_args_str = self._generate_cmd_args_str(self.final_cmd_args, nodes)
 
         full_cmd = f"python {self._launcher_scripts_path()}/launcher_scripts/main.py {cmd_args_str}"

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -86,12 +86,22 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             self.slurm_system.gpus_per_node if self.slurm_system.gpus_per_node is not None else "null"
         )
 
-        if ("data_dir" in self.final_cmd_args) and (self.final_cmd_args["data_dir"] == "DATA_DIR"):
-            raise ValueError(
-                "The 'data_dir' field of the NeMo launcher test contains the placeholder 'DATA_DIR'. "
-                "Please update the test schema TOML file with a valid path to the dataset. "
-                "The 'data_dir' field must point to an actual dataset location, not a placeholder."
-            )
+        if self.final_cmd_args.get("training.model.data.data_impl") != "mock":
+            data_dir = self.final_cmd_args.get("data_dir")
+            data_prefix = self.final_cmd_args.get("training.model.data.data_prefix")
+
+            if data_dir is None or data_dir == "~":
+                raise ValueError(
+                    "The 'data_dir' field of the NeMo launcher test contains an invalid placeholder '~'. "
+                    "Please provide a valid path to the dataset in the test schema TOML file. "
+                    "The 'data_dir' field must point to an actual dataset location."
+                )
+
+            if data_prefix == "[]":
+                raise ValueError(
+                    "The 'data_prefix' field of the NeMo launcher test is missing or empty. "
+                    "Please update the test schema TOML file with a valid prefix for the training datasets."
+                )
 
         cmd_args_str = self._generate_cmd_args_str(self.final_cmd_args, nodes)
 

--- a/src/cloudai/test_definitions/nemo_launcher.py
+++ b/src/cloudai/test_definitions/nemo_launcher.py
@@ -56,7 +56,8 @@ class TrainingModelData(BaseModel):
     """Training model data configuration."""
 
     model_config = ConfigDict(extra="forbid")
-    data_prefix: str = "[\"1.0\",'${data_dir}/my-gpt3_00_text_document']"
+    data_prefix: str = "[]"
+    data_impl: str = "mock"
 
 
 class TrainingModel(BaseModel):
@@ -96,7 +97,7 @@ class NeMoLauncherCmdArgs(CmdArgs):
     repository_commit_hash: str = "cf411a9ede3b466677df8ee672bcc6c396e71e1a"
     docker_image_url: str = "nvcr.io/nvidian/nemofw-training:24.01.01"
     stages: str = '["training"]'
-    data_dir: str = "DATA_DIR"
+    data_dir: str = "~"
     numa_mapping: NumaMapping = Field(default_factory=NumaMapping)
     cluster: Cluster = Field(default_factory=Cluster)
     training: Training = Field(default_factory=Training)

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -206,6 +206,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
         cmd = nemo_cmd_gen.gen_exec_command(
             cmd_args=cmd_args,
@@ -225,6 +226,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
         cmd = nemo_cmd_gen.gen_exec_command(
             cmd_args=cmd_args,
@@ -243,6 +245,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
         tokenizer_path = tmp_path / "tokenizer"
         tokenizer_path.touch()
@@ -264,6 +267,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
         nemo_cmd_gen.slurm_system.extra_srun_args = "--reservation my-reservation"
         cmd = nemo_cmd_gen.gen_exec_command(
@@ -283,6 +287,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
         invalid_tokenizer_path = Path("/invalid/path/to/tokenizer")
 
@@ -309,6 +314,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
 
         nemo_cmd_gen.slurm_system.account = "test_account"
@@ -330,6 +336,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
 
         nemo_cmd_gen.slurm_system.account = None
@@ -351,6 +358,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "docker_image_url": "fake",
             "repository_url": "fake",
             "repository_commit_hash": "fake",
+            "data_dir": "/fake/data_dir",
         }
 
         nemo_cmd_gen.slurm_system.gpus_per_node = 4
@@ -377,27 +385,6 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
 
         assert "cluster.gpus_per_node=null" in cmd
 
-    def test_data_dir_validation(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
-        extra_env_vars = {"TEST_VAR_1": "value1"}
-        cmd_args = {
-            "docker_image_url": "fake",
-            "repository_url": "fake",
-            "repository_commit_hash": "fake",
-            "data_dir": "DATA_DIR",  # Invalid placeholder
-        }
-
-        with pytest.raises(
-            ValueError, match="The 'data_dir' field of the NeMo launcher test contains the placeholder 'DATA_DIR'."
-        ):
-            nemo_cmd_gen.gen_exec_command(
-                cmd_args=cmd_args,
-                extra_env_vars=extra_env_vars,
-                extra_cmd_args="",
-                output_path=Path(""),
-                num_nodes=1,
-                nodes=[],
-            )
-
     def test_argument_with_tilde_value(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
         extra_env_vars = {"TEST_VAR_1": "value1"}
         cmd_args = {
@@ -405,6 +392,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             "repository_url": "fake",
             "repository_commit_hash": "fake",
             "training.model.optim.bucket_cap_mb": "~",
+            "data_dir": "/fake/data_dir",
         }
 
         cmd = nemo_cmd_gen.gen_exec_command(
@@ -416,6 +404,65 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
             nodes=[],
         )
         assert "~training.model.optim.bucket_cap_mb=null" in cmd
+
+    def test_data_impl_mock_skips_checks(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
+        extra_env_vars = {"TEST_VAR_1": "value1"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+            "data_impl": "mock",
+            "data_dir": "DATA_DIR",
+        }
+
+        cmd = nemo_cmd_gen.gen_exec_command(
+            cmd_args=cmd_args,
+            extra_env_vars=extra_env_vars,
+            extra_cmd_args="",
+            output_path=Path(""),
+            num_nodes=1,
+            nodes=[],
+        )
+        assert "data_dir" in cmd
+
+    def test_data_dir_and_data_prefix_validation(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy):
+        extra_env_vars = {"TEST_VAR_1": "value1"}
+        cmd_args = {
+            "docker_image_url": "fake",
+            "repository_url": "fake",
+            "repository_commit_hash": "fake",
+            "data_impl": "not_mock",
+            "data_dir": "~",
+            "training.model.data.data_prefix": "[]",
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "The 'data_dir' field of the NeMo launcher test contains an invalid placeholder '~'. "
+                "Please provide a valid path to the dataset in the test schema TOML file. "
+                "The 'data_dir' field must point to an actual dataset location."
+            ),
+        ):
+            nemo_cmd_gen.gen_exec_command(
+                cmd_args=cmd_args,
+                extra_env_vars=extra_env_vars,
+                extra_cmd_args="",
+                output_path=Path(""),
+                num_nodes=1,
+                nodes=[],
+            )
+
+        cmd_args["data_dir"] = "/fake/data_dir"
+        with pytest.raises(ValueError, match="The 'data_prefix' field of the NeMo launcher test is missing or empty."):
+            nemo_cmd_gen.gen_exec_command(
+                cmd_args=cmd_args,
+                extra_env_vars=extra_env_vars,
+                extra_cmd_args="",
+                output_path=Path(""),
+                num_nodes=1,
+                nodes=[],
+            )
 
 
 class TestWriteSbatchScript:


### PR DESCRIPTION
## Summary
* **Use mock data by default in NeMo**: Set data_prefix to "[]", data_impl to "mock", "data_dir" to "~".
* **Validate NeMo launcher arguments**: Check data_dir and data_prefix only when data_impl is not mock
* **Make ruff happy**: Refactor NeMoLauncherSlurmCommandGenStrategy to lower the complexity of gen_exec_command.
* **Remove data_dir argument when data_impl==mock**

## Test Plan
1. CI passes
2. [Ran on a server.](https://github.com/Mellanox/cloudaix/pull/54)