### PR TITLE
Fixed typo in NeMoRunTestDefinition docstr

### DIFF
--- a/src/cloudai/test_definitions/nemo_run.py
+++ b/src/cloudai/test_definitions/nemo_run.py
@@ -29,7 +29,7 @@ class NeMoRunCmdArgs(CmdArgs):
 
 
 class NeMoRunTestDefinition(TestDefinition):
-    """Test object for NeMoLauncher."""
+    """Test object for NeMoRun."""
 
     cmd_args: NeMoRunCmdArgs
     _docker_image: Optional[DockerImage] = None


### PR DESCRIPTION
## Summary
Fixed typo in NeMoRunTestDefinition. It said it's a test object for NemoLauncher, now it's correctly referring to NeMoRun.

## Test Plan
Since I've only edited a comment I haven't tested anything in particular.