### PR TITLE
Do not require enroot on head node

### DIFF
--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -137,7 +137,7 @@ class BaseInstaller(ABC):
                     result = future.result()
                     done += 1
                     msg = (
-                        f"{done}/{total} Installation for {item} finished with status: "
+                        f"{done}/{total} Installation of {item}: "
                         f"{result.message if result.message else 'OK'}"
                     )
                     if result.success:

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -136,10 +136,7 @@ class BaseInstaller(ABC):
                 try:
                     result = future.result()
                     done += 1
-                    msg = (
-                        f"{done}/{total} Installation of {item}: "
-                        f"{result.message if result.message else 'OK'}"
-                    )
+                    msg = f"{done}/{total} Installation of {item}: {result.message if result.message else 'OK'}"
                     if result.success:
                         install_results[item] = "Success"
                         logging.info(msg)

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -56,9 +56,7 @@ class SlurmInstaller(BaseInstaller):
         """
         super().__init__(system)
         self.system = system
-        self.docker_image_cache_manager = DockerImageCacheManager(
-            self.system.install_path, self.system.cache_docker_images_locally, self.system.default_partition
-        )
+        self.docker_image_cache_manager = DockerImageCacheManager(system)
 
     def _check_prerequisites(self) -> InstallStatusResult:
         """

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -215,10 +215,10 @@ class DockerImageCacheManager:
             logging.error(error_message)
             return DockerImageCacheResult(False, Path(), error_message)
 
-        enroot_import_cmd = (
-            f"srun --export=ALL --partition={self.system.default_partition} "
-            f"enroot import -o {docker_image_path} docker://{docker_image_url}"
-        )
+        srun_prefix = f"srun --export=ALL --partition={self.system.default_partition}"
+        if self.system.account:
+            srun_prefix += f" --account={self.system.account}"
+        enroot_import_cmd = f"{srun_prefix} enroot import -o {docker_image_path} docker://{docker_image_url}"
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
 
         try:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -18,7 +18,6 @@ import logging
 import os
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -163,7 +162,9 @@ class DockerImageCacheManager:
         docker_image_path = Path(docker_image_url)
         if docker_image_path.is_file() and docker_image_path.exists():
             return DockerImageCacheResult(
-                True, docker_image_path.absolute(), f"Docker image file path is valid: {docker_image_url}."
+                True,
+                docker_image_path.absolute(),
+                f"Docker image file path is valid: {docker_image_url}.",
             )
 
         # Check if the cache file exists
@@ -205,7 +206,7 @@ class DockerImageCacheManager:
             logging.error(error_message)
             return DockerImageCacheResult(False, Path(), error_message)
 
-        prerequisite_check = self._check_prerequisites(docker_image_url)
+        prerequisite_check = self._check_prerequisites()
         if not prerequisite_check:
             logging.error(f"Prerequisite check failed: {prerequisite_check.message}")
             return DockerImageCacheResult(False, Path(), prerequisite_check.message)
@@ -240,26 +241,14 @@ class DockerImageCacheManager:
             return DockerImageCacheResult(True, docker_image_path.absolute(), success_message)
         except subprocess.CalledProcessError as e:
             error_message = (
-                f"Failed to import Docker image from {docker_image_url}. Command: {enroot_import_cmd}. Error: {e}"
+                f"Failed to import Docker image {docker_image_url}. Command: {enroot_import_cmd}. Error: {e.stderr}"
             )
             logging.error(error_message)
-            return DockerImageCacheResult(
-                False,
-                Path(),
-                (
-                    f"Failed to import Docker image from {docker_image_url}. "
-                    f"Command: {enroot_import_cmd}. "
-                    f"Error: {e}. Please check the Docker image URL and ensure that it is accessible and set up with "
-                    f"valid credentials."
-                ),
-            )
+            return DockerImageCacheResult(False, message=error_message)
 
-    def _check_prerequisites(self, docker_image_url: str) -> PrerequisiteCheckResult:
+    def _check_prerequisites(self) -> PrerequisiteCheckResult:
         """
         Check prerequisites for caching Docker image.
-
-        Args:
-            docker_image_url (str): URL of the Docker image.
 
         Returns:
             PrerequisiteCheckResult: Result of the prerequisite check.
@@ -271,85 +260,11 @@ class DockerImageCacheManager:
             missing_binaries_str = ", ".join(missing_binaries)
             logging.error(f"{missing_binaries_str} are required for caching Docker images but are not installed.")
             return PrerequisiteCheckResult(
-                False, f"{missing_binaries_str} are required for caching Docker images but are not installed."
+                False,
+                f"{missing_binaries_str} are required for caching Docker images but are not installed.",
             )
 
-        docker_accessible = self._check_docker_image_accessibility(docker_image_url)
-        if not docker_accessible.success:
-            logging.error(f"Docker image URL {docker_image_url} is not accessible. Error: {docker_accessible.message}")
-            return docker_accessible
-
         return PrerequisiteCheckResult(True, "All prerequisites are met.")
-
-    def _check_docker_image_accessibility(self, docker_image_url: str) -> PrerequisiteCheckResult:
-        """
-        Check if the Docker image URL is accessible.
-
-        Args:
-            docker_image_url (str): URL of the Docker image.
-
-        Returns:
-            PrerequisiteCheckResult: Result of the Docker image accessibility check.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            docker_image_path = Path(temp_dir) / "docker_image.sqsh"
-            enroot_import_cmd = f"enroot import -o {docker_image_path} docker://{docker_image_url}"
-
-            logging.debug(f"Checking Docker image accessibility: {enroot_import_cmd}")
-
-            process = subprocess.Popen(enroot_import_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            try:
-                while True:
-                    error_output = ""
-                    if process.stderr:
-                        error_output = process.stderr.readline().decode().strip()
-
-                    if error_output:
-                        if (
-                            "Downloading" in error_output
-                            or "Found all layers in cache" in error_output
-                            or "Fetching image manifest list" in error_output
-                        ):
-                            logging.debug(
-                                f"Docker image URL, {docker_image_url}, is accessible. "
-                                f"Command used: {enroot_import_cmd}. Found keyword: {error_output.strip()}"
-                            )
-                            process.terminate()
-                            return PrerequisiteCheckResult(
-                                True, f"Docker image URL, {docker_image_url}, is accessible."
-                            )
-                        if "[ERROR]" in error_output:
-                            logging.error(
-                                f"Failed to access Docker image URL, {docker_image_url}. "
-                                f"Command used: {enroot_import_cmd}. Error: {error_output}"
-                            )
-                            process.terminate()
-                            if "401 Unauthorized" in error_output:
-                                detailed_message = (
-                                    f"Failed to access Docker image URL: {docker_image_url}. Error: {error_output}\n"
-                                    "This error indicates that access to the Docker image URL is unauthorized. "
-                                    "Please ensure you have the necessary permissions and have followed the "
-                                    "instructions in the README for setting up your credentials correctly."
-                                )
-                                return PrerequisiteCheckResult(False, detailed_message)
-                            return PrerequisiteCheckResult(
-                                False, f"Failed to access Docker image URL: {docker_image_url}. Error: {error_output}"
-                            )
-                    if process.poll() is not None:
-                        break
-
-                logging.debug(f"Failed to access Docker image URL: {docker_image_url}. Unknown error.")
-                return PrerequisiteCheckResult(
-                    False, f"Failed to access Docker image URL: {docker_image_url}. Unknown error."
-                )
-            finally:
-                # Ensure the temporary docker image file is removed
-                if docker_image_path.exists():
-                    try:
-                        docker_image_path.unlink()
-                        logging.debug(f"Temporary Docker image file removed: {docker_image_path}")
-                    except OSError as e:
-                        logging.error(f"Failed to remove temporary Docker image file {docker_image_path}. Error: {e}")
 
     def uninstall_cached_image(self, docker_image_filename: str) -> DockerImageCacheResult:
         """

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -242,7 +242,7 @@ class DockerImageCacheManager:
             error_message = (
                 f"Failed to import Docker image {docker_image_url}. Command: {enroot_import_cmd}. Error: {e.stderr}"
             )
-            logging.error(error_message)
+            logging.debug(error_message)
             return DockerImageCacheResult(False, message=error_message)
 
     def _check_prerequisites(self) -> PrerequisiteCheckResult:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -217,7 +217,7 @@ class DockerImageCacheManager:
             return DockerImageCacheResult(False, Path(), error_message)
 
         enroot_import_cmd = (
-            f"srun --export=ALL --partition={self.partition_name} "
+            f"srun --export=ALL --partition={self.partition_name} --account=coreai_dlalgo_ci "
             f"enroot import -o {docker_image_path} docker://{docker_image_url}"
         )
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
@@ -253,7 +253,7 @@ class DockerImageCacheManager:
         Returns:
             PrerequisiteCheckResult: Result of the prerequisite check.
         """
-        required_binaries = ["enroot", "srun"]
+        required_binaries = ["srun"]
         missing_binaries = [binary for binary in required_binaries if not shutil.which(binary)]
 
         if missing_binaries:

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -16,7 +16,7 @@
 
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from cloudai.util.docker_image_cache_manager import (
     DockerImageCacheManager,
@@ -50,12 +50,18 @@ def test_ensure_docker_image_url_cache_enabled(mock_access, mock_exists, mock_is
         manager,
         "cache_docker_image",
         return_value=DockerImageCacheResult(
-            True, Path("/fake/install/path/subdir/docker_image.sqsh"), "Docker image cached successfully."
+            True,
+            Path("/fake/install/path/subdir/docker_image.sqsh"),
+            "Docker image cached successfully.",
         ),
     ):
-        result = manager.ensure_docker_image("docker.io/hello-world", "docker_image.sqsh")
+        result = manager.ensure_docker_image(
+            "docker.io/hello-world", "docker_image.sqsh"
+        )
         assert result.success
-        assert result.docker_image_path == Path("/fake/install/path/subdir/docker_image.sqsh")
+        assert result.docker_image_path == Path(
+            "/fake/install/path/subdir/docker_image.sqsh"
+        )
         assert result.message == "Docker image cached successfully."
 
 
@@ -63,8 +69,12 @@ def test_ensure_docker_image_url_cache_enabled(mock_access, mock_exists, mock_is
 @patch("pathlib.Path.exists")
 @patch("os.access")
 @patch("subprocess.run")
-@patch("cloudai.util.docker_image_cache_manager.DockerImageCacheManager._check_prerequisites")
-def test_cache_docker_image(mock_check_prerequisites, mock_run, mock_access, mock_exists, mock_is_file):
+@patch(
+    "cloudai.util.docker_image_cache_manager.DockerImageCacheManager._check_prerequisites"
+)
+def test_cache_docker_image(
+    mock_check_prerequisites, mock_run, mock_access, mock_exists, mock_is_file
+):
     manager = DockerImageCacheManager(Path("/fake/install/path"), True, "default")
 
     # Test when cached file already exists
@@ -72,15 +82,24 @@ def test_cache_docker_image(mock_check_prerequisites, mock_run, mock_access, moc
     result = manager.cache_docker_image("docker.io/hello-world", "image.tar.gz")
     assert result.success
     assert result.docker_image_path == Path("/fake/install/path/image.tar.gz")
-    assert result.message == "Cached Docker image already exists at /fake/install/path/image.tar.gz."
+    assert (
+        result.message
+        == "Cached Docker image already exists at /fake/install/path/image.tar.gz."
+    )
 
     # Test creating subdirectory when it doesn't exist
     mock_is_file.return_value = False
-    mock_exists.side_effect = [True, False, True]  # install_path exists, subdir_path does not, install_path again
+    mock_exists.side_effect = [
+        True,
+        False,
+        True,
+    ]  # install_path exists, subdir_path does not, install_path again
     result = manager.cache_docker_image("docker.io/hello-world", "image.tar.gz")
 
     # Ensure prerequisites are always met for the following tests
-    mock_check_prerequisites.return_value = PrerequisiteCheckResult(True, "All prerequisites are met.")
+    mock_check_prerequisites.return_value = PrerequisiteCheckResult(
+        True, "All prerequisites are met."
+    )
 
     # Reset the mock calls
     mock_run.reset_mock()
@@ -88,8 +107,16 @@ def test_cache_docker_image(mock_check_prerequisites, mock_run, mock_access, moc
 
     # Test caching success with subprocess command (removal of default partition keyword)
     mock_is_file.return_value = False
-    mock_exists.side_effect = [True, True, True, True, True]  # Ensure all path checks return True
-    mock_run.return_value = subprocess.CompletedProcess(args=["cmd"], returncode=0, stderr="")
+    mock_exists.side_effect = [
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]  # Ensure all path checks return True
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["cmd"], returncode=0, stderr=""
+    )
     result = manager.cache_docker_image("docker.io/hello-world", "image.tar.gz")
     mock_run.assert_called_once_with(
         "srun --export=ALL --partition=default enroot import -o /fake/install/path/image.tar.gz docker://docker.io/hello-world",
@@ -99,7 +126,10 @@ def test_cache_docker_image(mock_check_prerequisites, mock_run, mock_access, moc
         text=True,
     )
     assert result.success
-    assert result.message == "Docker image cached successfully at /fake/install/path/image.tar.gz."
+    assert (
+        result.message
+        == "Docker image cached successfully at /fake/install/path/image.tar.gz."
+    )
 
     # Test caching failure due to subprocess error
     mock_is_file.return_value = False
@@ -110,13 +140,17 @@ def test_cache_docker_image(mock_check_prerequisites, mock_run, mock_access, moc
     # Test caching failure due to disk-related errors
     mock_is_file.return_value = False
     mock_run.side_effect = None
-    mock_run.return_value = subprocess.CompletedProcess(args=["cmd"], returncode=1, stderr="Disk quota exceeded\n")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["cmd"], returncode=1, stderr="Disk quota exceeded\n"
+    )
     mock_exists.side_effect = [True, True, True, True, True]
     result = manager.cache_docker_image("docker.io/hello-world", "image.tar.gz")
     assert not result.success
     assert "Disk quota exceeded" in result.message
 
-    mock_run.return_value = subprocess.CompletedProcess(args=["cmd"], returncode=1, stderr="Write error\n")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["cmd"], returncode=1, stderr="Write error\n"
+    )
     result = manager.cache_docker_image("docker.io/hello-world", "image.tar.gz")
     assert not result.success
     assert "Write error" in result.message
@@ -132,7 +166,10 @@ def test_uninstall_cached_image(mock_is_file, mock_unlink):
     mock_is_file.return_value = True
     result = manager.uninstall_cached_image("image.tar.gz")
     assert result.success
-    assert result.message == "Cached Docker image removed successfully from /fake/install/path/image.tar.gz."
+    assert (
+        result.message
+        == "Cached Docker image removed successfully from /fake/install/path/image.tar.gz."
+    )
     mock_unlink.assert_called_once()
 
     # Test failed removal due to OSError
@@ -145,109 +182,44 @@ def test_uninstall_cached_image(mock_is_file, mock_unlink):
     mock_is_file.return_value = False
     result = manager.uninstall_cached_image("image.tar.gz")
     assert result.success
-    assert result.message == "No cached Docker image found to remove at /fake/install/path/image.tar.gz."
+    assert (
+        result.message
+        == "No cached Docker image found to remove at /fake/install/path/image.tar.gz."
+    )
 
 
 @patch("shutil.which")
-@patch("cloudai.util.docker_image_cache_manager.DockerImageCacheManager._check_docker_image_accessibility")
-def test_check_prerequisites(mock_check_docker_image_accessibility, mock_which):
+def test_check_prerequisites(mock_which):
     manager = DockerImageCacheManager(Path("/fake/install/path"), True, "default")
 
     # Ensure enroot and srun are installed
     mock_which.side_effect = lambda x: x in ["enroot", "srun"]
 
     # Test all prerequisites met
-    mock_check_docker_image_accessibility.return_value = PrerequisiteCheckResult(
-        True, "Docker image URL is accessible."
-    )
-    result = manager._check_prerequisites("docker.io/hello-world")
+    result = manager._check_prerequisites()
     assert result.success
     assert result.message == "All prerequisites are met."
 
     # Test enroot not installed
     mock_which.side_effect = lambda x: x != "enroot"
-    result = manager._check_prerequisites("docker.io/hello-world")
+    result = manager._check_prerequisites()
     assert not result.success
-    assert result.message == "enroot are required for caching Docker images but are not installed."
+    assert (
+        result.message
+        == "enroot are required for caching Docker images but are not installed."
+    )
 
     # Test srun not installed
     mock_which.side_effect = lambda x: x != "srun"
-    result = manager._check_prerequisites("docker.io/hello-world")
+    result = manager._check_prerequisites()
     assert not result.success
-    assert result.message == "srun are required for caching Docker images but are not installed."
+    assert (
+        result.message
+        == "srun are required for caching Docker images but are not installed."
+    )
 
     # Ensure enroot and srun are installed again
     mock_which.side_effect = lambda x: x in ["enroot", "srun"]
-
-    # Test Docker image URL not accessible
-    mock_check_docker_image_accessibility.return_value = PrerequisiteCheckResult(
-        False, "Docker image URL not accessible."
-    )
-    result = manager._check_prerequisites("docker.io/hello-world")
-    assert not result.success
-    assert "Docker image URL not accessible." in result.message
-
-
-@patch("subprocess.Popen")
-@patch("shutil.which")
-@patch("tempfile.TemporaryDirectory")
-def test_check_docker_image_accessibility_with_enroot(mock_tempdir, mock_which, mock_popen):
-    manager = DockerImageCacheManager(Path("/fake/install/path"), True, "default")
-
-    # Ensure docker binary is not available
-    mock_which.return_value = None
-
-    # Mocking the TemporaryDirectory context manager
-    mock_temp_dir = MagicMock()
-    mock_tempdir.return_value.__enter__.return_value = mock_temp_dir
-    temp_dir_path = Path("/fake/temp/dir")
-    mock_temp_dir.__enter__.return_value = temp_dir_path
-
-    # Mock Popen for enroot command with success scenario
-    process_mock = MagicMock()
-    process_mock.stderr.readline.side_effect = [
-        b"Found all layers in cache\n",  # Simulate successful output
-        b"",
-        b"",
-    ]
-    process_mock.poll.side_effect = [None, None, 0]  # Simulate process running then finishing
-
-    mock_popen.return_value = process_mock
-
-    result = manager._check_docker_image_accessibility("docker.io/hello-world")
-    assert result.success
-    assert result.message == "Docker image URL, docker.io/hello-world, is accessible."
-
-    # Verify the command contains the required keywords
-    command = mock_popen.call_args[0][0]
-    assert "enroot import -o" in command
-    assert "docker://docker.io/hello-world" in command
-
-    # Mock Popen for enroot command with failure scenario
-    process_mock.reset_mock()
-    process_mock.stderr.readline.side_effect = [
-        b"[ERROR] URL https://nvcr.io/proxy_auth returned error code: 401 Unauthorized\n",  # Simulate 401 error output
-        b"",
-        b"",
-    ]
-    process_mock.poll.side_effect = [None, None, 0]  # Simulate process running then finishing
-
-    mock_popen.return_value = process_mock
-
-    result = manager._check_docker_image_accessibility("docker.io/hello-world")
-    assert not result.success
-    assert (
-        "Failed to access Docker image URL: docker.io/hello-world. "
-        "Error: [ERROR] URL https://nvcr.io/proxy_auth returned error code: 401 Unauthorized\n"
-        "This error indicates that access to the Docker image URL is unauthorized. "
-        "Please ensure you have the necessary permissions and have followed the instructions in the README "
-        "for setting up your credentials correctly." in result.message.replace("\n\n", "\n")
-    )
-
-    # Verify the command contains the required keywords
-    command = mock_popen.call_args[0][0]
-    assert "enroot import -o" in command
-    assert "docker://docker.io/hello-world" in command
 
 
 @patch("pathlib.Path.is_file")


### PR DESCRIPTION
## Summary
Do not check image accessibility from the head node using `enroot`: many systems don't allow such actions. Instead, rely on actual `srun ... enroot import ...` result and report its error to user.

Addresses https://redmine.mellanox.com/issues/4212401.

## Test Plan
1. CI
2. Manual on EOS with enabled caching.

For both runs below the failure is expected as test TOML has invalid URL (`docker://DOCKER_IMAGE`).

First run:
```bash
cloudai install --system-config eos.toml --tests-dir conf/common/test/
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Not all components are ready
[INFO] Going to install 5 item(s)
[INFO] 1/5 Installation of PythonExecutable(git_url=https://github.com/NVIDIA/NeMo-Framework-Launcher.git, commit_hash=599ecfcbbd64fd2de02f2cc093b1610d73854022): OK
[ERROR] 2/5 Installation of DockerImage(url=DOCKER_IMAGE): Failed to import Docker image DOCKER_IMAGE. Command: srun --export=ALL --partition=batch --account=... enroot import -o /cloudai-install/__DOCKER_IMAGE__notag.sqsh docker://DOCKER_IMAGE. Error: srun: WARNING: Please set a name for this job, formatted like this:
srun: 	...-<subproject>.<details>
srun: job 1760479 queued and waiting for resources
srun: job 1760479 has been allocated resources
srun: error: eos0549: task 0: Exited with exit code 1
srun: Terminating StepId=1760479.0
[ERROR] Invalid image reference: docker://DOCKER_IMAGE

[INFO] 3/5 Installation of DockerImage(url=nvcr.io/nvidia/pytorch:24.02-py3): Docker image cached successfully at /cloudai-install/nvcr.io_nvidia__pytorch__24.02-py3.sqsh.
[INFO] 4/5 Installation of DockerImage(url=nvcr.io/nvidia/nemo:24.09): Docker image cached successfully at /cloudai-install/nvcr.io_nvidia__nemo__24.09.sqsh.
[INFO] 5/5 Installation of DockerImage(url=nvcr.io/nvidia/nemo:24.05.01): Docker image cached successfully at /cloudai-install/nvcr.io_nvidia__nemo__24.05.01.sqsh.
[ERROR] 1 item(s) failed to install.
```

Second run:
```bash
cloudai install --system-config eos.toml --tests-dir conf/common/test/
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Not all components are ready
[INFO] Going to install 5 item(s)
[WARNING] Git repository already exists at /cloudai-install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022.
[WARNING] Virtual environment already exists at /cloudai-install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022-venv.
[INFO] 1/5 Installation of DockerImage(url=nvcr.io/nvidia/nemo:24.09): Cached Docker image already exists at /cloudai-install/nvcr.io_nvidia__nemo__24.09.sqsh.
[INFO] 2/5 Installation of DockerImage(url=nvcr.io/nvidia/pytorch:24.02-py3): Cached Docker image already exists at /cloudai-install/nvcr.io_nvidia__pytorch__24.02-py3.sqsh.
[INFO] 3/5 Installation of DockerImage(url=nvcr.io/nvidia/nemo:24.05.01): Cached Docker image already exists at /cloudai-install/nvcr.io_nvidia__nemo__24.05.01.sqsh.
[INFO] 4/5 Installation of PythonExecutable(git_url=https://github.com/NVIDIA/NeMo-Framework-Launcher.git, commit_hash=599ecfcbbd64fd2de02f2cc093b1610d73854022): OK
[ERROR] 5/5 Installation of DockerImage(url=DOCKER_IMAGE): Failed to import Docker image DOCKER_IMAGE. Command: srun --export=ALL --partition=batch --account=... enroot import -o /cloudai-install/__DOCKER_IMAGE__notag.sqsh docker://DOCKER_IMAGE. Error: srun: WARNING: Please set a name for this job, formatted like this:
srun: 	...-<subproject>.<details>
srun: job 1760594 queued and waiting for resources
srun: job 1760594 has been allocated resources
[ERROR] Invalid image reference: docker://DOCKER_IMAGE
srun: error: eos0022: task 0: Exited with exit code 1
srun: Terminating StepId=1760594.0

[ERROR] 1 item(s) failed to install.
```

## Additional Notes
—
