### PR TITLE
Do not require enroot on head node (backport #323)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -363,6 +363,39 @@ You can update the fields to adjust the behavior. For example, you can update th
 2. Follow the instructions under 'Usage Tips' on how to download the tokenizer.
 3. Replace "training.model.tokenizer.model=TOKENIZER_MODEL" with "training.model.tokenizer.model=YOUR_TOKENIZER_PATH" (the tokenizer should be a .model file) in conf/common/test/llama.toml.
 
+
+## Using Test Hooks in CloudAI
+
+A test hook in CloudAI is a specialized test that runs either before or after each main test in a scenario, providing flexibility to prepare the environment or clean up resources. Hooks are defined as pre-test or post-test and referenced in the test scenario’s TOML file using `pre_test` and `post_test` fields.
+```
+name = "nccl-test"
+
+pre_test = "nccl_test_pre"
+post_test = "nccl_test_post"
+
+[[Tests]]
+id = "Tests.1"
+test_name = "nccl_test_all_reduce"
+num_nodes = "2"
+time_limit = "00:20:00"
+```
+
+CloudAI organizes hooks in a dedicated directory structure:
+
+- Hook directory: All hook configurations reside in `conf/hook/`.
+- Hook test scenarios: Place pre-test hook and post-test hook scenario files in `conf/hook/`.
+- Hook tests: Place individual tests referenced in hooks within `conf/hook/test/`.
+
+In the execution flow, pre-test hooks run before the main test, which only executes if the pre-test completes successfully. Post-test hooks follow the main test, provided the prior steps succeed. If a pre-test hook fails, the main test and its post-test hook are skipped.
+```
+name = "nccl_test_pre"
+
+[[Tests]]
+id = "Tests.1"
+test_name = "nccl_test_all_reduce"
+time_limit = "00:20:00"
+```
+
 ## Troubleshooting
 In this section, we will guide you through identifying the root cause of issues, determining whether they stem from system infrastructure or a bug in CloudAI. Users should closely follow the USER_GUIDE.md and README.md for installation, adding test templates, tests, and test scenarios.
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -363,39 +363,6 @@ You can update the fields to adjust the behavior. For example, you can update th
 2. Follow the instructions under 'Usage Tips' on how to download the tokenizer.
 3. Replace "training.model.tokenizer.model=TOKENIZER_MODEL" with "training.model.tokenizer.model=YOUR_TOKENIZER_PATH" (the tokenizer should be a .model file) in conf/common/test/llama.toml.
 
-
-## Using Test Hooks in CloudAI
-
-A test hook in CloudAI is a specialized test that runs either before or after each main test in a scenario, providing flexibility to prepare the environment or clean up resources. Hooks are defined as pre-test or post-test and referenced in the test scenario’s TOML file using `pre_test` and `post_test` fields.
-```
-name = "nccl-test"
-
-pre_test = "nccl_test_pre"
-post_test = "nccl_test_post"
-
-[[Tests]]
-id = "Tests.1"
-test_name = "nccl_test_all_reduce"
-num_nodes = "2"
-time_limit = "00:20:00"
-```
-
-CloudAI organizes hooks in a dedicated directory structure:
-
-- Hook directory: All hook configurations reside in `conf/hook/`.
-- Hook test scenarios: Place pre-test hook and post-test hook scenario files in `conf/hook/`.
-- Hook tests: Place individual tests referenced in hooks within `conf/hook/test/`.
-
-In the execution flow, pre-test hooks run before the main test, which only executes if the pre-test completes successfully. Post-test hooks follow the main test, provided the prior steps succeed. If a pre-test hook fails, the main test and its post-test hook are skipped.
-```
-name = "nccl_test_pre"
-
-[[Tests]]
-id = "Tests.1"
-test_name = "nccl_test_all_reduce"
-time_limit = "00:20:00"
-```
-
 ## Troubleshooting
 In this section, we will guide you through identifying the root cause of issues, determining whether they stem from system infrastructure or a bug in CloudAI. Users should closely follow the USER_GUIDE.md and README.md for installation, adding test templates, tests, and test scenarios.
 

--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -122,10 +122,16 @@ class BaseInstaller:
                     else:
                         install_results[test_template.name] = result.message
                     done += 1
-                    logging.info(
-                        f"{done}/{total} Installation for {test_template.name} finished with status: "
+                    msg = (
+                        f"{done}/{total} Installation of {test_template.name}: "
                         f"{result.message if result.message else 'OK'}"
                     )
+                    if result.success:
+                        install_results[test_template.name] = "Success"
+                        logging.info(msg)
+                    else:
+                        install_results[test_template.name] = result.message
+                        logging.error(msg)
                 except Exception as e:
                     done += 1
                     logging.error(f"{done}/{total} Installation failed for {test_template.name}: {e}")

--- a/src/cloudai/schema/test_template/jax_toolbox/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/jax_toolbox/slurm_install_strategy.py
@@ -33,9 +33,9 @@ class JaxToolboxSlurmInstallStrategy(SlurmInstallStrategy):
         if docker_image_result.success:
             return InstallStatusResult(success=True)
         else:
-            if self.docker_image_cache_manager.cache_docker_images_locally:
+            if self.docker_image_cache_manager.system.cache_docker_images_locally:
                 expected_docker_image_path = os.path.join(
-                    self.docker_image_cache_manager.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+                    self.docker_image_cache_manager.system.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
                 )
                 return InstallStatusResult(
                     success=False,

--- a/src/cloudai/schema/test_template/nccl_test/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_install_strategy.py
@@ -39,9 +39,9 @@ class NcclTestSlurmInstallStrategy(SlurmInstallStrategy):
         if docker_image_result.success:
             return InstallStatusResult(success=True)
         else:
-            if self.docker_image_cache_manager.cache_docker_images_locally:
+            if self.docker_image_cache_manager.system.cache_docker_images_locally:
                 expected_docker_image_path = os.path.join(
-                    self.docker_image_cache_manager.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+                    self.docker_image_cache_manager.system.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
                 )
                 return InstallStatusResult(
                     success=False,

--- a/src/cloudai/schema/test_template/ucc_test/slurm_install_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_install_strategy.py
@@ -39,9 +39,9 @@ class UCCTestSlurmInstallStrategy(SlurmInstallStrategy):
         if docker_image_result.success:
             return InstallStatusResult(success=True)
         else:
-            if self.docker_image_cache_manager.cache_docker_images_locally:
+            if self.docker_image_cache_manager.system.cache_docker_images_locally:
                 expected_docker_image_path = os.path.join(
-                    self.docker_image_cache_manager.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
+                    self.docker_image_cache_manager.system.install_path, self.SUBDIR_PATH, self.DOCKER_IMAGE_FILENAME
                 )
                 return InstallStatusResult(
                     success=False,

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -46,11 +46,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         self.install_path = self.slurm_system.install_path
         self.default_env_vars.update(self.slurm_system.global_env_vars)
 
-        self.docker_image_cache_manager = DockerImageCacheManager(
-            self.slurm_system.install_path,
-            self.slurm_system.cache_docker_images_locally,
-            self.slurm_system.default_partition,
-        )
+        self.docker_image_cache_manager = DockerImageCacheManager(self.slurm_system)
         docker_image_url_info = self.cmd_args.get("docker_image_url")
         if docker_image_url_info is not None:
             self.docker_image_url = docker_image_url_info.get("default")

--- a/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_install_strategy.py
@@ -41,11 +41,7 @@ class SlurmInstallStrategy(InstallStrategy):
         super().__init__(system, env_vars, cmd_args)
         self.slurm_system = cast(SlurmSystem, self.system)
         self.install_path = self.slurm_system.install_path
-        self.docker_image_cache_manager = DockerImageCacheManager(
-            self.slurm_system.install_path,
-            self.slurm_system.cache_docker_images_locally,
-            self.slurm_system.default_partition,
-        )
+        self.docker_image_cache_manager = DockerImageCacheManager(self.slurm_system)
         docker_image_url_info = self.cmd_args.get("docker_image_url")
         if docker_image_url_info is not None:
             self.docker_image_url = docker_image_url_info.get("default")

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -238,7 +238,7 @@ class DockerImageCacheManager:
                 return DockerImageCacheResult(False, "", error_message)
 
         enroot_import_cmd = (
-            f"srun --export=ALL --partition={self.partition_name} "
+            f"srun --export=ALL --partition={self.partition_name} --account=coreai_dlalgo_ci "
             f"enroot import -o {docker_image_path} docker://{docker_image_url}"
         )
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
@@ -286,7 +286,7 @@ class DockerImageCacheManager:
         Returns:
             PrerequisiteCheckResult: Result of the prerequisite check.
         """
-        required_binaries = ["enroot", "srun"]
+        required_binaries = ["srun"]
         missing_binaries = [binary for binary in required_binaries if not shutil.which(binary)]
 
         if missing_binaries:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -263,17 +263,8 @@ class DockerImageCacheManager:
             error_message = (
                 f"Failed to import Docker image from {docker_image_url}. Command: {enroot_import_cmd}. Error: {e}"
             )
-            logging.error(error_message)
-            return DockerImageCacheResult(
-                False,
-                "",
-                (
-                    f"Failed to import Docker image from {docker_image_url}. "
-                    f"Command: {enroot_import_cmd}. "
-                    f"Error: {e}. Please check the Docker image URL and ensure that it is accessible and set up with "
-                    f"valid credentials."
-                ),
-            )
+            logging.debug(error_message)
+            return DockerImageCacheResult(False, message=error_message)
 
     def _check_prerequisites(self, docker_image_url: str) -> PrerequisiteCheckResult:
         """

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -236,10 +236,10 @@ class DockerImageCacheManager:
                 logging.error(error_message)
                 return DockerImageCacheResult(False, "", error_message)
 
-        enroot_import_cmd = (
-            f"srun --export=ALL --partition={self.system.default_partition} "
-            f"enroot import -o {docker_image_path} docker://{docker_image_url}"
-        )
+        srun_prefix = f"srun --export=ALL --partition={self.system.default_partition}"
+        if self.system.account:
+            srun_prefix += f" --account={self.system.account}"
+        enroot_import_cmd = f"{srun_prefix} enroot import -o {docker_image_path} docker://{docker_image_url}"
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
 
         try:

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.util.docker_image_cache_manager import (
     DockerImageCacheManager,

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from cloudai import InstallStatusResult
 from cloudai.schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
 from cloudai.schema.test_template.nemo_launcher.slurm_install_strategy import (
@@ -94,7 +95,7 @@ class TestNcclTestSlurmInstallStrategy:
         )
 
     def test_is_installed_remote(self, strategy: NcclTestSlurmInstallStrategy):
-        strategy.docker_image_cache_manager.cache_docker_images_locally = False
+        strategy.docker_image_cache_manager.system.cache_docker_images_locally = False
 
         result = strategy.is_installed()
 
@@ -222,7 +223,7 @@ class TestUCCTestSlurmInstallStrategy:
         )
 
     def test_is_installed_remote(self, strategy: UCCTestSlurmInstallStrategy):
-        strategy.docker_image_cache_manager.cache_docker_images_locally = False
+        strategy.docker_image_cache_manager.system.cache_docker_images_locally = False
 
         result = strategy.is_installed()
 

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from cloudai import InstallStatusResult
 from cloudai.schema.test_template.nccl_test.slurm_install_strategy import NcclTestSlurmInstallStrategy
 from cloudai.schema.test_template.nemo_launcher.slurm_install_strategy import (

--- a/tests/test_slurm_install_strategy.py
+++ b/tests/test_slurm_install_strategy.py
@@ -37,6 +37,7 @@ def slurm_system(tmp_path: Path) -> SlurmSystem:
         install_path=str(tmp_path / "install"),
         output_path=str(tmp_path / "output"),
         default_partition="main",
+        cache_docker_images_locally=True,
         partitions={
             "main": [
                 SlurmNode(name="node1", partition="main", state=SlurmNodeState.IDLE),
@@ -66,8 +67,7 @@ def test_install_path_attribute(slurm_install_strategy: SlurmInstallStrategy, sl
 @pytest.fixture
 def mock_docker_image_cache_manager(slurm_system: SlurmSystem):
     mock = MagicMock()
-    mock.cache_docker_images_locally = True
-    mock.install_path = slurm_system.install_path
+    mock.system = slurm_system
     mock.check_docker_image_exists.return_value = InstallStatusResult(success=False, message="Docker image not found")
     mock.ensure_docker_image.return_value = InstallStatusResult(success=True)
     mock.uninstall_cached_image.return_value = InstallStatusResult(success=True)


### PR DESCRIPTION
## Summary
Do not require enroot on head node (backport #323).

## Test Plan
1. CI.
2. Manually run installation on EOS and IL1, works fine.

## Additional Notes
—