### PR TITLE
Remove assigning null when the value is null (NeMo launcher)

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -135,18 +135,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         self.final_cmd_args["training.trainer.num_nodes"] = str(len(nodes)) if nodes else num_nodes
 
     def _validate_data_config(self) -> None:
-        """Validate the data directory and prefix configuration for non-mock environments."""
+        """Validate the data prefix configuration for non-mock environments."""
         if self.final_cmd_args.get("training.model.data.data_impl") != "mock":
-            data_dir = self.final_cmd_args.get("data_dir")
             data_prefix = self.final_cmd_args.get("training.model.data.data_prefix")
-
-            if not data_dir or data_dir == "~":
-                raise ValueError(
-                    "The 'data_dir' field of the NeMo launcher test contains an invalid placeholder '~'. "
-                    "Please provide a valid path to the dataset in the test schema TOML file. "
-                    "The 'data_dir' field must point to an actual dataset location."
-                )
-
             if data_prefix == "[]":
                 raise ValueError(
                     "The 'data_prefix' field of the NeMo launcher test is missing or empty. "
@@ -198,10 +189,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                     value = f"\\'{value}\\'"
                 env_var_str_parts.append(f"+{key}={value}")
             else:
-                if value == "~":
-                    cmd_arg_str_parts.append(f"~{key}=null")
-                else:
-                    cmd_arg_str_parts.append(f"{key}={value}")
+                cmd_arg_str_parts.append(f"{key}={value}")
 
         if nodes:
             nodes_str = ",".join(nodes)

--- a/src/cloudai/test_definitions/nemo_launcher.py
+++ b/src/cloudai/test_definitions/nemo_launcher.py
@@ -97,7 +97,6 @@ class NeMoLauncherCmdArgs(CmdArgs):
     repository_commit_hash: str = "cf411a9ede3b466677df8ee672bcc6c396e71e1a"
     docker_image_url: str = "nvcr.io/nvidia/nemo:24.01.01"
     stages: str = '["training"]'
-    data_dir: str = "~"
     numa_mapping: NumaMapping = Field(default_factory=NumaMapping)
     cluster: Cluster = Field(default_factory=Cluster)
     training: Training = Field(default_factory=Training)

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher.py
@@ -16,7 +16,7 @@
 
 from pathlib import Path
 from typing import cast
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, PropertyMock, mock_open, patch
 
 import pytest
 from cloudai._core.test import Test
@@ -135,21 +135,13 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
 
         assert "cluster.gpus_per_node=null" in cmd
 
-    def test_argument_with_tilde_value(self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy, nemo_test_run: TestRun):
-        tdef: NeMoLauncherTestDefinition = cast(NeMoLauncherTestDefinition, nemo_test_run.test.test_definition)
-        tdef.cmd_args.training.model.micro_batch_size = "~"  # type: ignore
-
-        cmd = nemo_cmd_gen.gen_exec_command(nemo_test_run)
-        assert "~training.model.micro_batch_size=null" in cmd
-
     def test_data_impl_mock_skips_checks(
         self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy, nemo_test_run: TestRun
     ):
-        tdef: NeMoLauncherTestDefinition = cast(NeMoLauncherTestDefinition, nemo_test_run.test.test_definition)
-        tdef.cmd_args.data_dir = "DATA_DIR"
-
-        cmd = nemo_cmd_gen.gen_exec_command(nemo_test_run)
-        assert "data_dir" in cmd
+        with patch.object(Test, "extra_cmd_args", new_callable=PropertyMock) as mock_extra_cmd_args:
+            mock_extra_cmd_args.return_value = "data_dir=DATA_DIR"
+            cmd = nemo_cmd_gen.gen_exec_command(nemo_test_run)
+            assert "data_dir=DATA_DIR" in cmd
 
     def test_data_dir_and_data_prefix_validation(
         self, nemo_cmd_gen: NeMoLauncherSlurmCommandGenStrategy, nemo_test_run: TestRun
@@ -158,18 +150,9 @@ class TestNeMoLauncherSlurmCommandGenStrategy__GenExecCommand:
         tdef.cmd_args.training.model.data.data_impl = "not_mock"
         tdef.cmd_args.training.model.data.data_prefix = "[]"
 
-        with pytest.raises(
-            ValueError,
-            match=(
-                "The 'data_dir' field of the NeMo launcher test contains an invalid placeholder '~'. "
-                "Please provide a valid path to the dataset in the test schema TOML file. "
-                "The 'data_dir' field must point to an actual dataset location."
-            ),
+        with patch.object(Test, "extra_cmd_args", return_value="data_dir=DATA_DIR") and pytest.raises(
+            ValueError, match="The 'data_prefix' field of the NeMo launcher test is missing or empty."
         ):
-            nemo_cmd_gen.gen_exec_command(nemo_test_run)
-
-        tdef.cmd_args.data_dir = "/fake/data_dir"
-        with pytest.raises(ValueError, match="The 'data_prefix' field of the NeMo launcher test is missing or empty."):
             nemo_cmd_gen.gen_exec_command(nemo_test_run)
 
     @patch("pathlib.Path.open", new_callable=mock_open)


### PR DESCRIPTION
## Summary
This is a bug fix for https://redmine.mellanox.com/issues/4111103. Previously, we introduced https://github.com/NVIDIA/cloudai/pull/223 to allow users to remove keys from the argument list when not needed. However, it turns out that we cannot apply this approach to the data_dir argument. Therefore, this PR removes the feature, and any arguments that should be excluded by default should not be added to the test definition. Instead, they should be included in the extra_cmd_args section when necessary.

## Test Plan
1. CI passes.
2. Ran on a server