### PR TITLE
Always mount output path for SlurmContainer

### DIFF
--- a/src/cloudai/schema/test_template/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/slurm_container/slurm_command_gen_strategy.py
@@ -27,7 +27,9 @@ class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_srun_prefix(self, slurm_args: dict[str, Any], tr: TestRun) -> list[str]:
         tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, tr.test.test_definition)
         slurm_args["image_path"] = tdef.docker_image.installed_path
-        slurm_args["container_mounts"] = ",".join(tdef.container_mounts(self.system.install_path))
+        mounts = tdef.container_mounts(self.system.install_path)
+        mounts.append(f"{tr.output_path.absolute()}:/cloudai_run_results")
+        slurm_args["container_mounts"] = ",".join(mounts)
 
         cmd = super().gen_srun_prefix(slurm_args, tr)
         return cmd + ["--no-container-mount-home"]

--- a/tests/ref_data/slurm_container.sbatch
+++ b/tests/ref_data/slurm_container.sbatch
@@ -8,4 +8,4 @@
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
 
-srun --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/install/url__commit_hash:/work,__OUTPUT_DIR__/install/repo__mcore_vfm_commit_hash:/opt/megatron-lm --no-container-mount-home bash -c "pwd ; ls"
+srun --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/install/url__commit_hash:/work,__OUTPUT_DIR__/install/repo__mcore_vfm_commit_hash:/opt/megatron-lm,__OUTPUT_DIR__/output:/cloudai_run_results --no-container-mount-home bash -c "pwd ; ls"


### PR DESCRIPTION
## Summary
Always mount output path for SlurmContainer. This folder can be used for writing runtime artifacts.

## Test Plan
CI, manually

## Additional Notes
—