### PR TITLE
 Fix bugs in updating the output_path of JaxToolbox cmd_args

### DIFF
--- a/src/cloudai/test_definitions/grok.py
+++ b/src/cloudai/test_definitions/grok.py
@@ -91,7 +91,7 @@ class GrokTestDefinition(JaxToolboxTestDefinition):
             if k in {"profile", "perf"}:
                 res.setdefault(f"Grok.{k}", {})
                 res[f"Grok.{k}"]["XLA_FLAGS"] = v
-            elif k in {"pre_test", "docker_image_url", "load_container"}:
+            elif k in {"pre_test", "docker_image_url", "load_container", "output_path"}:
                 res[k] = v
             else:
                 res[f"Grok.{k}"] = v

--- a/tests/slurm_command_gen_strategy/test_jax_toolbox.py
+++ b/tests/slurm_command_gen_strategy/test_jax_toolbox.py
@@ -53,16 +53,19 @@ class TestJaxToolboxSlurmCommandGenStrategy:
             extra_env_vars={"COMBINE_THRESHOLD": "1"},
         )
 
+    @pytest.mark.parametrize("test_fixture", ["gpt_test", "grok_test"])
     def test_gen_exec_command(
         self,
         slurm_system,
         cmd_gen_strategy: JaxToolboxSlurmCommandGenStrategy,
         tmp_path: Path,
-        gpt_test: GPTTestDefinition,
+        request,
+        test_fixture,
     ) -> None:
-        gpt_test.cmd_args.pre_test = PreTest(enable=False)
+        test_def = request.getfixturevalue(test_fixture)
+        test_def.cmd_args.pre_test = PreTest(enable=False)
 
-        test = Test(test_definition=gpt_test, test_template=JaxToolbox(slurm_system, "name"))
+        test = Test(test_definition=test_def, test_template=JaxToolbox(slurm_system, "name"))
         test_run = TestRun(
             test=test,
             num_nodes=1,


### PR DESCRIPTION
## Summary
This is a bug fix for https://redmine.mellanox.com/issues/4125377. The `output_path` is updated in the `gen_exec_command` of `JaxToolboxSlurmCommandGenStrategy`, but it was eventually flattened to `{test_name}.output_path`, which caused the bug. This PR resolves the issue.

## Test Plan
1. CI passes. Added new unit tests
2. The following command works now
```
$ python ./cloudaix.py --log-level DEBUG --log-file dry-run_jax_grok.log dry-run --system-config ... --tests-dir conf/devops/verification/test/ --test-scenario ...
```