### PR TITLE
retry docker image enroot when cluster requires specifying GPU resource

### DIFF
--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -182,7 +182,9 @@ class DockerImageCacheManager:
         logging.debug(message)
         return DockerImageCacheResult(False, Path(), message)
 
-    def _import_docker_image(self, srun_prefix: str, docker_image_path: str, docker_image_url: str, retry: bool = False) -> DockerImageCacheResult:
+    def _import_docker_image(
+        self, srun_prefix: str, docker_image_path: str, docker_image_url: str, retry: bool = False
+    ) -> DockerImageCacheResult:
         enroot_import_cmd = f"{srun_prefix} enroot import -o {docker_image_path} docker://{docker_image_url}"
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
         try:

--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -182,6 +182,37 @@ class DockerImageCacheManager:
         logging.debug(message)
         return DockerImageCacheResult(False, Path(), message)
 
+    def _import_docker_image(self, srun_prefix: str, docker_image_path: str, docker_image_url: str, retry: bool = False) -> DockerImageCacheResult:
+        enroot_import_cmd = f"{srun_prefix} enroot import -o {docker_image_path} docker://{docker_image_url}"
+        logging.debug(f"Importing Docker image: {enroot_import_cmd}")
+        try:
+            p = subprocess.run(enroot_import_cmd, shell=True, check=True, capture_output=True, text=True)
+
+            if "Disk quota exceeded" in p.stderr or "Write error" in p.stderr:
+                error_message = (
+                    f"Failed to cache Docker image {docker_image_url}. Command: {enroot_import_cmd}. "
+                    f"Error: '{p.stderr}'\n\n"
+                    "This error indicates a disk-related issue. Please check if the disk is full or not usable. "
+                    "If the disk is full, consider using a different disk or removing unnecessary files."
+                )
+                logging.error(error_message)
+                return DockerImageCacheResult(False, Path(), error_message)
+
+            success_message = f"Docker image cached successfully at {docker_image_path}."
+            logging.debug(success_message)
+            logging.debug(f"Command used: {enroot_import_cmd}, stdout: {p.stdout}, stderr: {p.stderr}")
+            return DockerImageCacheResult(True, docker_image_path.absolute(), success_message)
+        except subprocess.CalledProcessError as e:
+            # Retry enroot by adding `--gpus=1`` if cluster requires specifing GPU resource
+            if retry is False and "Cannot find GPU specification" in e.stderr:
+                srun_prefix += " --gpus=1"
+                return self._import_docker_image(srun_prefix, docker_image_path, docker_image_url, True)
+            error_message = (
+                f"Failed to import Docker image {docker_image_url}. Command: {enroot_import_cmd}. Error: {e.stderr}"
+            )
+            logging.debug(error_message)
+            return DockerImageCacheResult(False, message=error_message)
+
     def cache_docker_image(self, docker_image_url: str, docker_image_filename: str) -> DockerImageCacheResult:
         """
         Cache the Docker image locally using enroot import.
@@ -218,32 +249,8 @@ class DockerImageCacheManager:
         srun_prefix = f"srun --export=ALL --partition={self.system.default_partition}"
         if self.system.account:
             srun_prefix += f" --account={self.system.account}"
-        enroot_import_cmd = f"{srun_prefix} enroot import -o {docker_image_path} docker://{docker_image_url}"
-        logging.debug(f"Importing Docker image: {enroot_import_cmd}")
 
-        try:
-            p = subprocess.run(enroot_import_cmd, shell=True, check=True, capture_output=True, text=True)
-
-            if "Disk quota exceeded" in p.stderr or "Write error" in p.stderr:
-                error_message = (
-                    f"Failed to cache Docker image {docker_image_url}. Command: {enroot_import_cmd}. "
-                    f"Error: '{p.stderr}'\n\n"
-                    "This error indicates a disk-related issue. Please check if the disk is full or not usable. "
-                    "If the disk is full, consider using a different disk or removing unnecessary files."
-                )
-                logging.error(error_message)
-                return DockerImageCacheResult(False, Path(), error_message)
-
-            success_message = f"Docker image cached successfully at {docker_image_path}."
-            logging.debug(success_message)
-            logging.debug(f"Command used: {enroot_import_cmd}, stdout: {p.stdout}, stderr: {p.stderr}")
-            return DockerImageCacheResult(True, docker_image_path.absolute(), success_message)
-        except subprocess.CalledProcessError as e:
-            error_message = (
-                f"Failed to import Docker image {docker_image_url}. Command: {enroot_import_cmd}. Error: {e.stderr}"
-            )
-            logging.debug(error_message)
-            return DockerImageCacheResult(False, message=error_message)
+        return self._import_docker_image(srun_prefix, docker_image_path, docker_image_url)
 
     def _check_prerequisites(self) -> PrerequisiteCheckResult:
         """

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -18,6 +18,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.util.docker_image_cache_manager import (
     DockerImageCacheManager,
@@ -198,8 +200,12 @@ def test_ensure_docker_image_no_local_cache(slurm_system: SlurmSystem):
     assert result.message == ""
 
 
-def test_system_with_account(slurm_system: SlurmSystem):
-    slurm_system.account = "test_account"
+@pytest.mark.parametrize(
+    "account, gpus_per_node", [(None, None), ("test_account", None), (None, 8), ("test_account", 8)]
+)
+def test_system_with_account(slurm_system: SlurmSystem, account, gpus_per_node):
+    slurm_system.account = account
+    slurm_system.gpus_per_node = gpus_per_node
     slurm_system.install_path.mkdir(parents=True, exist_ok=True)
 
     manager = DockerImageCacheManager(slurm_system)
@@ -209,11 +215,15 @@ def test_system_with_account(slurm_system: SlurmSystem):
         res = manager.cache_docker_image("docker.io/hello-world", "docker_image.sqsh")
         assert res.success
 
+    command = f"srun --export=ALL --partition={slurm_system.default_partition}"
+    if slurm_system.account:
+        command += f" --account={slurm_system.account}"
+    if slurm_system.gpus_per_node:
+        command += " --gres=gpu:1"
+    command += f" enroot import -o {slurm_system.install_path}/docker_image.sqsh docker://docker.io/hello-world"
+
     mock_run.assert_called_once_with(
-        (
-            f"srun --export=ALL --partition={slurm_system.default_partition} --account={slurm_system.account} "
-            f"enroot import -o {slurm_system.install_path}/docker_image.sqsh docker://docker.io/hello-world"
-        ),
+        command,
         shell=True,
         check=True,
         capture_output=True,

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -203,7 +203,7 @@ def test_ensure_docker_image_no_local_cache(slurm_system: SlurmSystem):
 @pytest.mark.parametrize(
     "account, gpus_per_node", [(None, None), ("test_account", None), (None, 8), ("test_account", 8)]
 )
-def test_system_with_account(slurm_system: SlurmSystem, account, gpus_per_node):
+def test_docker_import_with_extra_system_config(slurm_system: SlurmSystem, account, gpus_per_node):
     slurm_system.account = account
     slurm_system.gpus_per_node = gpus_per_node
     slurm_system.install_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
Currently the docker image enroot command only contains "account", "partition", "docker image url"
But some clusters may require explicit specify the GPU resource by using `--gpu=N`, like `CW-DFW`

## Test Plan
Use Cloudaix to do the testing
- Login into CW-DFW data copy node or login node
- Setup Cloudaix env
- Clone this branch, and install cloudai manually
- Run: `python cloudaix.py install --tests-dir ./conf/staging/dgx_cloud_acceptance_test/test/ --system-config ./conf/common/system/coreweave.toml`
- Confirm if the docker image has been downloaded to ./install successfully

## Additional Notes
`--gpu=1` will only be added into enroot command when the original command got `Cannot find GPU specification` error
