### PR TITLE
Am/verify configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
           set -o pipefail
 
           cloudai --help
-          cloudai verify-systems conf/common/system
-          cloudai verify-tests conf/common/test
-          cloudai verify-tests conf/release/spcx/l40s/test
-          cloudai verify-test-scenarios --system-config conf/common/system/example_slurm_cluster.toml --tests-dir conf/common/test conf/common/test_scenario
+
+          # this checks that all TOMLs are valid, Test Scenarios are checked agains _all_ tests
+          cloudai verify-configs conf/
+
+          # this checks that all TOMLs are valid, Test Scenarios are checked agains _only_ the tests in the specified directory
+          cloudai verify-configs --tests-dir conf/common/test conf/common
+          cloudai verify-configs --tests-dir conf/release/spcx/l40s/test conf/release/spcx/l40s

--- a/src/cloudai/_core/test_parser.py
+++ b/src/cloudai/_core/test_parser.py
@@ -141,7 +141,7 @@ class TestParser:
             else:
                 return strategy_type()
 
-        logging.warning(
+        logging.debug(
             f"No {strategy_interface.__name__} found for " f"{type(self).__name__} and " f"{type(self.system).__name__}"
         )
         return None

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -42,6 +42,7 @@ class CloudAICLI:
             "verify-systems",
             "verify-tests",
             "verify-test-scenarios",
+            "verify-configs",
         }
 
         self.parser = argparse.ArgumentParser(description="Cloud AI")
@@ -101,31 +102,41 @@ class CloudAICLI:
             )
 
         if "verify-systems" in self.DEFAULT_MODES:
-            p = self.add_command("verify-systems", "Verify the system configurations.", handle_verify_systems)
+            p = self.add_command(
+                "verify-systems",
+                "[DEPRECATED: use verify-configs] Verify the system configurations.",
+                handle_verify_systems,
+            )
             p.add_argument("system_configs", help="Path to the system configuration file or directory.", type=Path)
 
         if "verify-tests" in self.DEFAULT_MODES:
-            p = self.add_command("verify-tests", "Verify the test configurations.", handle_verify_tests)
+            p = self.add_command(
+                "verify-tests", "[DEPRECATED: use verify-configs] Verify the test configurations.", handle_verify_tests
+            )
             p.add_argument("test_configs", help="Path to the test configuration file or directory.", type=Path)
 
         if "verify-test-scenarios" in self.DEFAULT_MODES:
             p = self.add_command(
                 "verify-test-scenarios",
-                "Verify the test scenario configurations.",
+                "[DEPRECATED: use verify-configs] Verify the test scenario configurations.",
                 handle_verify_test_scenarios,
                 system_config=False,
                 tests_dir=True,
             )
             p.add_argument("test_scenarios", help="Path to the test scenario file or directory.", type=Path)
 
-        p = self.add_command(
-            "verify-configs",
-            "Verify all found TOML files in the given directory.",
-            handle_verify_all_configs,
-            system_config=False,
-            tests_dir=False,
-        )
-        p.add_argument("config_dir", help="Path to a file or the directory containing the TOML files.", type=Path)
+        if "verify-configs" in self.DEFAULT_MODES:
+            p = self.add_command(
+                "verify-configs",
+                (
+                    "Verify all found TOML files in the given directory. Test Scenarios are verified against all found "
+                    "Test TOML files or all Test TOML files in the given directory."
+                ),
+                handle_verify_all_configs,
+                system_config=False,
+                tests_dir=False,
+            )
+            p.add_argument("configs_dir", help="Path to a file or the directory containing the TOML files.", type=Path)
 
         return self.parser
 

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -123,7 +123,7 @@ class CloudAICLI:
             "Verify all found TOML files in the given directory.",
             handle_verify_all_configs,
             system_config=False,
-            tests_dir=True,
+            tests_dir=False,
         )
         p.add_argument("config_dir", help="Path to a file or the directory containing the TOML files.", type=Path)
 

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -22,6 +22,7 @@ from .handlers import (
     handle_dry_run_and_run,
     handle_generate_report,
     handle_install_and_uninstall,
+    handle_verify_all_configs,
     handle_verify_systems,
     handle_verify_test_scenarios,
     handle_verify_tests,
@@ -112,10 +113,19 @@ class CloudAICLI:
                 "verify-test-scenarios",
                 "Verify the test scenario configurations.",
                 handle_verify_test_scenarios,
-                system_config=True,
+                system_config=False,
                 tests_dir=True,
             )
             p.add_argument("test_scenarios", help="Path to the test scenario file or directory.", type=Path)
+
+        p = self.add_command(
+            "verify-configs",
+            "Verify all found TOML files in the given directory.",
+            handle_verify_all_configs,
+            system_config=False,
+            tests_dir=True,
+        )
+        p.add_argument("config_dir", help="Path to a file or the directory containing the TOML files.", type=Path)
 
         return self.parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ from cloudai.cli import (
     handle_verify_systems,
     handle_verify_tests,
 )
-from cloudai.cli.handlers import handle_verify_test_scenarios
+from cloudai.cli.handlers import handle_verify_all_configs, handle_verify_test_scenarios
 
 
 def test_help_message(capsys: pytest.CaptureFixture[str]) -> None:
@@ -259,6 +259,32 @@ class TestCLIDefaultModes:
             system_config=Path("system_config"),
             tests_dir=Path("tests_dir"),
             **{"test_scenarios": Path("test_scenarios")},
+        )
+
+    def test_verify_all_configs_mode(self, cli: CloudAICLI):
+        assert "verify-configs" in cli.handlers
+        assert cli.handlers["verify-configs"] is handle_verify_all_configs
+
+        args = cli.parser.parse_args(
+            ["verify-configs", "--system-config", "system_config", "--tests-dir", "tests_dir", "configs_dir"]
+        )
+        assert args == argparse.Namespace(
+            log_file="debug.log",
+            log_level="INFO",
+            mode="verify-configs",
+            system_config=Path("system_config"),
+            tests_dir=Path("tests_dir"),
+            **{"configs_dir": Path("configs_dir")},
+        )
+
+        args = cli.parser.parse_args(["verify-configs", "configs_dir"])
+        assert args == argparse.Namespace(
+            log_file="debug.log",
+            log_level="INFO",
+            mode="verify-configs",
+            system_config=None,
+            tests_dir=None,
+            **{"configs_dir": Path("configs_dir")},
         )
 
     def test_report_generation_mode(self, cli: CloudAICLI):


### PR DESCRIPTION
## Summary
Introduce `verify-configs` command that replaces all other `verify-*` commands. Based on https://github.com/NVIDIA/cloudai/pull/267.

New help contains:
```bash
modes:
    ...
    verify-systems      [DEPRECATED: use verify-configs] Verify the system configurations.
    verify-tests        [DEPRECATED: use verify-configs] Verify the test configurations.
    verify-test-scenarios
                        [DEPRECATED: use verify-configs] Verify the test scenario configurations.
    verify-configs      Verify all found TOML files in the given directory. Test Scenarios are verified against all found Test TOML files or all Test TOML files in the given directory.
```

## Test Plan
1. CI
2. Manual runs

## Additional Notes
—
