### PR TITLE
Bug fix for incorrect py_bin in NeMoLauncher

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -57,7 +57,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         cmd_args_str = self._generate_cmd_args_str(self.final_cmd_args, nodes)
 
-        py_bin = (self._launcher_scripts_path() / "nemo-venv" / "bin" / "python").absolute()
+        py_bin = (
+            self.system.install_path / NeMoLauncherSlurmInstallStrategy.SUBDIR_PATH / "nemo-venv" / "bin" / "python"
+        ).absolute()
         full_cmd = f"{py_bin} {self._launcher_scripts_path()}/launcher_scripts/main.py {cmd_args_str}"
 
         if tr.test.extra_cmd_args:


### PR DESCRIPTION
## Summary
Bug fix for incorrect py_bin in NeMoLauncher. Introduced by https://github.com/NVIDIA/cloudai/pull/230.

## Test Plan
Tested on an NVIDIA-internal server.
```
$ python ./cloudaix.py --mode run --system-config ... --tests-dir conf/common/test --test-scenario conf/common/test_scenario/gpt/gpt_175B.toml 
...
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: results/gpt_175B_2024-10-07_07-33-45
```