### PR TITLE
Remove unnecessary indirections

### DIFF
--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -326,7 +326,7 @@ class BaseRunner(ABC):
         Returns:
             JobStatusResult: The result containing the job status and an optional error message.
         """
-        return job.test_run.test.get_job_status(job.output_path)
+        return job.test_run.test.test_template.get_job_status(job.output_path)
 
     async def handle_job_completion(self, completed_job: BaseJob):
         """

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 
-from .job_status_result import JobStatusResult
 from .test_template import TestTemplate
 
 
@@ -170,18 +169,6 @@ class Test:
             Optional[int]: The retrieved job ID, or None if not found.
         """
         return self.test_template.get_job_id(stdout, stderr)
-
-    def get_job_status(self, output_path: Path) -> JobStatusResult:
-        """
-        Determine the status of a job based on the outputs located in the given output directory.
-
-        Args:
-            output_path (Path): Path to the output directory.
-
-        Returns:
-            JobStatusResult: The result containing the job status and an optional error message.
-        """
-        return self.test_template.get_job_status(output_path)
 
     def has_more_iterations(self) -> bool:
         """

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -157,19 +157,6 @@ class Test:
             nodes,
         )
 
-    def get_job_id(self, stdout: str, stderr: str) -> Optional[int]:
-        """
-        Retrieve the job ID using the test template's method.
-
-        Args:
-            stdout (str): Standard output from the command execution.
-            stderr (str): Standard error from the command execution.
-
-        Returns:
-            Optional[int]: The retrieved job ID, or None if not found.
-        """
-        return self.test_template.get_job_id(stdout, stderr)
-
     def has_more_iterations(self) -> bool:
         """
         Check if the test has more iterations to run.

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -60,7 +60,7 @@ class SlurmRunner(BaseRunner):
         job_id = 0
         if self.mode == "run":
             stdout, stderr = self.cmd_shell.execute(exec_cmd).communicate()
-            job_id = tr.test.get_job_id(stdout, stderr)
+            job_id = tr.test.test_template.get_job_id(stdout, stderr)
             if job_id is None:
                 raise JobIdRetrievalError(
                     test_name=str(tr.test.section_name),

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -60,7 +60,7 @@ class StandaloneRunner(BaseRunner):
         job_id = 0
         if self.mode == "run":
             pid = self.cmd_shell.execute(exec_cmd).pid
-            job_id = tr.test.get_job_id(str(pid), "")
+            job_id = tr.test.test_template.get_job_id(str(pid), "")
             if job_id is None:
                 raise JobIdRetrievalError(
                     test_name=str(tr.test.section_name),

--- a/tests/test_job_submission_error.py
+++ b/tests/test_job_submission_error.py
@@ -44,6 +44,7 @@ class MockTest(Test):
         self.name = "Mock Test"
         self.description = "A mock test description"
         self.test_template = MagicMock(spec=TestTemplate)
+        self.test_template.get_job_id.return_value = None
         self.env_vars = {}
         self.cmd_args = {}
         self.extra_env_vars = {}
@@ -53,9 +54,6 @@ class MockTest(Test):
 
     def gen_exec_command(self, *_, **__):
         return "sbatch mock_script.sh"
-
-    def get_job_id(self, stdout, stderr):
-        return None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
The Test class has two methods, get_job_id and get_job_status, but these functions merely call the same methods from the TestTemplate class, which is unnecessary. This PR removes the redundant indirections.

## Test Plan
CI passes