### PR TITLE
Fix pre-test generation for JaxToolbox

### DIFF
--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_command_gen_strategy.py
@@ -152,7 +152,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         commands = []
 
-        run_pre_test = cmd_args.get("pre_test", {}).get("enable", False)
+        run_pre_test = cmd_args.get("pre_test.enable", False)
         if run_pre_test:
             output_path = Path(cmd_args["output_path"]).resolve() / "output_pretest-%j-%n-%t.txt"
             error_path = Path(cmd_args["output_path"]).resolve() / "error_pretest-%j-%n-%t.txt"

--- a/tests/slurm_command_gen_strategy/test_jax_toolbox.py
+++ b/tests/slurm_command_gen_strategy/test_jax_toolbox.py
@@ -63,7 +63,7 @@ class TestJaxToolboxSlurmCommandGenStrategy:
         test_fixture,
     ) -> None:
         test_def = request.getfixturevalue(test_fixture)
-        test_def.cmd_args.pre_test = PreTest(enable=False)
+        test_def.cmd_args.pre_test = PreTest(enable=True)
 
         test = Test(test_definition=test_def, test_template=JaxToolbox(slurm_system, "name"))
         test_run = TestRun(
@@ -74,9 +74,13 @@ class TestJaxToolboxSlurmCommandGenStrategy:
             name="test-job",
         )
 
+        cmd_gen_strategy._generate_pre_test_command = MagicMock(return_value="pre_test_command")
         cmd = cmd_gen_strategy.gen_exec_command(test_run)
         assert cmd == f"sbatch {test_run.output_path}/cloudai_sbatch_script.sh"
         assert (test_run.output_path / "run.sh").exists()
+
+        content = Path(f"{test_run.output_path}/cloudai_sbatch_script.sh").read_text()
+        assert "pre_test_command" in content
 
     @pytest.mark.parametrize(
         "cmd_args, expected",


### PR DESCRIPTION
## Summary
Fixed pre-test generation for JaxToolbox. Internal [bug](https://redmine.mellanox.com/issues/4127427).

## Test Plan
1. CI. Updated unit-tests to catch the issue.
2. Command line from the bug in dry-run mode.

## Additional Notes
—
