### PR TITLE
Pass TestRun to gen_exec_command and gen_json

### DIFF
--- a/src/cloudai/_core/base_job.py
+++ b/src/cloudai/_core/base_job.py
@@ -34,7 +34,7 @@ class BaseJob:
         terminated_by_dependency (bool): Flag to indicate if the job was terminated due to a dependency.
     """
 
-    def __init__(self, mode: str, system: System, test_run: TestRun, output_path: Path):
+    def __init__(self, mode: str, system: System, test_run: TestRun):
         """
         Initialize a BaseJob instance.
 
@@ -42,13 +42,12 @@ class BaseJob:
             mode (str): The mode of the job (e.g., 'run', 'dry-run').
             system (System): The system in which the job is running.
             test_run (TestRun): The TestRun instance associated with this job.
-            output_path (Path): The path where the job's output is stored.
         """
         self.id: Union[str, int] = 0
         self.mode: str = mode
         self.system: System = system
         self.test_run: TestRun = test_run
-        self.output_path: Path = output_path
+        self.output_path: Path = test_run.output_path
         self.terminated_by_dependency: bool = False
 
     def is_running(self) -> bool:

--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from pathlib import Path
-from typing import Dict, List
+
+from cloudai._core.test_scenario import TestRun
 
 from .test_template_strategy import TestTemplateStrategy
 
@@ -29,25 +29,12 @@ class CommandGenStrategy(TestTemplateStrategy):
     """
 
     @abstractmethod
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
+    def gen_exec_command(self, tr: TestRun) -> str:
         """
         Generate the execution command for a test based on the given parameters.
 
         Args:
-            cmd_args (Dict[str, str]): Command-line arguments for the test.
-            extra_env_vars (Dict[str, str]): Additional environment variables.
-            extra_cmd_args (str): Additional command-line arguments.
-            output_path (Path): Path to the output directory.
-            num_nodes (int): The number of nodes to be used for the test execution.
-            nodes (List[str]): List of nodes for test execution, optional.
+            tr (TestRun): Contains the test and its run-specific configurations.
 
         Returns:
             str: The generated execution command.

--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -16,8 +16,7 @@
 
 from abc import abstractmethod
 
-from cloudai._core.test_scenario import TestRun
-
+from .test_scenario import TestRun
 from .test_template_strategy import TestTemplateStrategy
 
 

--- a/src/cloudai/_core/json_gen_strategy.py
+++ b/src/cloudai/_core/json_gen_strategy.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
+from .test_scenario import TestRun
 from .test_template_strategy import TestTemplateStrategy
 
 
@@ -29,27 +29,12 @@ class JsonGenStrategy(TestTemplateStrategy):
     """
 
     @abstractmethod
-    def gen_json(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        job_name: str,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> Dict[Any, Any]:
+    def gen_json(self, tr: TestRun) -> Dict[Any, Any]:
         """
         Generate the Kubernetes job specification based on the given parameters.
 
         Args:
-            cmd_args (Dict[str, str]): Command-line arguments for the job.
-            extra_env_vars (Dict[str, str]): Additional environment variables.
-            extra_cmd_args (str): Additional command-line arguments.
-            output_path (Path): Path to the output directory.
-            job_name (str): The name of the job.
-            num_nodes (int): The number of nodes to be used for job execution.
-            nodes (List[str]): List of nodes for job execution, optional.
+            tr (TestRun): Contains the test and its run-specific configurations.
 
         Returns:
             Dict[Any, Any]: The generated Kubernetes job specification in JSON format.

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 
 import sys
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -90,71 +89,6 @@ class Test:
             f"extra_cmd_args={self.extra_cmd_args}, "
             f"section_name={self.section_name}, "
             f"dependencies={self.dependencies}, iterations={self.iterations}, "
-        )
-
-    def gen_exec_command(
-        self, output_path: Path, time_limit: Optional[str] = None, num_nodes: int = 1, nodes: Optional[List[str]] = None
-    ) -> str:
-        """
-        Generate the command to run this specific test.
-
-        Args:
-            output_path (Path): Path to the output directory where logs and results will be stored.
-            time_limit (Optional[str]): Time limit for the test execution.
-            num_nodes (Optional[int]): Number of nodes to be used for the test execution.
-            nodes (Optional[List[str]]): List of nodes involved in the test.
-
-        Returns:
-            str: The command string.
-        """
-        if time_limit is not None:
-            self.cmd_args["time_limit"] = time_limit
-        if not nodes:
-            nodes = []
-
-        return self.test_template.gen_exec_command(
-            self.cmd_args,
-            self.extra_env_vars,
-            self.extra_cmd_args,
-            output_path,
-            num_nodes,
-            nodes,
-        )
-
-    def gen_json(
-        self,
-        output_path: Path,
-        job_name: str,
-        time_limit: Optional[str] = None,
-        num_nodes: int = 1,
-        nodes: Optional[List[str]] = None,
-    ) -> Dict[Any, Any]:
-        """
-        Generate a JSON dictionary representing the Kubernetes job specification for this test.
-
-        Args:
-            output_path (Path): Path to the output directory where logs and results will be stored.
-            job_name (str): The name assigned to the Kubernetes job.
-            time_limit (Optional[str]): Time limit for the test execution.
-            num_nodes (Optional[int]): Number of nodes to be used for the test execution.
-            nodes (Optional[List[str]]): List of nodes involved in the test.
-
-        Returns:
-            Dict[Any, Any]: A dictionary representing the Kubernetes job specification.
-        """
-        if time_limit is not None:
-            self.cmd_args["time_limit"] = time_limit
-        if not nodes:
-            nodes = []
-
-        return self.test_template.gen_json(
-            self.cmd_args,
-            self.extra_env_vars,
-            self.extra_cmd_args,
-            output_path,
-            job_name,
-            num_nodes,
-            nodes,
         )
 
     def has_more_iterations(self) -> bool:

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -15,19 +15,23 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
 
-from .test import Test
+if TYPE_CHECKING:
+    from .test import Test
 
 
 @dataclass
 class TestRun:
     __test__ = False
 
-    test: Test
+    test: "Test"
     num_nodes: int
     nodes: List[str]
+    output_path: Path = Path("")
     time_limit: Optional[str] = None
+    job_name: str = ""
 
 
 class TestScenario:

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from .command_gen_strategy import CommandGenStrategy
 from .grading_strategy import GradingStrategy
@@ -27,6 +27,7 @@ from .job_status_retrieval_strategy import JobStatusRetrievalStrategy
 from .json_gen_strategy import JsonGenStrategy
 from .report_generation_strategy import ReportGenerationStrategy
 from .system import System
+from .test_scenario import TestRun
 
 
 class TestTemplate:
@@ -121,88 +122,39 @@ class TestTemplate:
 
         return InstallStatusResult(success=True)
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
+    def gen_exec_command(self, tr: TestRun) -> str:
         """
         Generate an execution command for a test using this template.
 
-        This method must be implemented by subclasses.
-
         Args:
-            cmd_args (Dict[str, str]): Command-line arguments for the test.
-            extra_env_vars (Dict[str, str]): Extra environment variables.
-            extra_cmd_args (str): Extra command-line arguments.
-            output_path (Path): Path to the output directory.
-            num_nodes (int): The number of nodes to be used for the test execution.
-            nodes (List[str]): A list of nodes where the test will be executed.
+            tr (TestRun): Contains the test and its run-specific configurations.
 
         Returns:
             str: The generated execution command.
         """
-        if not nodes:
-            nodes = []
         if self.command_gen_strategy is None:
             raise ValueError(
                 "command_gen_strategy is missing. Ensure the strategy is registered in the Registry "
                 "by calling the appropriate registration function for the system type."
             )
-        return self.command_gen_strategy.gen_exec_command(
-            cmd_args,
-            extra_env_vars,
-            extra_cmd_args,
-            output_path,
-            num_nodes,
-            nodes,
-        )
+        return self.command_gen_strategy.gen_exec_command(tr)
 
-    def gen_json(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        job_name: str,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> Dict[Any, Any]:
+    def gen_json(self, tr: TestRun) -> Dict[Any, Any]:
         """
         Generate a JSON string representing the Kubernetes job specification for this test using this template.
 
         Args:
-            cmd_args (Dict[str, str]): Command-line arguments for the test.
-            extra_env_vars (Dict[str, str]): Extra environment variables.
-            extra_cmd_args (str): Extra command-line arguments.
-            output_path (Path): Path to the output directory.
-            job_name (str): The name of the job.
-            num_nodes (int): The number of nodes to be used for the test execution.
-            nodes (List[str]): A list of nodes where the test will be executed.
+            tr (TestRun): Contains the test and its run-specific configurations.
 
         Returns:
             Dict[Any, Any]: A dictionary representing the Kubernetes job specification.
         """
-        if not nodes:
-            nodes = []
         if self.json_gen_strategy is None:
             raise ValueError(
                 "json_gen_strategy is missing. Ensure the strategy is registered in the Registry "
                 "by calling the appropriate registration function for the system type."
             )
-        return self.json_gen_strategy.gen_json(
-            cmd_args,
-            extra_env_vars,
-            extra_cmd_args,
-            output_path,
-            job_name,
-            num_nodes,
-            nodes,
-        )
+        return self.json_gen_strategy.gen_json(tr)
 
     def get_job_id(self, stdout: str, stderr: str) -> Optional[int]:
         """

--- a/src/cloudai/runner/kubernetes/kubernetes_job.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_job.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 
-from pathlib import Path
-
 from cloudai import BaseJob, System, TestRun
 
 
@@ -31,12 +29,9 @@ class KubernetesJob(BaseJob):
         namespace (str): The namespace of the job.
         name (str): The name of the job.
         kind (str): The kind of the job.
-        output_path (Path): The path where the job's output is stored.
     """
 
-    def __init__(
-        self, mode: str, system: System, test_run: TestRun, namespace: str, name: str, kind: str, output_path: Path
-    ):
+    def __init__(self, mode: str, system: System, test_run: TestRun, namespace: str, name: str, kind: str):
         """
         Initialize a KubernetesJob instance.
 
@@ -47,9 +42,8 @@ class KubernetesJob(BaseJob):
             namespace (str): The namespace of the job.
             name (str): The name of the job.
             kind (str): The kind of the job.
-            output_path (Path): The path where the job's output is stored.
         """
-        super().__init__(mode, system, test_run, output_path)
+        super().__init__(mode, system, test_run)
         self.id = name
         self.namespace = namespace
         self.name = name

--- a/src/cloudai/runner/kubernetes/kubernetes_runner.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_runner.py
@@ -37,9 +37,9 @@ class KubernetesRunner(BaseRunner):
             KubernetesJob: A KubernetesJob object containing job details.
         """
         logging.info(f"Running test: {tr.test.section_name}")
-        job_output_path = self.get_job_output_path(tr.test)
+        tr.output_path = self.get_job_output_path(tr.test)
         job_name = tr.test.section_name.replace(".", "-").lower()
-        job_spec = tr.test.gen_json(job_output_path, job_name, tr.time_limit, tr.num_nodes, tr.nodes)
+        job_spec = tr.test.test_template.gen_json(tr)
         job_kind = job_spec.get("kind", "").lower()
         logging.info(f"Generated JSON string for test {tr.test.section_name}: {job_spec}")
         job_namespace = ""
@@ -48,7 +48,7 @@ class KubernetesRunner(BaseRunner):
             k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
             job_name, job_namespace = k8s_system.create_job(job_spec)
 
-        return KubernetesJob(self.mode, self.system, tr, job_namespace, job_name, job_kind, job_output_path)
+        return KubernetesJob(self.mode, self.system, tr, job_namespace, job_name, job_kind, tr.output_path)
 
     async def job_completion_callback(self, job: BaseJob) -> None:
         """

--- a/src/cloudai/runner/kubernetes/kubernetes_runner.py
+++ b/src/cloudai/runner/kubernetes/kubernetes_runner.py
@@ -48,7 +48,7 @@ class KubernetesRunner(BaseRunner):
             k8s_system: KubernetesSystem = cast(KubernetesSystem, self.system)
             job_name, job_namespace = k8s_system.create_job(job_spec)
 
-        return KubernetesJob(self.mode, self.system, tr, job_namespace, job_name, job_kind, tr.output_path)
+        return KubernetesJob(self.mode, self.system, tr, job_namespace, job_name, job_kind)
 
     async def job_completion_callback(self, job: BaseJob) -> None:
         """

--- a/src/cloudai/runner/slurm/slurm_job.py
+++ b/src/cloudai/runner/slurm/slurm_job.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Union
 
 from cloudai import BaseJob, System, TestRun
@@ -28,8 +27,8 @@ class SlurmJob(BaseJob):
         id (Union[str, int]): The unique identifier of the job.
     """
 
-    def __init__(self, mode: str, system: System, test_run: TestRun, job_id: Union[str, int], output_path: Path):
-        BaseJob.__init__(self, mode, system, test_run, output_path)
+    def __init__(self, mode: str, system: System, test_run: TestRun, job_id: Union[str, int]):
+        BaseJob.__init__(self, mode, system, test_run)
         self.id = job_id
 
     def __repr__(self) -> str:

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -53,9 +53,9 @@ class SlurmRunner(BaseRunner):
             SlurmJob: A SlurmJob object
         """
         logging.info(f"Running test: {tr.test.section_name}")
-        job_output_path = self.get_job_output_path(tr.test)
+        tr.output_path = self.get_job_output_path(tr.test)
 
-        exec_cmd = tr.test.gen_exec_command(job_output_path, tr.time_limit, tr.num_nodes, tr.nodes)
+        exec_cmd = tr.test.test_template.gen_exec_command(tr)
         logging.info(f"Executing command for test {tr.test.section_name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
@@ -69,4 +69,4 @@ class SlurmRunner(BaseRunner):
                     stderr=stderr,
                     message="Failed to retrieve job ID from command output.",
                 )
-        return SlurmJob(self.mode, self.system, tr, job_id, job_output_path)
+        return SlurmJob(self.mode, self.system, tr, job_id, tr.output_path)

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -69,4 +69,4 @@ class SlurmRunner(BaseRunner):
                     stderr=stderr,
                     message="Failed to retrieve job ID from command output.",
                 )
-        return SlurmJob(self.mode, self.system, tr, job_id, tr.output_path)
+        return SlurmJob(self.mode, self.system, tr, job_id)

--- a/src/cloudai/runner/standalone/standalone_job.py
+++ b/src/cloudai/runner/standalone/standalone_job.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Union
 
 from cloudai import BaseJob, System, TestRun
@@ -28,8 +27,8 @@ class StandaloneJob(BaseJob):
         id (Union[str, int]): The unique identifier of the job.
     """
 
-    def __init__(self, mode: str, system: System, test_run: TestRun, job_id: Union[str, int], output_path: Path):
-        BaseJob.__init__(self, mode, system, test_run, output_path)
+    def __init__(self, mode: str, system: System, test_run: TestRun, job_id: Union[str, int]):
+        BaseJob.__init__(self, mode, system, test_run)
         self.id = job_id
 
     def __repr__(self) -> str:

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import logging
-from pathlib import Path
 
 from cloudai import BaseRunner, JobIdRetrievalError, System, TestRun, TestScenario
 from cloudai.util import CommandShell
@@ -69,4 +68,4 @@ class StandaloneRunner(BaseRunner):
                     stderr="",
                     message="Failed to retrieve job ID from command output.",
                 )
-        return StandaloneJob(self.mode, self.system, tr, job_id, Path(tr.output_path))
+        return StandaloneJob(self.mode, self.system, tr, job_id)

--- a/src/cloudai/runner/standalone/standalone_runner.py
+++ b/src/cloudai/runner/standalone/standalone_runner.py
@@ -54,8 +54,8 @@ class StandaloneRunner(BaseRunner):
             StandaloneJob: A StandaloneJob object
         """
         logging.info(f"Running test: {tr.test.section_name}")
-        job_output_path = self.get_job_output_path(tr.test)
-        exec_cmd = tr.test.gen_exec_command(job_output_path, tr.time_limit, tr.num_nodes, tr.nodes)
+        tr.output_path = self.get_job_output_path(tr.test)
+        exec_cmd = tr.test.test_template.gen_exec_command(tr)
         logging.info(f"Executing command for test {tr.test.section_name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
@@ -69,4 +69,4 @@ class StandaloneRunner(BaseRunner):
                     stderr="",
                     message="Failed to retrieve job ID from command output.",
                 )
-        return StandaloneJob(self.mode, self.system, tr, job_id, Path(job_output_path))
+        return StandaloneJob(self.mode, self.system, tr, job_id, Path(tr.output_path))

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -14,26 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Any, Dict, List
 
+from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
 
 class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for ChakraReplay on Slurm systems."""
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+    def gen_exec_command(self, tr: TestRun) -> str:
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 
         required_args = [
@@ -48,9 +40,11 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
             raise KeyError(f"Missing required command-line arguments: {missing_args}")
 
         job_name_prefix = "chakra_replay"
-        slurm_args = self._parse_slurm_args(job_name_prefix, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
+        slurm_args = self._parse_slurm_args(job_name_prefix, final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
+        srun_command = self.generate_full_srun_command(
+            slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args
+        )
+        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
 
     def _parse_slurm_args(
         self,

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from pathlib import Path
 from typing import Any, Dict, List
 
+from cloudai import TestRun
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
@@ -31,53 +31,28 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         super().__init__(system, cmd_args)
         self.test_name = ""
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        """
-        Generate the SLURM execution command.
+    def gen_exec_command(self, tr: TestRun) -> str:
+        self.test_name = self._extract_test_name(tr.test.cmd_args)
 
-        This method generates the full SLURM command based on environment
-        variables, command-line arguments, and other parameters. It handles
-        the merging of environment variables and command arguments, and invokes
-        the appropriate strategy for handling thresholds.
-
-        Args:
-            cmd_args (Dict[str, str]): Command-line arguments for the job.
-            extra_env_vars (Dict[str, str]): Additional environment variables.
-            extra_cmd_args (str): Additional command arguments.
-            output_path (str): Path to the output directory.
-            num_nodes (int): Number of nodes to use.
-            nodes (List[str]): List of nodes.
-
-        Returns:
-            str: The full SLURM command to be executed.
-        """
-        self.test_name = self._extract_test_name(cmd_args)
-
-        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-        cmd_args["output_path"] = str(output_path)
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
+        tr.test.cmd_args["output_path"] = str(tr.output_path)
 
         combine_threshold_bytes = int(final_env_vars["COMBINE_THRESHOLD"])
-        num_nodes = len(nodes) if nodes else num_nodes
+        num_nodes = len(tr.nodes) if tr.nodes else tr.num_nodes
 
         # Handle thresholds and environment variable adjustments
-        self._handle_threshold_and_env(cmd_args, final_env_vars, combine_threshold_bytes, num_nodes)
+        self._handle_threshold_and_env(tr.test.cmd_args, final_env_vars, combine_threshold_bytes, num_nodes)
 
-        xla_flags = self._format_xla_flags(cmd_args, "perf")
+        xla_flags = self._format_xla_flags(tr.test.cmd_args, "perf")
         final_env_vars["XLA_FLAGS"] = f'"{xla_flags}"'
 
         env_vars_str = self._format_env_vars(final_env_vars)
 
-        slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, cmd_args, extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
+        slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, tr.test.cmd_args, num_nodes, tr.nodes)
+        srun_command = self.generate_full_srun_command(
+            slurm_args, final_env_vars, tr.test.cmd_args, tr.test.extra_cmd_args
+        )
+        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
 
     def _handle_threshold_and_env(
         self, cmd_args: Dict[str, Any], env_vars: Dict[str, str], combine_threshold_bytes: int, num_nodes: int

--- a/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/kubernetes_json_gen_strategy.py
@@ -14,30 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Any, Dict, List
 
-from cloudai import JsonGenStrategy
+from cloudai import JsonGenStrategy, TestRun
 
 
 class NcclTestKubernetesJsonGenStrategy(JsonGenStrategy):
     """JSON generation strategy for NCCL tests on Kubernetes systems."""
 
-    def gen_json(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        job_name: str,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> Dict[Any, Any]:
-        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
-        final_num_nodes = self._determine_num_nodes(num_nodes, nodes)
+    def gen_json(self, tr: TestRun) -> Dict[Any, Any]:
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
+        final_num_nodes = self._determine_num_nodes(tr.num_nodes, tr.nodes)
         job_spec = self._create_job_spec(
-            job_name, final_num_nodes, nodes, final_env_vars, final_cmd_args, extra_cmd_args
+            tr.job_name, final_num_nodes, tr.nodes, final_env_vars, final_cmd_args, tr.test.extra_cmd_args
         )
 
         return job_spec

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -17,6 +17,7 @@
 from pathlib import Path
 from typing import Any, Dict, List
 
+from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
 from .slurm_install_strategy import NcclTestSlurmInstallStrategy
@@ -25,17 +26,9 @@ from .slurm_install_strategy import NcclTestSlurmInstallStrategy
 class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NCCL tests on Slurm systems."""
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+    def gen_exec_command(self, tr: TestRun) -> str:
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 
         subtest_name = final_cmd_args.get("subtest_name")
@@ -48,9 +41,11 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                 "reduce_scatter_perf_mpi, scatter_perf_mpi, and sendrecv_perf_mpi."
             )
 
-        slurm_args = self._parse_slurm_args(subtest_name, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
+        slurm_args = self._parse_slurm_args(subtest_name, final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
+        srun_command = self.generate_full_srun_command(
+            slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args
+        )
+        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
 
     def _parse_slurm_args(
         self,

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -17,6 +17,7 @@
 from pathlib import Path
 from typing import Any, Dict, List
 
+from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
 from .slurm_install_strategy import NeMoLauncherSlurmInstallStrategy
@@ -25,19 +26,11 @@ from .slurm_install_strategy import NeMoLauncherSlurmInstallStrategy
 class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NeMo Megatron Launcher on Slurm systems."""
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        self._prepare_environment(cmd_args, extra_env_vars, output_path)
+    def gen_exec_command(self, tr: TestRun) -> str:
+        self._prepare_environment(tr.test.cmd_args, tr.test.extra_env_vars, tr.output_path)
 
-        nodes = self.slurm_system.parse_nodes(nodes)
-        self._set_node_config(nodes, num_nodes)
+        nodes = self.slurm_system.parse_nodes(tr.nodes)
+        self._set_node_config(nodes, tr.num_nodes)
 
         self.final_cmd_args["container"] = self.docker_image_cache_manager.ensure_docker_image(
             self.docker_image_url,
@@ -66,14 +59,14 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         full_cmd = f"python {self._launcher_scripts_path()}/launcher_scripts/main.py {cmd_args_str}"
 
-        if extra_cmd_args:
-            full_cmd = self._handle_extra_cmd_args(full_cmd, extra_cmd_args)
+        if tr.test.extra_cmd_args:
+            full_cmd = self._handle_extra_cmd_args(full_cmd, tr.test.extra_cmd_args)
 
         env_vars_str = " ".join(f"{key}={value}" for key, value in self.final_env_vars.items())
         full_cmd = f"{env_vars_str} {full_cmd}" if env_vars_str else full_cmd
 
         # Log the generated command to a bash file
-        self._log_command_to_file(full_cmd, output_path)
+        self._log_command_to_file(full_cmd, tr.output_path)
 
         return full_cmd.strip()
 

--- a/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/kubernetes_json_gen_strategy.py
@@ -14,27 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, cast
 
-from cloudai import JsonGenStrategy
+from cloudai import JsonGenStrategy, TestRun
 from cloudai.systems import KubernetesSystem
 
 
 class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
     """JSON generation strategy for Sleep on Kubernetes systems."""
 
-    def gen_json(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        job_name: str,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> Dict[Any, Any]:
-        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+    def gen_json(self, tr: TestRun) -> Dict[Any, Any]:
+        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
         sec = self.final_cmd_args["seconds"]
 
         kubernetes_system = cast(KubernetesSystem, self.system)
@@ -42,7 +32,7 @@ class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
         job_spec = {
             "apiVersion": "batch/v1",
             "kind": "Job",
-            "metadata": {"name": job_name, "namespace": kubernetes_system.default_namespace},
+            "metadata": {"name": tr.job_name, "namespace": kubernetes_system.default_namespace},
             "spec": {
                 "ttlSecondsAfterFinished": 0,
                 "template": {

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -14,31 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
+from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
 
 class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for Sleep on Slurm systems."""
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+    def gen_exec_command(self, tr: TestRun) -> str:
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 
-        slurm_args = self._parse_slurm_args("sleep", final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
+        slurm_args = self._parse_slurm_args("sleep", final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
+        srun_command = self.generate_full_srun_command(
+            slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args
+        )
+        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
 
     def generate_full_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str

--- a/src/cloudai/schema/test_template/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/standalone_command_gen_strategy.py
@@ -14,10 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import Dict, List
 
-from cloudai import CommandGenStrategy
+from cloudai import CommandGenStrategy, TestRun
 
 
 class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
@@ -27,17 +25,7 @@ class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
     This strategy generates a command to execute a sleep operation with specified duration on standalone systems.
     """
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        if not nodes:
-            nodes = []
-        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+    def gen_exec_command(self, tr: TestRun) -> str:
+        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
         sec = self.final_cmd_args["seconds"]
         return f"sleep {sec}"

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Any, Dict, List
 
+from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
 from .slurm_install_strategy import UCCTestSlurmInstallStrategy
@@ -26,26 +26,20 @@ from .template import UCCTest
 class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for UCC tests on Slurm systems."""
 
-    def gen_exec_command(
-        self,
-        cmd_args: Dict[str, str],
-        extra_env_vars: Dict[str, str],
-        extra_cmd_args: str,
-        output_path: Path,
-        num_nodes: int,
-        nodes: List[str],
-    ) -> str:
-        final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-        final_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+    def gen_exec_command(self, tr: TestRun) -> str:
+        final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
+        final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
         env_vars_str = self._format_env_vars(final_env_vars)
 
         collective = final_cmd_args.get("collective")
         if not collective or collective not in UCCTest.SUPPORTED_COLLECTIVES:
             raise KeyError("Collective name not specified or unsupported.")
 
-        slurm_args = self._parse_slurm_args(collective, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
+        slurm_args = self._parse_slurm_args(collective, final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
+        srun_command = self.generate_full_srun_command(
+            slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args
+        )
+        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
 
     def _parse_slurm_args(
         self,

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -58,7 +58,7 @@ def strategy_fixture(slurm_system: SlurmSystem) -> SlurmCommandGenStrategy:
 
 
 @pytest.fixture
-def test_run_fixture() -> TestRun:
+def test_run_fixture(tmp_path: Path) -> TestRun:
     test = Mock()
     test.cmd_args = {
         "docker_image_url": "fake",
@@ -74,7 +74,7 @@ def test_run_fixture() -> TestRun:
         test=test,
         num_nodes=2,
         nodes=[],
-        output_path=Path("/tmp/output"),
+        output_path=tmp_path / "output",
         job_name="test-job",
     )
     return tr

--- a/tests/test_standalone_system.py
+++ b/tests/test_standalone_system.py
@@ -61,7 +61,7 @@ def standalone_job(standalone_system, mock_test):
     Returns:
         StandaloneJob: A new instance of StandaloneJob for testing.
     """
-    return StandaloneJob("run", standalone_system, mock_test, 12345, Path("/fake/output/path"))
+    return StandaloneJob("run", standalone_system, mock_test, 12345)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Currently, CloudAI passes a very long list of arguments to `gen_exec_command` and `gen_json`. This PR proposes passing only the `TestRun` object to these methods. `TestRun` is a class that represents an instance of a test with run-specific arguments and configurations, such as the number of nodes and their list. Moreover, since `TestRun` has access to the original `Test` class, CloudAI no longer needs to pass arguments individually. Passing `TestRun` should suffice.

## Test Plan
1. CI passes
2. Ran on a server
```
$ python ./cloudaix.py --mode run --system-config ... --tests-dir conf/common/test --test-scenario conf/common/test_scenario/gpt/gpt_175B.toml 
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: gpt_175B
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: gpt_175B

Section Name: Tests.1
  Test Name: gpt3_126m_pile
  Description: gpt3_126m_pile
  No dependencies
...
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: results/gpt_175B_2024-10-07_07-47-02

```