### PR TITLE
Remove duplicated _format_env_vars calls

### DIFF
--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -26,7 +26,6 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_exec_command(self, tr: TestRun) -> str:
         final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
-        env_vars_str = self._format_env_vars(final_env_vars)
 
         required_args = [
             "docker_image_url",
@@ -42,7 +41,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
         job_name_prefix = "chakra_replay"
         slurm_args = self._parse_slurm_args(job_name_prefix, final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
         srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
+        return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def _parse_slurm_args(
         self,

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -46,11 +46,9 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         xla_flags = self._format_xla_flags(tr.test.cmd_args, "perf")
         final_env_vars["XLA_FLAGS"] = f'"{xla_flags}"'
 
-        env_vars_str = self._format_env_vars(final_env_vars)
-
         slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, tr.test.cmd_args, num_nodes, tr.nodes)
         srun_command = self.generate_srun_command(slurm_args, final_env_vars, tr.test.cmd_args, tr.test.extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
+        return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def _handle_threshold_and_env(
         self, cmd_args: Dict[str, Any], env_vars: Dict[str, str], combine_threshold_bytes: int, num_nodes: int

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -29,7 +29,6 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_exec_command(self, tr: TestRun) -> str:
         final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
-        env_vars_str = self._format_env_vars(final_env_vars)
 
         subtest_name = final_cmd_args.get("subtest_name")
         if subtest_name is None:
@@ -43,7 +42,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         slurm_args = self._parse_slurm_args(subtest_name, final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
         srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
+        return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def _parse_slurm_args(
         self,

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -26,11 +26,10 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_exec_command(self, tr: TestRun) -> str:
         final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
-        env_vars_str = self._format_env_vars(final_env_vars)
 
         slurm_args = self._parse_slurm_args("sleep", final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
         srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
+        return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def generate_test_command(
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -29,7 +29,6 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_exec_command(self, tr: TestRun) -> str:
         final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
         final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
-        env_vars_str = self._format_env_vars(final_env_vars)
 
         collective = final_cmd_args.get("collective")
         if not collective or collective not in UCCTest.SUPPORTED_COLLECTIVES:
@@ -37,7 +36,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         slurm_args = self._parse_slurm_args(collective, final_env_vars, final_cmd_args, tr.num_nodes, tr.nodes)
         srun_command = self.generate_srun_command(slurm_args, final_env_vars, final_cmd_args, tr.test.extra_cmd_args)
-        return self._write_sbatch_script(slurm_args, env_vars_str, srun_command, tr.output_path)
+        return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def _parse_slurm_args(
         self,

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -162,14 +162,14 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         return batch_script_content
 
     def _write_sbatch_script(
-        self, args: Dict[str, Any], env_vars_str: str, srun_command: str, output_path: Path
+        self, args: Dict[str, Any], env_vars: Dict[str, str], srun_command: str, output_path: Path
     ) -> str:
         """
         Write the batch script for Slurm submission and return the sbatch command.
 
         Args:
             args (Dict[str, Any]): Arguments including job settings.
-            env_vars_str (str): Environment variables.
+            env_vars (env_vars: Dict[str, str]): Environment variables.
             srun_command (str): srun command.
             output_path (Path): Output directory for script and logs.
 
@@ -184,6 +184,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         self._append_sbatch_directives(batch_script_content, args, output_path)
 
+        env_vars_str = self._format_env_vars(env_vars)
         batch_script_content.extend([env_vars_str, "", srun_command])
 
         batch_script_path = output_path / "cloudai_sbatch_script.sh"

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -99,11 +99,11 @@ def jax_strategy_fixture() -> JaxToolboxSlurmCommandGenStrategy:
 
 def test_filename_generation(strategy_fixture: SlurmCommandGenStrategy, tmp_path: Path):
     args = {"job_name": "test_job", "num_nodes": 2, "partition": "test_partition", "node_list_str": "node1,node2"}
-    env_vars_str = "export TEST_VAR=VALUE"
+    env_vars = {"TEST_VAR": "VALUE"}
     srun_command = "srun --test test_arg"
     output_path = tmp_path
 
-    sbatch_command = strategy_fixture._write_sbatch_script(args, env_vars_str, srun_command, output_path)
+    sbatch_command = strategy_fixture._write_sbatch_script(args, env_vars, srun_command, output_path)
     filepath_from_command = sbatch_command.split()[-1]
 
     # Check that the file exists at the specified path
@@ -387,7 +387,7 @@ class TestWriteSbatchScript:
     }
 
     def setup_method(self):
-        self.env_vars_str = "export TEST_VAR=VALUE"
+        self.env_vars = {"TEST_VAR": "VALUE"}
         self.srun_command = "srun --test test_arg"
 
     def assert_slurm_directives(self, lines: list[str]):
@@ -423,12 +423,12 @@ class TestWriteSbatchScript:
         del args[missing_arg]
 
         with pytest.raises(KeyError) as exc_info:
-            strategy_fixture._write_sbatch_script(args, self.env_vars_str, self.srun_command, tmp_path)
+            strategy_fixture._write_sbatch_script(args, self.env_vars, self.srun_command, tmp_path)
         assert missing_arg in str(exc_info.value)
 
     def test_only_mandatory_args(self, strategy_fixture: SlurmCommandGenStrategy, tmp_path: Path):
         sbatch_command = strategy_fixture._write_sbatch_script(
-            self.MANDATORY_ARGS, self.env_vars_str, self.srun_command, tmp_path
+            self.MANDATORY_ARGS, self.env_vars, self.srun_command, tmp_path
         )
 
         filepath_from_command = sbatch_command.split()[-1]
@@ -481,7 +481,7 @@ class TestWriteSbatchScript:
             str_arg = arg.replace("_", "-")
             expected_str = f"#SBATCH --{str_arg}={v}"
 
-        sbatch_command = strategy_fixture._write_sbatch_script(args, self.env_vars_str, self.srun_command, tmp_path)
+        sbatch_command = strategy_fixture._write_sbatch_script(args, self.env_vars, self.srun_command, tmp_path)
 
         filepath_from_command = sbatch_command.split()[-1]
         with open(filepath_from_command, "r") as file:
@@ -498,7 +498,7 @@ class TestWriteSbatchScript:
         strategy_fixture.slurm_system.extra_srun_args = "--reservation my-reservation"
         args = self.MANDATORY_ARGS.copy()
 
-        sbatch_command = strategy_fixture._write_sbatch_script(args, self.env_vars_str, self.srun_command, tmp_path)
+        sbatch_command = strategy_fixture._write_sbatch_script(args, self.env_vars, self.srun_command, tmp_path)
         filepath_from_command = sbatch_command.split()[-1]
         with open(filepath_from_command, "r") as file:
             file_contents = file.read()
@@ -510,7 +510,7 @@ class TestWriteSbatchScript:
         args = self.MANDATORY_ARGS.copy()
         args[add_arg] = "fake"
 
-        sbatch_command = strategy_fixture._write_sbatch_script(args, self.env_vars_str, self.srun_command, tmp_path)
+        sbatch_command = strategy_fixture._write_sbatch_script(args, self.env_vars, self.srun_command, tmp_path)
 
         filepath_from_command = sbatch_command.split()[-1]
         with open(filepath_from_command, "r") as file:


### PR DESCRIPTION
## Summary
Remove duplicated _format_env_vars calls. The _format_env_vars function is called in every test template's gen_exec_command, which is redundant. This PR eliminates the function calls within each template and moves the _format_env_vars call to the parent class.

## Test Plan
CI passes