### PR TITLE
Improve verify modes

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -25,31 +25,6 @@ import toml
 from cloudai import Parser, Registry, ReportGenerator, Runner, Test, TestParser, TestTemplate
 
 
-def handle_verify_systems(args: argparse.Namespace) -> int:
-    root: Path = args.system_configs
-    if not root.exists():
-        logging.error(f"Tests directory {root} does not exist.")
-        return 1
-
-    test_tomls = [root]
-    if root.is_dir():
-        test_tomls = list(root.glob("*.toml"))
-        if not test_tomls:
-            logging.error(f"No test tomls found in {root}")
-            return 1
-
-    rc = 0
-    for test_toml in test_tomls:
-        logging.info(f"Verifying {test_toml}...")
-        try:
-            Parser.parse_system(test_toml)
-        except Exception:
-            rc = 1
-            break
-
-    return rc
-
-
 def identify_unique_test_templates(tests: List[Test]) -> List[TestTemplate]:
     """
     Identify unique test templates from a list of tests.
@@ -209,21 +184,48 @@ def handle_generate_report(args: argparse.Namespace) -> int:
     return 0
 
 
-def handle_verify_tests(args: argparse.Namespace) -> int:
-    """Verify the test configurations."""
-    root: Path = args.test_configs
+def expand_file_list(root: Path) -> tuple[int, List[Path]]:
     if not root.exists():
-        logging.error(f"Tests directory {root} does not exist.")
-        return 1
+        logging.error(f"{root} does not exist.")
+        return (1, [])
 
     test_tomls = [root]
     if root.is_dir():
         test_tomls = list(root.glob("*.toml"))
         if not test_tomls:
-            logging.error(f"No test tomls found in {root}")
-            return 1
+            logging.error(f"No TOMLs found in {root}")
+            return (1, [])
 
-    rc = 0
+    return (0, test_tomls)
+
+
+def handle_verify_systems(args: argparse.Namespace) -> int:
+    root: Path = args.system_configs
+    err, system_tomls = expand_file_list(root)
+    if err:
+        return 1
+
+    nfailed = 0
+    for test_toml in system_tomls:
+        logging.info(f"Verifying {test_toml}...")
+        try:
+            Parser.parse_system(test_toml)
+        except Exception:
+            nfailed = 1
+
+    if nfailed == 0:
+        logging.info(f"Checked systems: {len(system_tomls)}, all passed")
+
+    return nfailed
+
+
+def handle_verify_tests(args: argparse.Namespace) -> int:
+    root: Path = args.test_configs
+    err, test_tomls = expand_file_list(root)
+    if err:
+        return 1
+
+    nfailed = 0
     for test_toml in test_tomls:
         logging.info(f"Verifying {test_toml}...")
         try:
@@ -231,36 +233,30 @@ def handle_verify_tests(args: argparse.Namespace) -> int:
             parser.current_file = test_toml
             parser.load_test_definition(toml.load(test_toml))
         except Exception:
-            rc = 1
-            break
+            nfailed = 1
 
-    return rc
+    if nfailed == 0:
+        logging.info(f"Checked tests: {len(test_tomls)}, all passed")
+
+    return nfailed
 
 
 def handle_verify_test_scenarios(args: argparse.Namespace) -> int:
     root: Path = args.test_scenarios
-    if not root.exists():
-        logging.error(f"Tests directory {root} does not exist.")
+    err, test_tomls = expand_file_list(root)
+    if err:
         return 1
 
-    test_tomls = [root]
-    if root.is_dir():
-        test_tomls = list(root.glob("*.toml"))
-        if not test_tomls:
-            logging.error(f"No test tomls found in {root}")
-            return 1
-
-    rc = 0
+    nfailed = 0
     for test_toml in test_tomls:
         logging.info(f"Verifying {test_toml}...")
         try:
             parser = Parser(args.system_config)
             parser.parse(args.tests_dir, test_toml)
         except Exception:
-            rc = 1
-            break
+            nfailed = 1
 
-    if rc == 0:
+    if nfailed == 0:
         logging.info(f"Checked scenarios: {len(test_tomls)}, all passed")
 
-    return rc
+    return nfailed

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -203,7 +203,7 @@ def handle_verify_systems(args: argparse.Namespace) -> int:
     root: Path = args.system_configs
     err, system_tomls = expand_file_list(root)
     if err:
-        return 1
+        return err
 
     nfailed = 0
     for test_toml in system_tomls:
@@ -211,9 +211,11 @@ def handle_verify_systems(args: argparse.Namespace) -> int:
         try:
             Parser.parse_system(test_toml)
         except Exception:
-            nfailed = 1
+            nfailed += 1
 
-    if nfailed == 0:
+    if nfailed:
+        logging.error(f"{nfailed} out of {len(system_tomls)} system configurations have issues.")
+    else:
         logging.info(f"Checked systems: {len(system_tomls)}, all passed")
 
     return nfailed
@@ -223,7 +225,7 @@ def handle_verify_tests(args: argparse.Namespace) -> int:
     root: Path = args.test_configs
     err, test_tomls = expand_file_list(root)
     if err:
-        return 1
+        return err
 
     nfailed = 0
     for test_toml in test_tomls:
@@ -233,9 +235,11 @@ def handle_verify_tests(args: argparse.Namespace) -> int:
             parser.current_file = test_toml
             parser.load_test_definition(toml.load(test_toml))
         except Exception:
-            nfailed = 1
+            nfailed += 1
 
-    if nfailed == 0:
+    if nfailed:
+        logging.error(f"{nfailed} out of {len(test_tomls)} test configurations have issues.")
+    else:
         logging.info(f"Checked tests: {len(test_tomls)}, all passed")
 
     return nfailed
@@ -245,7 +249,7 @@ def handle_verify_test_scenarios(args: argparse.Namespace) -> int:
     root: Path = args.test_scenarios
     err, test_tomls = expand_file_list(root)
     if err:
-        return 1
+        return err
 
     nfailed = 0
     for test_toml in test_tomls:
@@ -254,9 +258,11 @@ def handle_verify_test_scenarios(args: argparse.Namespace) -> int:
             parser = Parser(args.system_config)
             parser.parse(args.tests_dir, test_toml)
         except Exception:
-            nfailed = 1
+            nfailed += 1
 
-    if nfailed == 0:
+    if nfailed:
+        logging.error(f"{nfailed} out of {len(test_tomls)} test scenarios have issues.")
+    else:
         logging.info(f"Checked scenarios: {len(test_tomls)}, all passed")
 
     return nfailed

--- a/src/cloudai/parser.py
+++ b/src/cloudai/parser.py
@@ -98,8 +98,16 @@ class Parser:
         with Path(system_config_path).open() as f:
             logging.debug(f"Opened system config file: {system_config_path}")
             data = toml.load(f)
-            scheduler = data.get("scheduler", "").lower()
+            scheduler: Optional[str] = data.get("scheduler")
+            if scheduler is None:
+                logging.error(f"Missing 'scheduler' key in {system_config_path}")
+                raise SystemConfigParsingError(f"Missing 'scheduler' key in {system_config_path}")
+
             if scheduler not in registry.systems_map:
+                logging.error(
+                    f"Unsupported system type '{scheduler}' in {system_config_path}. "
+                    f"Should be one of: {', '.join(registry.systems_map.keys())}"
+                )
                 raise SystemConfigParsingError(
                     f"Unsupported system type '{scheduler}' in {system_config_path}. "
                     f"Supported types: {', '.join(registry.systems_map.keys())}"


### PR DESCRIPTION
## Summary
1. Verify all configs, not just till first failure.
2. Improve errors reporting.

## Test Plan
1. CI.
2. Manual run for different modes and check output.

## Additional Notes
Example output:
```bash
cloudai verify-systems conf/common/system
[INFO] Verifying conf/common/system/standalone_system.toml...
[INFO] Verifying conf/common/system/example_slurm_cluster.toml...
[ERROR] Failed to parse system definition: conf/common/system/example_slurm_cluster.toml
[ERROR] Field 'install_path': Field required
[INFO] Verifying conf/common/system/kubernetes_cluster.toml...
[ERROR] Failed to parse system definition: conf/common/system/kubernetes_cluster.toml
[ERROR] Field 'install_path': Field required
[ERROR] 2 out of 3 system configurations have issues.
```
