### PR TITLE
Fix missing 'output_path' in cmd_args

### DIFF
--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -35,19 +35,20 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         self.test_name = self._extract_test_name(tr.test.cmd_args)
 
         final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
-        tr.test.cmd_args["output_path"] = str(tr.output_path)
+        cmd_args = tr.test.test_definition.cmd_args_dict
+        cmd_args["output_path"] = str(tr.output_path)
 
         combine_threshold_bytes = int(final_env_vars["COMBINE_THRESHOLD"])
         num_nodes = len(tr.nodes) if tr.nodes else tr.num_nodes
 
         # Handle thresholds and environment variable adjustments
-        self._handle_threshold_and_env(tr.test.cmd_args, final_env_vars, combine_threshold_bytes, num_nodes)
+        self._handle_threshold_and_env(cmd_args, final_env_vars, combine_threshold_bytes, num_nodes)
 
-        xla_flags = self._format_xla_flags(tr.test.cmd_args, "perf")
+        xla_flags = self._format_xla_flags(cmd_args, "perf")
         final_env_vars["XLA_FLAGS"] = f'"{xla_flags}"'
 
-        slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, tr.test.cmd_args, num_nodes, tr.nodes)
-        srun_command = self.generate_srun_command(slurm_args, final_env_vars, tr.test.cmd_args, tr.test.extra_cmd_args)
+        slurm_args = self._parse_slurm_args("JaxToolbox", final_env_vars, cmd_args, num_nodes, tr.nodes)
+        srun_command = self.generate_srun_command(slurm_args, final_env_vars, cmd_args, tr.test.extra_cmd_args)
         return self._write_sbatch_script(slurm_args, final_env_vars, srun_command, tr.output_path)
 
     def _handle_threshold_and_env(


### PR DESCRIPTION
## Summary
Fix missing 'output_path' in cmd_args.

## Test Plan
1. CI
2. Manual run

## Additional Notes
—
