### PR TITLE
Update NeMo launcher commit hash and image tag

### DIFF
--- a/src/cloudai/test_definitions/nemo_launcher.py
+++ b/src/cloudai/test_definitions/nemo_launcher.py
@@ -94,8 +94,8 @@ class NeMoLauncherCmdArgs(CmdArgs):
     """NeMoLauncher test command arguments."""
 
     repository_url: str = "https://github.com/NVIDIA/NeMo-Framework-Launcher.git"
-    repository_commit_hash: str = "cf411a9ede3b466677df8ee672bcc6c396e71e1a"
-    docker_image_url: str = "nvcr.io/nvidia/nemo:24.01.01"
+    repository_commit_hash: str = "599ecfcbbd64fd2de02f2cc093b1610d73854022"
+    docker_image_url: str = "nvcr.io/nvidia/nemo:24.05.01"
     stages: str = '["training"]'
     numa_mapping: NumaMapping = Field(default_factory=NumaMapping)
     cluster: Cluster = Field(default_factory=Cluster)


### PR DESCRIPTION
## Summary
Bug fix for [this issue](https://redmine.mellanox.com/issues/4107571). The problem is due to missing LLAMA3 configuration files, as reported by Arik Gelman. The bug was introduced by [this PR](https://github.com/NVIDIA/cloudai/pull/145). We should have used the commit hash 599ecfcbbd64fd2de02f2cc093b1610d73854022, but we are currently using cf411a9ede3b466677df8ee672bcc6c396e71e1a. You can see [here](https://github.com/NVIDIA/cloudai/blob/854e06f6487af364f93e29e606c9960a38899829/conf/common/test_template/nemo_launcher.toml#L26) that we used 599ecfcbbd64fd2de02f2cc093b1610d73854022 before this PR. The [commit hash](https://github.com/NVIDIA/NeMo-Framework-Launcher/tree/599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts/conf/training/llama) has the required configuration files, such as [llama3_70b.yaml](https://github.com/NVIDIA/NeMo-Framework-Launcher/blob/599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts/conf/training/llama/llama3_70b.yaml).

## Test Plan
Ran on an NVIDIA server manually. Could submit a job.