### PR TITLE
Fix ABC usage issues

### DIFF
--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from .test_scenario import TestRun
 from .test_template_strategy import TestTemplateStrategy
 
 
-class CommandGenStrategy(TestTemplateStrategy):
+class CommandGenStrategy(TestTemplateStrategy, ABC):
     """
     Abstract base class defining the interface for command generation strategies across different system environments.
 
@@ -53,7 +53,6 @@ class CommandGenStrategy(TestTemplateStrategy):
         """
         pass
 
-    @abstractmethod
     def gen_srun_success_check(self, tr: TestRun) -> str:
         """
         Generate the Slurm success check command to verify if a test run was successful.
@@ -64,4 +63,4 @@ class CommandGenStrategy(TestTemplateStrategy):
         Returns:
             str: The generated command to check the success of the test run.
         """
-        pass
+        return ""

--- a/src/cloudai/_core/json_gen_strategy.py
+++ b/src/cloudai/_core/json_gen_strategy.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 
 import re
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any, Dict
 
 from .test_scenario import TestRun
 from .test_template_strategy import TestTemplateStrategy
 
 
-class JsonGenStrategy(TestTemplateStrategy):
+class JsonGenStrategy(TestTemplateStrategy, ABC):
     """
     Abstract base class for generating Kubernetes job specifications based on system and test parameters.
 

--- a/src/cloudai/_core/test.py
+++ b/src/cloudai/_core/test.py
@@ -90,7 +90,7 @@ class CmdArgs(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class TestDefinition(BaseModel):
+class TestDefinition(BaseModel, ABC):
     """Base Test object."""
 
     __test__ = False


### PR DESCRIPTION
## Summary
1. Inherit from ABC if there @abstractmethods
2. Do not make gen_srun_success_check() abstruct, simply return an empty string by default. When needed, this method will be overriden.

## Test Plan
1. CI.
2. Unfortunately, `ruff` and `pyright` do not catch such issues. Here is pyright's position about it: https://github.com/microsoft/pyright/issues/3952

## Additional Notes
—