### PR TITLE
Refactor SlurmCommandGenStrategy

### DIFF
--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -49,7 +49,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         job_name_prefix = "chakra_replay"
         slurm_args = self._parse_slurm_args(job_name_prefix, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _parse_slurm_args(

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -76,7 +76,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = self._format_env_vars(final_env_vars)
 
         slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, cmd_args, extra_cmd_args)
+        srun_command = self.generate_srun_command(slurm_args, final_env_vars, cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _handle_threshold_and_env(
@@ -202,7 +202,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return base_args
 
-    def generate_full_srun_command(
+    def generate_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, Any], extra_cmd_args: str
     ) -> str:
         """

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -49,7 +49,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             )
 
         slurm_args = self._parse_slurm_args(subtest_name, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _parse_slurm_args(

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -37,10 +37,10 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         env_vars_str = self._format_env_vars(final_env_vars)
 
         slurm_args = self._parse_slurm_args("sleep", final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
-    def generate_full_srun_command(
+    def generate_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
         srun_command_parts = [

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -44,7 +44,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             raise KeyError("Collective name not specified or unsupported.")
 
         slurm_args = self._parse_slurm_args(collective, final_env_vars, final_cmd_args, num_nodes, nodes)
-        srun_command = self.generate_full_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
+        srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, extra_cmd_args)
         return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, output_path)
 
     def _parse_slurm_args(

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -123,11 +123,11 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
     def generate_full_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
-        srun_command_parts = self.generate_srun_command(slurm_args, env_vars, cmd_args, extra_cmd_args)
+        srun_command_parts = self.generate_srun_prefix(slurm_args, env_vars, cmd_args, extra_cmd_args)
         test_command_parts = self.generate_test_command(slurm_args, env_vars, cmd_args, extra_cmd_args)
         return " \\\n".join(srun_command_parts + test_command_parts)
 
-    def generate_srun_command(
+    def generate_srun_prefix(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         srun_command_parts = ["srun", f"--mpi={self.slurm_system.mpi}"]

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -120,7 +120,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             job_name = f"{self.slurm_system.account}-{job_name_prefix}.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         return job_name
 
-    def generate_full_srun_command(
+    def generate_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
         srun_command_parts = self.generate_srun_prefix(slurm_args, env_vars, cmd_args, extra_cmd_args)

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -123,13 +123,11 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
     def generate_srun_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
-        srun_command_parts = self.generate_srun_prefix(slurm_args, env_vars, cmd_args, extra_cmd_args)
+        srun_command_parts = self.generate_srun_prefix(slurm_args)
         test_command_parts = self.generate_test_command(slurm_args, env_vars, cmd_args, extra_cmd_args)
         return " \\\n".join(srun_command_parts + test_command_parts)
 
-    def generate_srun_prefix(
-        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
-    ) -> List[str]:
+    def generate_srun_prefix(self, slurm_args: Dict[str, Any]) -> List[str]:
         srun_command_parts = ["srun", f"--mpi={self.slurm_system.mpi}"]
         if slurm_args.get("image_path"):
             srun_command_parts.append(f'--container-image={slurm_args["image_path"]}')

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -149,17 +149,17 @@ class TestGenerateSrunCommand__CmdGeneration:
         assert test_command == []
 
     def test_generate_srun_prefix(self, strategy_fixture: SlurmCommandGenStrategy):
-        srun_command = strategy_fixture.generate_srun_prefix({}, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix({})
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}"]
 
     def test_generate_srun_prefix_with_extra_args(self, strategy_fixture: SlurmCommandGenStrategy):
         strategy_fixture.slurm_system.extra_srun_args = "--extra-args value"
-        srun_command = strategy_fixture.generate_srun_prefix({}, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix({})
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}", "--extra-args value"]
 
     def test_generate_srun_prefix_with_container_image(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "fake_image_path"}
-        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args)
         assert srun_command == [
             "srun",
             f"--mpi={strategy_fixture.slurm_system.mpi}",
@@ -168,7 +168,7 @@ class TestGenerateSrunCommand__CmdGeneration:
 
     def test_generate_srun_prefix_with_container_image_and_mounts(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "fake_image_path", "container_mounts": "fake_mounts"}
-        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args)
         assert srun_command == [
             "srun",
             f"--mpi={strategy_fixture.slurm_system.mpi}",
@@ -178,11 +178,11 @@ class TestGenerateSrunCommand__CmdGeneration:
 
     def test_generate_srun_empty_str(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "", "container_mounts": ""}
-        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args)
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}"]
 
         slurm_args = {"image_path": "fake", "container_mounts": ""}
-        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args)
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}", "--container-image=fake"]
 
     def test_generate_srun_command(self, strategy_fixture: SlurmCommandGenStrategy):
@@ -675,9 +675,7 @@ class TestWriteSbatchScript:
 
 class TestNCCLSlurmCommandGen:
     def get_cmd(self, slurm_system: SlurmSystem, slurm_args: dict, cmd_args: dict) -> str:
-        return NcclTestSlurmCommandGenStrategy(slurm_system, {}).generate_srun_command(
-            slurm_args, {}, cmd_args, ""
-        )
+        return NcclTestSlurmCommandGenStrategy(slurm_system, {}).generate_srun_command(slurm_args, {}, cmd_args, "")
 
     def test_only_mandatory(self, slurm_system: SlurmSystem) -> None:
         slurm_args = {"image_path": "fake_image_path"}

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -185,11 +185,11 @@ class TestGenerateSrunCommand__CmdGeneration:
         srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}", "--container-image=fake"]
 
-    def test_generate_full_srun_command(self, strategy_fixture: SlurmCommandGenStrategy):
+    def test_generate_srun_command(self, strategy_fixture: SlurmCommandGenStrategy):
         strategy_fixture.generate_srun_prefix = lambda *_, **__: ["srun", "--test", "test_arg"]
         strategy_fixture.generate_test_command = lambda *_, **__: ["test_command"]
 
-        full_srun_command = strategy_fixture.generate_full_srun_command({}, {}, {}, "")
+        full_srun_command = strategy_fixture.generate_srun_command({}, {}, {}, "")
         assert full_srun_command == " \\\n".join(["srun", "--test", "test_arg", "test_command"])
 
 
@@ -675,7 +675,7 @@ class TestWriteSbatchScript:
 
 class TestNCCLSlurmCommandGen:
     def get_cmd(self, slurm_system: SlurmSystem, slurm_args: dict, cmd_args: dict) -> str:
-        return NcclTestSlurmCommandGenStrategy(slurm_system, {}).generate_full_srun_command(
+        return NcclTestSlurmCommandGenStrategy(slurm_system, {}).generate_srun_command(
             slurm_args, {}, cmd_args, ""
         )
 

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -148,27 +148,27 @@ class TestGenerateSrunCommand__CmdGeneration:
         test_command = strategy_fixture.generate_test_command({}, {}, {}, "")
         assert test_command == []
 
-    def test_generate_srun_command(self, strategy_fixture: SlurmCommandGenStrategy):
-        srun_command = strategy_fixture.generate_srun_command({}, {}, {}, "")
+    def test_generate_srun_prefix(self, strategy_fixture: SlurmCommandGenStrategy):
+        srun_command = strategy_fixture.generate_srun_prefix({}, {}, {}, "")
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}"]
 
-    def test_generate_srun_command_with_extra_args(self, strategy_fixture: SlurmCommandGenStrategy):
+    def test_generate_srun_prefix_with_extra_args(self, strategy_fixture: SlurmCommandGenStrategy):
         strategy_fixture.slurm_system.extra_srun_args = "--extra-args value"
-        srun_command = strategy_fixture.generate_srun_command({}, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix({}, {}, {}, "")
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}", "--extra-args value"]
 
-    def test_generate_srun_command_with_container_image(self, strategy_fixture: SlurmCommandGenStrategy):
+    def test_generate_srun_prefix_with_container_image(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "fake_image_path"}
-        srun_command = strategy_fixture.generate_srun_command(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
         assert srun_command == [
             "srun",
             f"--mpi={strategy_fixture.slurm_system.mpi}",
             "--container-image=fake_image_path",
         ]
 
-    def test_generate_srun_command_with_container_image_and_mounts(self, strategy_fixture: SlurmCommandGenStrategy):
+    def test_generate_srun_prefix_with_container_image_and_mounts(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "fake_image_path", "container_mounts": "fake_mounts"}
-        srun_command = strategy_fixture.generate_srun_command(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
         assert srun_command == [
             "srun",
             f"--mpi={strategy_fixture.slurm_system.mpi}",
@@ -178,15 +178,15 @@ class TestGenerateSrunCommand__CmdGeneration:
 
     def test_generate_srun_empty_str(self, strategy_fixture: SlurmCommandGenStrategy):
         slurm_args = {"image_path": "", "container_mounts": ""}
-        srun_command = strategy_fixture.generate_srun_command(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}"]
 
         slurm_args = {"image_path": "fake", "container_mounts": ""}
-        srun_command = strategy_fixture.generate_srun_command(slurm_args, {}, {}, "")
+        srun_command = strategy_fixture.generate_srun_prefix(slurm_args, {}, {}, "")
         assert srun_command == ["srun", f"--mpi={strategy_fixture.slurm_system.mpi}", "--container-image=fake"]
 
     def test_generate_full_srun_command(self, strategy_fixture: SlurmCommandGenStrategy):
-        strategy_fixture.generate_srun_command = lambda *_, **__: ["srun", "--test", "test_arg"]
+        strategy_fixture.generate_srun_prefix = lambda *_, **__: ["srun", "--test", "test_arg"]
         strategy_fixture.generate_test_command = lambda *_, **__: ["test_command"]
 
         full_srun_command = strategy_fixture.generate_full_srun_command({}, {}, {}, "")


### PR DESCRIPTION
## Summary
* Renamed generate_srun_command to generate_srun_prefix to better reflect its role
* Removed unused args in generate_srun_prefix
* Renamed generate_full_srun_command to generate_srun_command

## Test Plan
CI passes