### PR TITLE
Fix bug by removing trailing newline from +cluster.nodelist in command args

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -193,7 +193,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         if nodes:
             nodes_str = ",".join(nodes)
-            cmd_arg_str_parts.append(f"+cluster.nodelist=\\'{nodes_str}\\'\n")
+            cmd_arg_str_parts.append(f"+cluster.nodelist=\\'{nodes_str}\\'")
 
         return " ".join(cmd_arg_str_parts + env_var_str_parts)
 

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
@@ -55,30 +55,34 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         return NeMoLauncherSlurmCommandGenStrategy(slurm_system, {})
 
     @pytest.mark.parametrize(
-        "expected_content",
+        "expected_content, nodes",
         [
-            [
-                "TEST_VAR_1=value1",
-                "+env_vars.TEST_VAR_1=value1",
-                'stages=["training"]',
-                "cluster.gpus_per_node=null",
-                "cluster.partition=main",
-                "numa_mapping.enable=True",
-                "training.exp_manager.create_checkpoint_callback=False",
-                "training.model.data.data_impl=mock",
-                "training.model.data.data_prefix=[]",
-                "training.model.global_batch_size=128",
-                "training.model.micro_batch_size=2",
-                "training.model.pipeline_model_parallel_size=4",
-                "training.model.tensor_model_parallel_size=4",
-                "training.run.time_limit=3:00:00",
-                "training.trainer.enable_checkpointing=False",
-                "training.trainer.log_every_n_steps=1",
-                "training.trainer.max_steps=400",
-                "training.trainer.num_nodes=2",
-                "training.trainer.val_check_interval=100",
-                "training=gpt3/40b_improved",
-            ]
+            (
+                [
+                    "TEST_VAR_1=value1",
+                    "+env_vars.TEST_VAR_1=value1",
+                    'stages=["training"]',
+                    "cluster.gpus_per_node=null",
+                    "cluster.partition=main",
+                    "numa_mapping.enable=True",
+                    "training.exp_manager.create_checkpoint_callback=False",
+                    "training.model.data.data_impl=mock",
+                    "training.model.data.data_prefix=[]",
+                    "training.model.global_batch_size=128",
+                    "training.model.micro_batch_size=2",
+                    "training.model.pipeline_model_parallel_size=4",
+                    "training.model.tensor_model_parallel_size=4",
+                    "training.run.time_limit=3:00:00",
+                    "training.trainer.enable_checkpointing=False",
+                    "training.trainer.log_every_n_steps=1",
+                    "training.trainer.max_steps=400",
+                    "training.trainer.num_nodes=2",
+                    "training.trainer.val_check_interval=100",
+                    "training=gpt3/40b_improved",
+                    "+cluster.nodelist=\\'node1,node2\\'",
+                ],
+                ["node1", "node2"],
+            ),
         ],
     )
     def test_generate_exec_command(
@@ -86,8 +90,11 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy,
         test_run: TestRun,
         expected_content: List[str],
+        nodes: List[str],
     ) -> None:
+        test_run.nodes = nodes
         cmd = cmd_gen_strategy.gen_exec_command(test_run)
+
         for content in expected_content:
             assert any(content in part for part in cmd.split())
         assert "training.run.name=" in cmd


### PR DESCRIPTION
## Summary
Bug fix for https://redmine.mellanox.com/issues/4128871.

## Test Plan
1. CI passes
2. Ran on a server
num_nodes
```
#!/bin/bash

# Parameters
#SBATCH --account=coreai_dlalgo_ci
#SBATCH --error=/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.err
#SBATCH --exclusive
#SBATCH --job-name=coreai_dlalgo_ci-cloudai.nemo:run
#SBATCH --mem=0
#SBATCH --nodes=8
#SBATCH --ntasks-per-node=8
#SBATCH --output=/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.out
#SBATCH --partition=batch
#SBATCH --time=96:00:00

# setup
export NCCL_IB_TIMEOUT=20
export TRANSFORMERS_OFFLINE=0
export TORCH_NCCL_AVOID_RECORD_STREAMS=1
export NCCL_NVLS_ENABLE=0
export NVTE_DP_AMAX_REDUCE_INTERVAL=0
export NVTE_ASYNC_AMAX_REDUCTION=1
export NVTE_FUSED_ATTN=0
export NCCL_SOCKET_IFNAME=eno8303
export NCCL_IB_GID_INDEX=3
export NCCL_IB_TC=96
export NCCL_IB_HCA=mlx5_0:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_9:1,mlx5_10:1,mlx5_11:1
export NCCL_IB_QPS_PER_CONNECTION=4
export NCCL_IB_ADAPTIVE_ROUTING=1
export NCCL_IB_SPLIT_DATA_ON_QPS=0
export NCCL_IBEXT_DISABLE=0
export OMPI_MCA_btl=tcp,self
export OMPI_MCA_btl_tcp_if_include=eno8303
export UCX_IB_GID_INDEX=3
export UCX_RNDV_SCHEME=get_zcopy
export UCX_RNDV_THRESH=0
export MELLANOX_VISIBLE_DEVICES=0,3,4,5,6,9,10,11
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export GLOO_SOCKET_IFNAME=eno8303
export HYDRA_FULL_ERROR=1

# command 1
srun --output /home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.out --error /home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.err --container-image nvcr.io/nvidia/nemo:24.05.01 --container-mounts /home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts:/home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts,/home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts/data:/home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts/data,/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0:/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0 --no-container-mount-home --mpi=pmix bash -c "
  cd /opt/NeMo;
  git rev-parse HEAD;
  export PYTHONPATH=/opt/NeMo:\${PYTHONPATH};
  CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 nsys profile -s none -t nvtx,cuda -o /home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0/run/results/profile_logs/profile_\${SLURM_JOB_ID}_node\${SLURM_NODEID}_rank\${SLURM_PROCID} --force-overwrite true --capture-range=cudaProfilerApi --capture-range-end=stop python3 -u /opt/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py  \
  --config-path=/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-33-39/Tests.1/0/run \
  --config-name=run_hydra.yaml \
  model.gc_interval=100 "
```
nodes
```
#!/bin/bash

# Parameters
#SBATCH --account=coreai_dlalgo_ci
#SBATCH --error=/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.err
#SBATCH --exclusive
#SBATCH --job-name=coreai_dlalgo_ci-cloudai.nemo:run
#SBATCH --mem=0
#SBATCH --nodelist=eos1,eos2,eos3,eos06,eos07,eos08,eos09,eos10,eos11
#SBATCH --nodes=9
#SBATCH --ntasks-per-node=8
#SBATCH --output=/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.out
#SBATCH --partition=batch
#SBATCH --time=96:00:00

# setup
export NCCL_IB_TIMEOUT=20
export TRANSFORMERS_OFFLINE=0
export TORCH_NCCL_AVOID_RECORD_STREAMS=1
export NCCL_NVLS_ENABLE=0
export NVTE_DP_AMAX_REDUCE_INTERVAL=0
export NVTE_ASYNC_AMAX_REDUCTION=1
export NVTE_FUSED_ATTN=0
export NCCL_SOCKET_IFNAME=eno8303
export NCCL_IB_GID_INDEX=3
export NCCL_IB_TC=96
export NCCL_IB_HCA=mlx5_0:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_9:1,mlx5_10:1,mlx5_11:1
export NCCL_IB_QPS_PER_CONNECTION=4
export NCCL_IB_ADAPTIVE_ROUTING=1
export NCCL_IB_SPLIT_DATA_ON_QPS=0
export NCCL_IBEXT_DISABLE=0
export OMPI_MCA_btl=tcp,self
export OMPI_MCA_btl_tcp_if_include=eno8303
export UCX_IB_GID_INDEX=3
export UCX_RNDV_SCHEME=get_zcopy
export UCX_RNDV_THRESH=0
export MELLANOX_VISIBLE_DEVICES=0,3,4,5,6,9,10,11
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export GLOO_SOCKET_IFNAME=eno8303
export HYDRA_FULL_ERROR=1

# command 1
srun --output /home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.out --error /home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0/run/log-coreai_dlalgo_ci-cloudai.nemo:run_%j.err --container-image nvcr.io/nvidia/nemo:24.05.01 --container-mounts /home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts:/home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts,/home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts/data:/home/theo/cloudaix-main/install/NeMo-Launcher/NeMo-Launcher/launcher_scripts/data,/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0:/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0 --no-container-mount-home --mpi=pmix bash -c "
  cd /opt/NeMo;
  git rev-parse HEAD;
  export PYTHONPATH=/opt/NeMo:\${PYTHONPATH};
  CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 nsys profile -s none -t nvtx,cuda -o /home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0/run/results/profile_logs/profile_\${SLURM_JOB_ID}_node\${SLURM_NODEID}_rank\${SLURM_PROCID} --force-overwrite true --capture-range=cudaProfilerApi --capture-range-end=stop python3 -u /opt/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py  \
  --config-path=/home/theo/cloudaix-main/results/llama3_70b_16N_LONG_RUN_2024-10-23_03-34-46/Tests.1/0/run \
  --config-name=run_hydra.yaml \
  model.gc_interval=100 "
```