### PR TITLE
Use the latest Chakra replay

### DIFF
--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -37,11 +37,10 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
     def generate_test_command(self, env_vars: Dict[str, str], cmd_args: Dict[str, str], tr: TestRun) -> List[str]:
         srun_command_parts = [
-            "python /workspace/param/train/comms/pt/commsTraceReplay.py",
+            "comm_replay",
             f'--trace-type {cmd_args["trace_type"]}',
             f'--trace-path {cmd_args["trace_path"]}',
-            f'--backend {cmd_args["backend"]}',
-            f'--device {cmd_args["device"]}',
+            f'--num-replays {cmd_args["num_replays"]}',
             tr.test.extra_cmd_args,
         ]
         return srun_command_parts

--- a/src/cloudai/test_definitions/chakra_replay.py
+++ b/src/cloudai/test_definitions/chakra_replay.py
@@ -27,8 +27,7 @@ class ChakraReplayCmdArgs(CmdArgs):
     mpi: str = "pmix"
     trace_type: str = "et"
     trace_path: Optional[str] = None
-    backend: str = "nccl"
-    device: str = "cuda"
+    num_replays: int = 1
 
 
 class ChakraReplayTestDefinition(TestDefinition):

--- a/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
@@ -91,26 +91,24 @@ class TestChakraReplaySlurmCommandGenStrategy:
         "cmd_args, extra_cmd_args, expected_result",
         [
             (
-                {"trace_type": "comms_trace", "trace_path": "/workspace/traces/", "backend": "nccl", "device": "gpu"},
+                {"trace_type": "comms_trace", "trace_path": "/workspace/traces/", "num_replays": 10},
                 "--max-steps 100",
                 [
-                    "python /workspace/param/train/comms/pt/commsTraceReplay.py",
+                    "comm_replay",
                     "--trace-type comms_trace",
                     "--trace-path /workspace/traces/",
-                    "--backend nccl",
-                    "--device gpu",
+                    "--num-replays 10",
                     "--max-steps 100",
                 ],
             ),
             (
-                {"trace_type": "comms_trace", "trace_path": "/workspace/traces/", "backend": "nccl", "device": "gpu"},
+                {"trace_type": "comms_trace", "trace_path": "/workspace/traces/", "num_replays": 5},
                 "",
                 [
-                    "python /workspace/param/train/comms/pt/commsTraceReplay.py",
+                    "comm_replay",
                     "--trace-type comms_trace",
                     "--trace-path /workspace/traces/",
-                    "--backend nccl",
-                    "--device gpu",
+                    "--num-replays 5",
                     "",
                 ],
             ),
@@ -132,7 +130,7 @@ class TestChakraReplaySlurmCommandGenStrategy:
     def test_generate_test_command_invalid_args(
         self, cmd_gen_strategy: ChakraReplaySlurmCommandGenStrategy, slurm_system: SlurmSystem
     ) -> None:
-        cmd_args: Dict[str, str] = {"trace_type": "comms_trace", "backend": "nccl", "device": "gpu"}
+        cmd_args: Dict[str, str] = {"trace_type": "comms_trace"}
 
         tr = create_autospec_dataclass(TestRun)
         tr.test.extra_cmd_args = "--max-steps 100"


### PR DESCRIPTION
## Summary
Chakra replay has been renovated by Sanshan, Songyan, and Taekyung. This PR updates Chakra replay so that it can use the latest Chakra replay

## Test Plan
1. CI passes
2. Ran on a real system: /auto/e2e/israel1/workload_results/chakra_replay_2024-11-06_17-54-27/Tests.1/0
stdout.txt
```
--------------------------------------------------
+ 1 all_gather
--------------------------------------------------
Size of Input tensors (bytes)
 Total (MB)            Max.       Min.       Average           p50           p95
    976.56   1024000000.00 1024000000.00   1024000000.00   1024000000.00   1024000000.00
Size of Output tensors (bytes)
 Total (MB)            Max.       Min.       Average           p50           p95
   7812.50   8192000000.00 8192000000.00   8192000000.00   8192000000.00   8192000000.00
--------------------------------------------------
+ 1 all_reduce
--------------------------------------------------
Size of Input tensors (bytes)
 Total (MB)            Max.       Min.       Average           p50           p95
    976.56   1024000000.00 1024000000.00   1024000000.00   1024000000.00   1024000000.00
Size of Output tensors (bytes)
 Total (MB)            Max.       Min.       Average           p50           p95
    976.56   1024000000.00 1024000000.00   1024000000.00   1024000000.00   1024000000.00
--------------------------------------------------
+ 1 reduce_scatter_base
--------------------------------------------------
Size of Input tensors (bytes)
 Total (MB)            Max.       Min.       Average           p50           p95
   7812.50   8192000000.00 8192000000.00   8192000000.00   8192000000.00   8192000000.00
Size of Output tensors (bytes)
 Total (MB)            Max.       Min.       Average           p50           p95
    976.56   1024000000.00 1024000000.00   1024000000.00   1024000000.00   1024000000.00

==================== Performance of replayed comms ====================
--------------------------------------------------
 Total latency (us) of comms in trace 4676694.207: 
--------------------------------------------------
--------------------------------------------------
 Replayed 1 all_gather (46.36%): 
--------------------------------------------------
Latency (us)
      Total       Max.       Min.    Average        p50        p95
 2104266.33 2104266.33 2104266.33 2104266.33 2104266.33 2104266.33
--------------------------------------------------
 Replayed 1 all_reduce (14.06%): 
--------------------------------------------------
Latency (us)
      Total       Max.       Min.    Average        p50        p95
  638121.91  638121.91  638121.91  638121.91  638121.91  638121.91
--------------------------------------------------
 Replayed 1 reduce_scatter_base (39.58%): 
--------------------------------------------------
Latency (us)
      Total       Max.       Min.    Average        p50        p95
 1796687.05 1796687.05 1796687.05 1796687.05 1796687.05 1796687.05
--------------------------------------------------
 Replayed 3 wait (0.00%): 
--------------------------------------------------
Latency (us)
      Total       Max.       Min.    Average        p50        p95
      71.50      48.21      10.04      23.83      13.25      44.71
```