### PR TITLE
Move more fields from Test to TestRun

### DIFF
--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from pydantic import BaseModel, ConfigDict
 
@@ -34,9 +34,6 @@ class Test:
         cmd_args: Dict[str, str],
         extra_env_vars: Dict[str, str],
         extra_cmd_args: str,
-        sol: Optional[float] = None,
-        weight: float = 0.0,
-        ideal_perf: float = 1.0,
     ) -> None:
         """
         Initialize a Test instance.
@@ -48,11 +45,6 @@ class Test:
             cmd_args (Dict[str, str]): Command-line arguments for the test.
             extra_env_vars (Dict[str, str]): Extra environment variables.
             extra_cmd_args (str): Extra command-line arguments.
-            iterations (Union[int, str]): Total number of iterations to run the test. Can be an integer or 'infinite'
-                for endless iterations.
-            sol (Optional[float]): Speed-of-light performance for reference.
-            weight (float): The weight of this test in a test scenario, indicating its relative importance or priority.
-            ideal_perf (float): The ideal performance value for comparison.
         """
         self.name = name
         self.description = description
@@ -60,9 +52,6 @@ class Test:
         self.cmd_args = cmd_args
         self.extra_env_vars = extra_env_vars
         self.extra_cmd_args = extra_cmd_args
-        self.sol = sol
-        self.weight = weight
-        self.ideal_perf = ideal_perf
 
     def __repr__(self) -> str:
         """

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -57,6 +57,9 @@ class TestRun:
     iterations: int = 1
     current_iteration: int = 0
     time_limit: Optional[str] = None
+    sol: Optional[float] = None
+    weight: float = 0.0
+    ideal_perf: float = 1.0
     dependencies: dict[str, TestDependency] = field(default_factory=dict)
 
     def __hash__(self) -> int:

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -189,9 +189,6 @@ class TestScenarioParser:
             cmd_args=copy.deepcopy(original_test.cmd_args),
             extra_env_vars=copy.deepcopy(original_test.extra_env_vars),
             extra_cmd_args=original_test.extra_cmd_args,
-            sol=test_info.sol,
-            weight=test_info.weight * normalized_weight,
-            ideal_perf=test_info.ideal_perf,
         )
 
         tr = TestRun(
@@ -201,5 +198,8 @@ class TestScenarioParser:
             iterations=test_info.iterations,
             nodes=test_info.nodes,
             time_limit=test_info.time_limit,
+            sol=test_info.sol,
+            weight=test_info.weight * normalized_weight,
+            ideal_perf=test_info.ideal_perf,
         )
         return tr

--- a/src/cloudai/report_generator/report_generator.py
+++ b/src/cloudai/report_generator/report_generator.py
@@ -17,7 +17,7 @@
 import logging
 from pathlib import Path
 
-from cloudai import Test, TestScenario
+from cloudai import TestRun, TestScenario
 
 
 class ReportGenerator:
@@ -57,9 +57,9 @@ class ReportGenerator:
                 logging.warning(f"Directory '{test_output_dir}' not found.")
                 continue
 
-            self._generate_test_report(test_output_dir, tr.test)
+            self._generate_test_report(test_output_dir, tr)
 
-    def _generate_test_report(self, directory_path: Path, test: Test) -> None:
+    def _generate_test_report(self, directory_path: Path, tr: TestRun) -> None:
         """
         Generate reports for a test by iterating through subdirectories within the directory path.
 
@@ -67,10 +67,10 @@ class ReportGenerator:
 
         Args:
             directory_path (Path): Directory for the test's section.
-            test (Test): The test for report generation.
+            tr (TestRun): The test run object.
         """
         for subdir in directory_path.iterdir():
-            if subdir.is_dir() and test.test_template.can_handle_directory(subdir):
-                test.test_template.generate_report(test.name, subdir, test.sol)
+            if subdir.is_dir() and tr.test.test_template.can_handle_directory(subdir):
+                tr.test.test_template.generate_report(tr.test.name, subdir, tr.sol)
             else:
-                logging.warning(f"Skipping directory '{subdir}' for test '{test.name}'")
+                logging.warning(f"Skipping directory '{subdir}' for test '{tr.test.name}'")

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -46,12 +46,12 @@ def test_single_test_case(test: Test, test_scenario_parser: TestScenarioParser) 
     assert tr.iterations == 1
     assert tr.current_iteration == 0
     assert tr.dependencies == {}
+    assert tr.weight == 0
+    assert tr.ideal_perf == 1.0
+    assert tr.sol is None
     atest = test_scenario.test_runs[0].test
     assert atest.name == test.name
     assert atest.description == test.description
-    assert atest.weight == 0
-    assert atest.ideal_perf == 1.0
-    assert atest.sol is None
     assert atest.test_template == test.test_template
     assert atest.cmd_args == test.cmd_args
     assert atest.extra_env_vars == test.extra_env_vars

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -70,7 +70,7 @@ def test_with_some_props(
     test_scenario = test_scenario_parser._parse_data(
         {"name": "nccl-test", "Tests": [{"id": "1", "test_name": "nccl", prop: cfg_value}]}
     )
-    atest = test_scenario.test_runs[0].test
+    atest = test_scenario.test_runs[0]
     val = getattr(atest, prop)
     assert val != tvalue
     assert val == cfg_value


### PR DESCRIPTION
## Summary
Move more fields from `Test` to `TestRun`. This is to unblock `Test` and `TestDefinition` merging under single object to avoid confusion.

## Test Plan
CI

## Additional Notes
—
