### PR TITLE
Fix missing time limit in sbatch script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ line-length = 120
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "."]
 empty_parameter_set_mark = "fail_at_collect"
 
 [tool.importlinter]

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -112,8 +112,8 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             "num_nodes": num_nodes,
             "node_list_str": node_list_str,
         }
-        if "time_limit" in cmd_args:
-            slurm_args["time_limit"] = cmd_args["time_limit"]
+        if tr.time_limit:
+            slurm_args["time_limit"] = tr.time_limit
 
         return slurm_args
 


### PR DESCRIPTION
## Summary
Fix missing time limit in sbatch script.

## Test Plan
1. CI.
2. Local dry-runs and ensure that `--time` is present when `time_limit` is set in scenario.

## Additional Notes
—
