### PR TITLE
Remove unnecessary arg from generate_test_command

### DIFF
--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -61,7 +61,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return base_args
 
     def generate_test_command(
-        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+        self, env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         srun_command_parts = [
             "python /workspace/param/train/comms/pt/commsTraceReplay.py",

--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -73,7 +73,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return base_args
 
     def generate_test_command(
-        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+        self, env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         srun_command_parts = [f"/usr/local/bin/{cmd_args['subtest_name']}"]
         nccl_test_args = [

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
@@ -32,6 +32,6 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def generate_test_command(
-        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+        self, env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         return [f'sleep {cmd_args["seconds"]}']

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -61,7 +61,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return base_args
 
     def generate_test_command(
-        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+        self, env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         srun_command_parts = ["/opt/hpcx/ucc/bin/ucc_perftest"]
 

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -124,7 +124,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> str:
         srun_command_parts = self.generate_srun_prefix(slurm_args)
-        test_command_parts = self.generate_test_command(slurm_args, env_vars, cmd_args, extra_cmd_args)
+        test_command_parts = self.generate_test_command(env_vars, cmd_args, extra_cmd_args)
         return " \\\n".join(srun_command_parts + test_command_parts)
 
     def generate_srun_prefix(self, slurm_args: Dict[str, Any]) -> List[str]:
@@ -140,7 +140,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         return srun_command_parts
 
     def generate_test_command(
-        self, slurm_args: Dict[str, Any], env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
+        self, env_vars: Dict[str, str], cmd_args: Dict[str, str], extra_cmd_args: str
     ) -> List[str]:
         return []
 

--- a/tests/test_slurm_command_gen_strategy.py
+++ b/tests/test_slurm_command_gen_strategy.py
@@ -170,7 +170,7 @@ def test_raises_if_no_default_partition(slurm_system: SlurmSystem):
 
 class TestGenerateSrunCommand__CmdGeneration:
     def test_generate_test_command(self, strategy_fixture: SlurmCommandGenStrategy):
-        test_command = strategy_fixture.generate_test_command({}, {}, {}, "")
+        test_command = strategy_fixture.generate_test_command({}, {}, "")
         assert test_command == []
 
     def test_generate_srun_prefix(self, strategy_fixture: SlurmCommandGenStrategy):


### PR DESCRIPTION
## Summary
The `generate_test_command` function is intended to generate the core command used in an `srun` command. As a result, it does not need to accept `slurm_args`, which should be managed by a prefix-generating function. This PR removes `slurm_args` from the argument list.

## Test Plan
CI passes