### PR TITLE
Mount NCCL_TOPO_FILE in NCCL test

### DIFF
--- a/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nccl_test/slurm_command_gen_strategy.py
@@ -31,10 +31,9 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
 
         container_mounts = ""
-        if "NCCL_TOPO_FILE" in env_vars and "DOCKER_NCCL_TOPO_FILE" in env_vars:
-            nccl_graph_path = Path(env_vars["NCCL_TOPO_FILE"]).resolve()
-            nccl_graph_file = env_vars["DOCKER_NCCL_TOPO_FILE"]
-            container_mounts = f"{nccl_graph_path}:{nccl_graph_file}"
+        if "NCCL_TOPO_FILE" in env_vars:
+            nccl_topo_file = Path(env_vars["NCCL_TOPO_FILE"]).resolve()
+            container_mounts = f"{nccl_topo_file}:{nccl_topo_file}"
         elif "NCCL_TOPO_FILE" in env_vars:
             del env_vars["NCCL_TOPO_FILE"]
 

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -35,12 +35,12 @@ class TestNcclTestSlurmCommandGenStrategy:
         [
             (
                 "nccl_test",
-                {"NCCL_TOPO_FILE": "/path/to/topo", "DOCKER_NCCL_TOPO_FILE": "/docker/topo"},
+                {"NCCL_TOPO_FILE": "/path/to/topo"},
                 {"subtest_name": "all_reduce_perf", "docker_image_url": "fake_image_url"},
                 2,
                 ["node1", "node2"],
                 {
-                    "container_mounts": "/path/to/topo:/docker/topo",
+                    "container_mounts": "/path/to/topo:/path/to/topo",
                 },
             ),
             (
@@ -50,7 +50,7 @@ class TestNcclTestSlurmCommandGenStrategy:
                 1,
                 ["node1"],
                 {
-                    "container_mounts": "",
+                    "container_mounts": "/path/to/topo:/path/to/topo",
                 },
             ),
         ],


### PR DESCRIPTION
## Summary
This is a PR to mount NCCL_TOPO_FILE to the container when NCCL_TOPO_FILE is set. Previously, a pair of environment variables was used to set NCCL_TOPO_FILE. However, this approach was unnecessary and confusing. With this PR, NCCL_TOPO_FILE is mounted to the container whenever it is available.

## Test Plan
Ran it on a server.