### PR TITLE
Fix num_nodes calculation for nemo_run

### DIFF
--- a/src/cloudai/schema/test_template/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_run/slurm_command_gen_strategy.py
@@ -41,7 +41,7 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         command = ["nemo", "llm", tdef.cmd_args.task, "--factory", tdef.cmd_args.recipe_name, "-y"]
 
         if tr.nodes:
-            command.append(f"trainer.num_nodes={len(tr.nodes)}")
+            command.append(f"trainer.num_nodes={len(self.system.parse_nodes(tr.nodes))}")
         elif tr.num_nodes > 0:
             command.append(f"trainer.num_nodes={tr.num_nodes}")
 

--- a/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
@@ -79,3 +79,14 @@ class TestNeMoRunSlurmCommandGenStrategy:
             test_run,
         )
         assert cmd == expected_cmd, f"Expected command {expected_cmd}, but got {cmd}"
+
+    def test_num_nodes(self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy, test_run: TestRun) -> None:
+        test_run.nodes = ["node[1-3]"]
+        cmd = cmd_gen_strategy.generate_test_command(
+            test_run.test.test_definition.extra_env_vars,
+            test_run.test.test_definition.cmd_args.model_dump(),
+            test_run,
+        )
+
+        num_nodes_param = [p for p in cmd if "trainer.num_nodes" in p][0]
+        assert num_nodes_param == "trainer.num_nodes=3"


### PR DESCRIPTION
## Summary
`TestRun.nodes` might contain non-expanded list of nodes like `["nodes1-3"]`, which should be converted to actual list of slurm nodes.

## Test Plan
CI.

## Additional Notes
—