### PR TITLE
Remove delay support in dependencies

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -135,7 +135,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.1"
-  time = 0
 ```
 
 Notes on the test scenario:
@@ -264,7 +263,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.1"
-  time = 0
 
 [[Tests]]
 id = "Tests.3"
@@ -274,7 +272,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.2"
-  time = 0
 ```
 
 The `name` field is the test scenario name, which can be any unique identifier for the scenario. Each test has a section name, following the convention `Tests.1`, `Tests.2`, etc., with an increasing index. The `name` of a test should be specified in this section and must correspond to an entry in the test schema. If a test in a test scenario is not present in the test schema, CloudAI will not be able to identify it.
@@ -283,7 +280,7 @@ There are two ways to specify nodes. The first is using the `num_nodes` field as
 
 You can optionally specify a time limit in the Slurm format. Tests can have dependencies. If no dependencies are specified, all tests will run in parallel. CloudAI supports three types of dependencies: `start_post_init`, `start_post_comp`, and `end_post_comp`.
 
-Dependencies of a test can be described as a subsection of the test. The dependency name should appear first, followed by a dictionary as its value. The dictionary has two fields: `name` and `time`. The `name` field specifies the test that the current test depends on, and the `time` field specifies the delay in seconds.
+Dependencies of a test can be described as a subsection of the test. It requires other tests' `id` and dependency `type`.
 
 - `start_post_init` means the test starts after the prior test begins, with a specified delay.
 - `start_post_comp` means the test starts after the prior test completes.

--- a/conf/common/test_scenario/nccl_test.toml
+++ b/conf/common/test_scenario/nccl_test.toml
@@ -29,7 +29,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.1"
-  time = 0
 
 
 [[Tests]]
@@ -40,7 +39,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.2"
-  time = 0
 
 
 [[Tests]]
@@ -51,7 +49,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.3"
-  time = 0
 
 
 [[Tests]]
@@ -62,7 +59,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.4"
-  time = 0
 
 
 [[Tests]]
@@ -73,7 +69,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.5"
-  time = 0
 
 
 [[Tests]]
@@ -84,7 +79,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.6"
-  time = 0
 
 
 [[Tests]]
@@ -95,7 +89,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.7"
-  time = 0
 
 
 [[Tests]]
@@ -106,7 +99,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.8"
-  time = 0
 
 
 [[Tests]]
@@ -117,7 +109,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.9"
-  time = 0
 
 
 [[Tests]]
@@ -128,7 +119,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.10"
-  time = 0
 
 
 [[Tests]]
@@ -139,7 +129,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.11"
-  time = 0
 
 
 [[Tests]]
@@ -150,7 +139,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.12"
-  time = 0
 
 
 [[Tests]]
@@ -161,7 +149,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.13"
-  time = 0
 
 
 [[Tests]]
@@ -172,7 +159,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.14"
-  time = 0
 
 
 [[Tests]]
@@ -183,7 +169,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.15"
-  time = 0
 
 
 [[Tests]]
@@ -194,7 +179,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.16"
-  time = 0
 
 
 [[Tests]]
@@ -205,7 +189,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.17"
-  time = 0
 
 
 [[Tests]]
@@ -216,7 +199,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.18"
-  time = 0
 
 
 [[Tests]]
@@ -227,7 +209,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.19"
-  time = 0
 
 
 [[Tests]]
@@ -238,7 +219,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.20"
-  time = 0
 
 
 [[Tests]]
@@ -249,7 +229,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.21"
-  time = 0
 
 
 [[Tests]]
@@ -260,7 +239,6 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.22"
-  time = 0
 
 
 [[Tests]]
@@ -271,4 +249,3 @@ time_limit = "00:20:00"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.23"
-  time = 0

--- a/conf/common/test_scenario/nemo_launcher.toml
+++ b/conf/common/test_scenario/nemo_launcher.toml
@@ -27,7 +27,6 @@ num_nodes = "4"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.1"
-  time = 0
 
 
 [[Tests]]
@@ -37,4 +36,3 @@ num_nodes = "4"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.2"
-  time = 0

--- a/conf/common/test_scenario/nemo_launcher_with_noise.toml
+++ b/conf/common/test_scenario/nemo_launcher_with_noise.toml
@@ -28,4 +28,3 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "start_post_init"
   id = "Tests.1"
-  time = 450

--- a/conf/common/test_scenario/sleep.toml
+++ b/conf/common/test_scenario/sleep.toml
@@ -26,7 +26,6 @@ test_name = "sleep_5"
   [[Tests.dependencies]]
   type = "start_post_init"
   id = "Tests.1"
-  time = 5
 
 [[Tests]]
 id = "Tests.3"
@@ -34,7 +33,6 @@ test_name = "sleep_5"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.1"
-  time = 0
 
 [[Tests]]
 id = "Tests.4"
@@ -42,4 +40,3 @@ test_name = "sleep_20"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.1"
-  time = 5

--- a/conf/common/test_scenario/ucc_test.toml
+++ b/conf/common/test_scenario/ucc_test.toml
@@ -28,7 +28,6 @@ num_nodes = "2"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.1"
-  time = 0
 
 [[Tests]]
 id = "Tests.3"
@@ -37,7 +36,6 @@ num_nodes = "2"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.2"
-  time = 0
 
 [[Tests]]
 id = "Tests.4"
@@ -46,7 +44,6 @@ num_nodes = "2"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.3"
-  time = 0
 
 [[Tests]]
 id = "Tests.5"
@@ -55,4 +52,3 @@ num_nodes = "2"
   [[Tests.dependencies]]
   type = "start_post_comp"
   id = "Tests.4"
-  time = 0

--- a/conf/release/spcx/l40s/test_scenario/l40s_bc_nccl_test.toml
+++ b/conf/release/spcx/l40s/test_scenario/l40s_bc_nccl_test.toml
@@ -27,7 +27,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.1"
-  time = 0
 
 
 [[Tests]]
@@ -37,7 +36,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.2"
-  time = 0
 
 
 [[Tests]]
@@ -47,7 +45,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.3"
-  time = 0
 
 
 [[Tests]]
@@ -58,7 +55,6 @@ time_limit = "00:30:00"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.4"
-  time = 0
 
 
 [[Tests]]
@@ -68,7 +64,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.5"
-  time = 0
 
 
 [[Tests]]
@@ -78,7 +73,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.6"
-  time = 0
 
 
 [[Tests]]
@@ -88,7 +82,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.7"
-  time = 0
 
 
 [[Tests]]
@@ -98,7 +91,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.8"
-  time = 0
 
 
 [[Tests]]
@@ -108,7 +100,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.9"
-  time = 0
 
 
 [[Tests]]
@@ -118,7 +109,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.10"
-  time = 0
 
 
 [[Tests]]
@@ -128,7 +118,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.11"
-  time = 0
 
 
 [[Tests]]
@@ -138,7 +127,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.12"
-  time = 0
 
 
 [[Tests]]
@@ -148,7 +136,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.13"
-  time = 0
 
 
 [[Tests]]
@@ -158,7 +145,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.14"
-  time = 0
 
 
 [[Tests]]
@@ -168,7 +154,6 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.15"
-  time = 0
 
 
 [[Tests]]
@@ -178,4 +163,3 @@ num_nodes = "16"
   [[Tests.dependencies]]
   type = "end_post_comp"
   id = "Tests.16"
-  time = 0

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -169,7 +169,7 @@ class BaseRunner(ABC):
             logging.error(e)
             exit(1)
 
-    async def delayed_submit_test(self, tr: TestRun, delay: int):
+    async def delayed_submit_test(self, tr: TestRun, delay: int = 0):
         """
         Delay the start of a test based on start_post_comp dependency.
 
@@ -218,7 +218,7 @@ class BaseRunner(ABC):
             if tr not in self.testrun_to_job_map:
                 for dep_type, dep in tr.dependencies.items():
                     if (dep_type == "start_post_init") and (dep.test_run == started_test_run):
-                        await self.delayed_submit_test(tr, dep.time)
+                        await self.delayed_submit_test(tr)
 
     def find_dependency_free_tests(self) -> List[TestRun]:
         """
@@ -372,7 +372,7 @@ class BaseRunner(ABC):
             if tr not in self.testrun_to_job_map:
                 for dep_type, dep in tr.dependencies.items():
                     if dep_type == "start_post_comp" and dep.test_run.test == completed_job.test_run.test:
-                        task = await self.delayed_submit_test(tr, dep.time)
+                        task = await self.delayed_submit_test(tr)
                         if task:
                             tasks.append(task)
 
@@ -380,7 +380,7 @@ class BaseRunner(ABC):
         for test, dependent_job in self.testrun_to_job_map.items():
             for dep_type, dep in test.dependencies.items():
                 if dep_type == "end_post_comp" and dep.test_run.test == completed_job.test_run.test:
-                    task = await self.delayed_kill_job(dependent_job, dep.time)
+                    task = await self.delayed_kill_job(dependent_job)
                     tasks.append(task)
 
         return tasks

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -28,21 +28,18 @@ class TestDependency:
 
     Attributes
         test_run (TestRun): TestRun object it depends on.
-        time (int): Time in seconds after which this dependency is met.
     """
 
     __test__ = False
 
-    def __init__(self, test_run: "TestRun", time: int) -> None:
+    def __init__(self, test_run: "TestRun") -> None:
         """
         Initialize a TestDependency instance.
 
         Args:
             test_run (TestRun): TestRun object it depends on.
-            time (int): Time in seconds to meet the dependency.
         """
         self.test_run = test_run
-        self.time = time
 
 
 @dataclass
@@ -120,10 +117,7 @@ class TestScenario:
             if tr.dependencies:
                 for dep_type, dependency in tr.dependencies.items():
                     if dependency:
-                        s += (
-                            f"  {dep_type.replace('_', ' ').title()}: {dependency.test_run.name}, "
-                            f"Time: {dependency.time} seconds"
-                        )
+                        s += f"  {dep_type.replace('_', ' ').title()}: {dependency.test_run.name}"
             else:
                 s += "  No dependencies"
         return s

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -30,7 +30,6 @@ class _TestDependencyTOML(BaseModel):
 
     type: Literal["end_post_comp", "start_post_init", "start_post_comp"]
     id: str
-    time: int = 0
 
 
 class _TestRunTOML(BaseModel):
@@ -144,8 +143,7 @@ class TestScenarioParser:
         for section, tr in testruns_by_id.items():
             test_info = tests_data[section]
             tr.dependencies = {
-                dep.type: TestDependency(time=dep.time, test_run=testruns_by_id[dep.id])
-                for dep in test_info.dependencies
+                dep.type: TestDependency(test_run=testruns_by_id[dep.id]) for dep in test_info.dependencies
             }
 
         return TestScenario(

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -150,7 +150,6 @@ def test_two_dependent_cases(test: Test, test_scenario_parser: TestScenarioParse
     assert test_scenario.test_runs[0].test.name == t1.name
     assert "end_post_comp" in test_scenario.test_runs[0].dependencies
     assert isinstance(test_scenario.test_runs[0].dependencies["end_post_comp"].test_run, TestRun)
-    assert test_scenario.test_runs[0].dependencies["end_post_comp"].time == 0
 
     assert test_scenario.test_runs[1].test.name == t2.name
     assert test_scenario.test_runs[1].dependencies == {}


### PR DESCRIPTION
## Summary
As we can't guarantee this delay, we are removing it to avoid confusion.

## Test Plan
CI.

## Additional Notes
—
