### PR TITLE
Use absolute path for NeMo launcher repository

### DIFF
--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -47,7 +47,11 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             )
         self.final_cmd_args["cluster.gpus_per_node"] = self.system.gpus_per_node or "null"
 
-        repo_path = tdef.python_executable.git_repo.installed_path
+        repo_path = (
+            tdef.python_executable.git_repo.installed_path.absolute()
+            if tdef.python_executable.git_repo.installed_path is not None
+            else None
+        )
         if not repo_path:
             logging.warning(
                 f"Local clone of git repo {tdef.python_executable.git_repo} does not exist. "


### PR DESCRIPTION
## Summary
Bug fix for https://redmine.mellanox.com/issues/4170613

## Test Plan
1. CI passes
2. Ran on a server
```
$ python cloudaix.py --log-level DEBUG --log-file run_nemo_gpt3_40b.log run --system-config conf/common/system/israel_1.toml --tests-dir conf/common/test/ --test-scenario conf/devops/verification/test_scenario/nemo_gpt3_40b_nightly.toml
[INFO] Initializing Runner [RUN] mode 
[INFO] Creating SlurmRunner
[DEBUG] SlurmRunner initialized
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[DEBUG] Executing command for test Tests.1: NCCL_SOCKET_IFNAME=eno8303 NCCL_IB_GID_INDEX=3 NCCL_IB_TC=96 NCCL_IB_HCA=mlx5_0:1,mlx5_3:1,mlx5_4:1,mlx5_5
:1,mlx5_6:1,mlx5_9:1,mlx5_10:1,mlx5_11:1 NCCL_IB_ADAPTIVE_ROUTING=1 NCCL_IB_SPLIT_DATA_ON_QPS=0 NCCL_IBEXT_DISABLE=0 OMPI_MCA_btl=tcp,self OMPI_MCA_bt
l_tcp_if_include=eno8303 UCX_IB_GID_INDEX=3 UCX_RNDV_SCHEME=get_zcopy UCX_RNDV_THRESH=0 MELLANOX_VISIBLE_DEVICES=0,3,4,5,6,9,10,11 CUDA_VISIBLE_DEVICE
S=0,1,2,3,4,5,6,7 GLOO_SOCKET_IFNAME=eno8303 HYDRA_FULL_ERROR=1 /labhome/theo/cloudaix-main/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc09
3b1610d73854022-venv/bin/python install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts/main.py cluster.gpus_per_no
de=8 numa_mapping.enable=True stages=["training"] training.exp_manager.create_checkpoint_callback=False training.model.data.data_impl=mock training.mo
del.data.data_prefix=[] training.model.global_batch_size=128 training.model.micro_batch_size=2 training.model.pipeline_model_parallel_size=4 training.
model.tensor_model_parallel_size=4 training.run.name=run training.run.time_limit=3:00:00 training.trainer.enable_checkpointing=False training.trainer.
log_every_n_steps=1 training.trainer.max_steps=20 training.trainer.val_check_interval=10 training=gpt3/40b_improved cluster.partition=ISR1-ALL trainin
g.trainer.num_nodes=8 container=nvcr.io/nvidia/nemo:24.05.01 base_results_dir=/auto/e2e/israel1/workload_results/gpt3_40b_nightly_2024-11-15_22-14-20/
Tests.1/0 launcher_scripts_path=install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts +env_vars.NCCL_SOCKET_IFNAM
E=eno8303 +env_vars.NCCL_IB_GID_INDEX=3 +env_vars.NCCL_IB_TC=96 +env_vars.NCCL_IB_HCA=\'mlx5_0:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_9:1,mlx5_10:
1,mlx5_11:1\' +env_vars.NCCL_IB_ADAPTIVE_ROUTING=1 +env_vars.NCCL_IB_SPLIT_DATA_ON_QPS=0 +env_vars.NCCL_IBEXT_DISABLE=0 +env_vars.OMPI_MCA_btl=\'tcp,s
elf\' +env_vars.OMPI_MCA_btl_tcp_if_include=eno8303 +env_vars.UCX_IB_GID_INDEX=3 +env_vars.UCX_RNDV_SCHEME=get_zcopy +env_vars.UCX_RNDV_THRESH=0 +env_
vars.MELLANOX_VISIBLE_DEVICES=\'0,3,4,5,6,9,10,11\' +env_vars.CUDA_VISIBLE_DEVICES=\'0,1,2,3,4,5,6,7\' +env_vars.GLOO_SOCKET_IFNAME=eno8303 +env_vars.
HYDRA_FULL_ERROR=1 ~training.run.dependency
...
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: /auto/e2e/israel1/workload_results/gpt3_40b_nightly_2024-11-15_22-19-53
[DEBUG] Opening a stub record reader pointing at /auto/e2e/israel1/workload_results/gpt3_40b_nightly_2024-11-15_22-19-53/Tests.1/0/run/results/events.out.tfevents.1731702144.hgx-isr1-020.2879061.0
[DEBUG] Loading events from /auto/e2e/israel1/workload_results/gpt3_40b_nightly_2024-11-15_22-19-53/Tests.1/0/run/results/events.out.tfevents.1731702144.hgx-isr1-020.2879061.0
[DEBUG] End of file in /auto/e2e/israel1/workload_results/gpt3_40b_nightly_2024-11-15_22-19-53/Tests.1/0/run/results/events.out.tfevents.1731702144.hgx-isr1-020.2879061.0
[DEBUG] No more events in /auto/e2e/israel1/workload_results/gpt3_40b_nightly_2024-11-15_22-19-53/Tests.1/0/run/results/events.out.tfevents.1731702144.hgx-isr1-020.2879061.0
[INFO] All test scenario execution attempts are complete. Please review the 'run_nemo_gpt3_40b.log' file to confirm successful completion or to identify any issues.
```