### PR TITLE
Use venv for nemo launcher

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -64,7 +64,8 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         cmd_args_str = self._generate_cmd_args_str(self.final_cmd_args, nodes)
 
-        full_cmd = f"python {self._launcher_scripts_path()}/launcher_scripts/main.py {cmd_args_str}"
+        py_bin = (self._launcher_scripts_path() / "nemo-venv" / "bin" / "python").absolute()
+        full_cmd = f"{py_bin} {self._launcher_scripts_path()}/launcher_scripts/main.py {cmd_args_str}"
 
         if extra_cmd_args:
             full_cmd = self._handle_extra_cmd_args(full_cmd, extra_cmd_args)

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -164,11 +164,12 @@ class TestNeMoLauncherSlurmInstallStrategy:
         repo_path.mkdir(parents=True, exist_ok=True)
         requirements_file.touch()
 
+        py_bin = subdir_path / "nemo-venv" / "bin" / "python"
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             strategy._install_requirements(subdir_path)
             mock_run.assert_called_with(
-                ["pip", "install", "-r", str(requirements_file)], capture_output=True, text=True
+                [py_bin, "-m", "pip", "install", "-r", str(requirements_file)], capture_output=True, text=True
             )
 
     def test_clone_repository_when_path_exists(self, strategy: NeMoLauncherSlurmInstallStrategy):

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -168,9 +168,10 @@ class TestNeMoLauncherSlurmInstallStrategy:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             strategy._install_requirements(subdir_path)
-            mock_run.assert_called_with(
-                [py_bin, "-m", "pip", "install", "-r", str(requirements_file)], capture_output=True, text=True
-            )
+
+        calls = mock_run.call_args_list
+        assert calls[0][0][0] == ["python", "-m", "venv", str(py_bin.parent.parent)]
+        assert calls[1][0][0] == [py_bin, "-m", "pip", "install", "-r", str(requirements_file)]
 
     def test_clone_repository_when_path_exists(self, strategy: NeMoLauncherSlurmInstallStrategy):
         subdir_path = Path(strategy.slurm_system.install_path) / strategy.SUBDIR_PATH


### PR DESCRIPTION
## Summary
Create a virtual environment and run NeMo Launcher inside it.

Before that Cloud AI env was used and some dependencies might either conflict raising a warning or fail to install causing installation error.

## Test Plan
1. CI.
2. Manual run of installation.
3. Work with verification team to test it in the environment where installation error appeared first.

## Additional Notes
—
