### PR TITLE
Fix race condition during docker images caching

### DIFF
--- a/src/cloudai/__main__.py
+++ b/src/cloudai/__main__.py
@@ -143,9 +143,9 @@ def identify_unique_test_templates(tests: List[Test]) -> List[TestTemplate]:
     seen_names: Set[str] = set()
 
     for test in tests:
-        template_name = test.test_template.name
-        if template_name not in seen_names:
-            seen_names.add(template_name)
+        template_type = type(test.test_template).__name__
+        if template_type not in seen_names:
+            seen_names.add(template_type)
             unique_templates.append(test.test_template)
 
     return unique_templates


### PR DESCRIPTION
## Summary
It happened when two tests based on the same TestTemplate class, but with different test_template_name started caching the same image into the same location.

## Test Plan
1. CI
2. Follow reproducing steps from the internal bug.

## Additional Notes
—
