### PR TITLE
Rename --output-dir to --results-dir for generate-report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cloudai generate-report\
     --tests-dir conf/common/test\
     --results-dir /path/to/results_directory
 ```
-In the generate-report mode, use the --output-dir argument to specify a subdirectory under the result directory.
+In the generate-report mode, use the --results-dir argument to specify a subdirectory under the result directory.
 This subdirectory is usually named with a timestamp for unique identification.
 
 To uninstall test prerequisites, run CloudAI CLI in uninstall mode:

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ To generate reports, execute CloudAI CLI in generate-report mode:
 cloudai generate-report\
     --system-config conf/common/system/example_slurm_cluster.toml\
     --tests-dir conf/common/test\
-    --results-dir /path/to/results_directory
+    --result-dir /path/to/result_directory
 ```
-In the generate-report mode, use the --results-dir argument to specify a subdirectory under the output directory.
+In the generate-report mode, use the --result-dir argument to specify a subdirectory under the output directory.
 This subdirectory is usually named with a timestamp for unique identification.
 
 To uninstall test prerequisites, run CloudAI CLI in uninstall mode:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cloudai generate-report\
     --tests-dir conf/common/test\
     --results-dir /path/to/results_directory
 ```
-In the generate-report mode, use the --results-dir argument to specify a subdirectory under the result directory.
+In the generate-report mode, use the --results-dir argument to specify a subdirectory under the output directory.
 This subdirectory is usually named with a timestamp for unique identification.
 
 To uninstall test prerequisites, run CloudAI CLI in uninstall mode:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To generate reports, execute CloudAI CLI in generate-report mode:
 cloudai generate-report\
     --system-config conf/common/system/example_slurm_cluster.toml\
     --tests-dir conf/common/test\
-    --output-dir /path/to/output_directory
+    --results-dir /path/to/results_directory
 ```
 In the generate-report mode, use the --output-dir argument to specify a subdirectory under the result directory.
 This subdirectory is usually named with a timestamp for unique identification.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -173,10 +173,10 @@ cloudai generate-report \
    --test-scenario myconfig/scenario.toml \
    --system-config myconfig/system.toml \
    --tests-dir myconfig/tests/ \
-   --results-dir results/2024-06-18_17-40-13/
+   --result-dir results/2024-06-18_17-40-13/
 ```
 
-`--results-dir` accepts one scenario run results directory.
+`--result-dir` accepts one scenario run result directory.
 
 ## Describing a System in the System Schema
 In this section, we introduce the concept of the system schema, explain the meaning of each field, and describe how the fields should be used. The system schema is a TOML file that allows users to define a system's configuration.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -176,7 +176,7 @@ cloudai generate-report \
    --results-dir results/2024-06-18_17-40-13/
 ```
 
-`--output-dir` accepts one scenario run results directory.
+`--results-dir` accepts one scenario run results directory.
 
 ## Describing a System in the System Schema
 In this section, we introduce the concept of the system schema, explain the meaning of each field, and describe how the fields should be used. The system schema is a TOML file that allows users to define a system's configuration.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -173,7 +173,7 @@ cloudai generate-report \
    --test-scenario myconfig/scenario.toml \
    --system-config myconfig/system.toml \
    --tests-dir myconfig/tests/ \
-   --output-dir results/2024-06-18_17-40-13/
+   --results-dir results/2024-06-18_17-40-13/
 ```
 
 `--output-dir` accepts one scenario run results directory.

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -62,6 +62,7 @@ class CloudAICLI:
         tests_dir: Optional[bool] = None,
         test_scenario: Optional[bool] = None,
         output_dir: Optional[bool] = None,
+        results_dir: Optional[bool] = None,
     ) -> argparse.ArgumentParser:
         p = self.subparsers.add_parser(name, help=help_text)
         self.handlers[name] = handler
@@ -77,6 +78,8 @@ class CloudAICLI:
             p.add_argument("--test-scenario", help="Path to the test scenario file.", required=test_scenario, type=Path)
         if output_dir is not None:
             p.add_argument("--output-dir", help="Path to the output directory.", required=output_dir, type=Path)
+        if results_dir is not None:
+            p.add_argument("--results-dir", help="Path to the results directory.", required=results_dir, type=Path)
 
         return p
 
@@ -92,7 +95,7 @@ class CloudAICLI:
                 system_config=True,
                 tests_dir=True,
                 test_scenario=True,
-                output_dir=True,
+                results_dir=True,
             )
 
         if "verify-configs" in self.DEFAULT_MODES:

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -62,7 +62,7 @@ class CloudAICLI:
         tests_dir: Optional[bool] = None,
         test_scenario: Optional[bool] = None,
         output_dir: Optional[bool] = None,
-        results_dir: Optional[bool] = None,
+        result_dir: Optional[bool] = None,
     ) -> argparse.ArgumentParser:
         p = self.subparsers.add_parser(name, help=help_text)
         self.handlers[name] = handler
@@ -78,8 +78,8 @@ class CloudAICLI:
             p.add_argument("--test-scenario", help="Path to the test scenario file.", required=test_scenario, type=Path)
         if output_dir is not None:
             p.add_argument("--output-dir", help="Path to the output directory.", required=output_dir, type=Path)
-        if results_dir is not None:
-            p.add_argument("--results-dir", help="Path to the results directory.", required=results_dir, type=Path)
+        if result_dir is not None:
+            p.add_argument("--result-dir", help="Path to the result directory.", required=result_dir, type=Path)
 
         return p
 
@@ -95,7 +95,7 @@ class CloudAICLI:
                 system_config=True,
                 tests_dir=True,
                 test_scenario=True,
-                results_dir=True,
+                result_dir=True,
             )
 
         if "verify-configs" in self.DEFAULT_MODES:

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -175,7 +175,7 @@ def handle_generate_report(args: argparse.Namespace) -> int:
     assert test_scenario is not None
 
     logging.info("Generating report based on system and test scenario")
-    generator = ReportGenerator(args.results_dir)
+    generator = ReportGenerator(args.result_dir)
     generator.generate_report(test_scenario)
 
     logging.info("Report generation completed.")

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -175,7 +175,7 @@ def handle_generate_report(args: argparse.Namespace) -> int:
     assert test_scenario is not None
 
     logging.info("Generating report based on system and test scenario")
-    generator = ReportGenerator(args.output_dir)
+    generator = ReportGenerator(args.results_dir)
     generator.generate_report(test_scenario)
 
     logging.info("Report generation completed.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,8 +258,8 @@ class TestCLIDefaultModes:
                 "tests_dir",
                 "--test-scenario",
                 "test_scenario",
-                "--results-dir",
-                "results_dir",
+                "--result-dir",
+                "result_dir",
             ]
         )
         assert args == argparse.Namespace(
@@ -267,7 +267,7 @@ class TestCLIDefaultModes:
             log_level="INFO",
             mode="generate-report",
             test_scenario=Path("test_scenario"),
-            results_dir=Path("results_dir"),
+            result_dir=Path("result_dir"),
             system_config=Path("system_config"),
             tests_dir=Path("tests_dir"),
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,8 +258,8 @@ class TestCLIDefaultModes:
                 "tests_dir",
                 "--test-scenario",
                 "test_scenario",
-                "--output-dir",
-                "output_dir",
+                "--results-dir",
+                "results_dir",
             ]
         )
         assert args == argparse.Namespace(
@@ -267,7 +267,7 @@ class TestCLIDefaultModes:
             log_level="INFO",
             mode="generate-report",
             test_scenario=Path("test_scenario"),
-            output_dir=Path("output_dir"),
+            results_dir=Path("results_dir"),
             system_config=Path("system_config"),
             tests_dir=Path("tests_dir"),
         )


### PR DESCRIPTION
## Summary
Bug fix for https://redmine.mellanox.com/issues/4125866. 

## Test Plan
1. CI passes
2. Ran on a server
```
(test4) theo@login-eos02:~/cloudaix-main$ rm results/nccl-test_2024-10-21_05-58-17/Tests.1/0/cloudai_nccl_test_bokeh_report.html
(test4) theo@login-eos02:~/cloudaix-main$ rm results/nccl-test_2024-10-21_05-58-17/Tests.1/0/cloudai_nccl_test_csv_report.csv 
(test4) theo@login-eos02:~/cloudaix-main$ python ./cloudaix.py generate-report --system-config /home/theo/cloudaix-main/conf/common/system/eos.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nccl_test.toml --results-dir results/nccl-test_2024-10-21_05-58-17/
/home/theo/scratch/miniconda3/envs/test4/lib/python3.9/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.20) or chardet (5.2.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
[INFO] Generating report based on system and test scenario
[INFO] Report generation completed.
(test4) theo@login-eos02:~/cloudaix-main$ ls results/nccl-test_2024-10-21_05-58-17/Tests.1/0/
cloudai_nccl_test_bokeh_report.html  cloudai_nccl_test_csv_report.csv  cloudai_sbatch_script.sh  stderr.txt  stdout.txt
```