### PR TITLE
Fix time limit calculation to include pre and post test hook durations

### DIFF
--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 import logging
+import re
+from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import toml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
@@ -24,6 +26,73 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 from .exceptions import TestScenarioParsingError, format_validation_error
 from .test import Test
 from .test_scenario import TestDependency, TestRun, TestScenario
+
+
+def parse_time_limit(limit: str) -> timedelta:
+    try:
+        if re.match(r"^\d+[smhdw]$", limit, re.IGNORECASE):
+            return parse_abbreviated_time(limit)
+        if "-" in limit:
+            return parse_dashed_time(limit)
+        if len(limit.split(":")) == 3:
+            hours, minutes, seconds = map(int, limit.split(":"))
+            return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        if len(limit.split(":")) == 2:
+            hours, minutes = map(int, limit.split(":"))
+            return timedelta(hours=hours, minutes=minutes)
+    except ValueError as err:
+        raise ValueError(f"Invalid time limit format: {limit}. Refer to SLURM time format documentation.") from err
+
+    raise ValueError(f"Unsupported time limit format: {limit}. Refer to SLURM time format documentation.")
+
+
+def parse_abbreviated_time(limit: str) -> timedelta:
+    value, unit = int(limit[:-1]), limit[-1].lower()
+    if unit == "s":
+        return timedelta(seconds=value)
+    if unit == "m":
+        return timedelta(minutes=value)
+    if unit == "h":
+        return timedelta(hours=value)
+    if unit == "d":
+        return timedelta(days=value)
+    if unit == "w":
+        return timedelta(weeks=value)
+    raise ValueError(f"Invalid abbreviated time format: {limit}")
+
+
+def parse_dashed_time(limit: str) -> timedelta:
+    days, time_part = limit.split("-", 1)
+    hours, minutes, seconds = map(int, time_part.split(":"))
+    return timedelta(days=int(days), hours=hours, minutes=minutes, seconds=seconds)
+
+
+def format_time_limit(total_time: timedelta) -> str:
+    total_seconds = int(total_time.total_seconds())
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if days > 0:
+        return f"{days}-{hours:02}:{minutes:02}:{seconds:02}"
+    return f"{hours:02}:{minutes:02}:{seconds:02}"
+
+
+def calculate_total_time_limit(
+    time_limit: Optional[str] = None, test_hooks: Optional[List[TestScenario]] = None
+) -> str:
+    total_time = timedelta()
+
+    if time_limit:
+        total_time += parse_time_limit(time_limit)
+
+    if test_hooks:
+        for hook in test_hooks:
+            if hook:
+                for test_run in hook.test_runs:
+                    if test_run.time_limit:
+                        total_time += parse_time_limit(test_run.time_limit)
+
+    return format_time_limit(total_time)
 
 
 class _TestDependencyTOML(BaseModel):
@@ -217,13 +286,16 @@ class TestScenarioParser:
 
         test = Test(test_definition=original_test.test_definition, test_template=original_test.test_template)
 
+        hooks = [hook for hook in [pre_test, post_test] if hook is not None]
+        total_time_limit = calculate_total_time_limit(time_limit=test_info.time_limit, test_hooks=hooks)
+
         tr = TestRun(
             test_info.id,
             test,
             num_nodes=test_info.num_nodes or 1,
             iterations=test_info.iterations,
             nodes=test_info.nodes,
-            time_limit=test_info.time_limit,
+            time_limit=total_time_limit,
             sol=test_info.sol,
             weight=test_info.weight * normalized_weight,
             ideal_perf=test_info.ideal_perf,

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -15,14 +15,13 @@
 # limitations under the License.
 
 
-from datetime import timedelta
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 from cloudai import CmdArgs, Test, TestRun, TestScenarioParser, TestScenarioParsingError
-from cloudai._core.test_scenario_parser import _TestScenarioTOML, calculate_total_time_limit, parse_time_limit
+from cloudai._core.test_scenario_parser import _TestScenarioTOML, calculate_total_time_limit
 from tests.conftest import MyTestDefinition
 
 
@@ -208,46 +207,17 @@ def test_test_id_must_contain_at_least_one_letter() -> None:
 @pytest.mark.parametrize(
     "time_str, expected",
     [
-        ("10m", timedelta(minutes=10)),
-        ("1h", timedelta(hours=1)),
-        ("2d", timedelta(days=2)),
-        ("1w", timedelta(weeks=1)),
-        ("30s", timedelta(seconds=30)),
-    ],
-)
-def test_parse_time_limit_with_abbreviated_formats(time_str, expected):
-    assert parse_time_limit(time_str) == expected
-
-
-@pytest.mark.parametrize(
-    "time_str, expected",
-    [
-        ("1-12:30:45", timedelta(days=1, hours=12, minutes=30, seconds=45)),
-    ],
-)
-def test_parse_time_limit_with_dashed_format(time_str, expected):
-    assert parse_time_limit(time_str) == expected
-
-
-@pytest.mark.parametrize(
-    "time_str, expected",
-    [
-        ("12:30:45", timedelta(hours=12, minutes=30, seconds=45)),
-        ("12:30", timedelta(hours=12, minutes=30)),
-    ],
-)
-def test_parse_time_limit_with_colon_formats(time_str, expected):
-    assert parse_time_limit(time_str) == expected
-
-
-@pytest.mark.parametrize(
-    "time_str, expected",
-    [
+        ("10m", "00:10:00"),
         ("1h", "01:00:00"),
-        ("1-12:00:00", "1-12:00:00"),
+        ("2d", "2-00:00:00"),
+        ("1w", "7-00:00:00"),
+        ("30s", "00:00:30"),
+        ("1-12:30:45", "1-12:30:45"),
+        ("12:30:45", "12:30:45"),
+        ("12:30", "12:30:00"),
     ],
 )
-def test_calculate_total_time_limit_with_main_time_only(time_str, expected):
+def test_calculate_total_time_limit(time_str, expected):
     assert calculate_total_time_limit(time_limit=time_str) == expected
 
 

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -91,7 +91,7 @@ def test_with_time_limit(test: Test, test_scenario_parser: TestScenarioParser) -
     test_scenario = test_scenario_parser._parse_data(
         {"name": "nccl-test", "Tests": [{"id": "1", "test_name": "nccl", "time_limit": "10m"}]}
     )
-    assert test_scenario.test_runs[0].time_limit == "10m"
+    assert test_scenario.test_runs[0].time_limit == "00:10:00"
 
 
 def test_two_independent_cases(test: Test, test_scenario_parser: TestScenarioParser) -> None:


### PR DESCRIPTION
## Summary
Bug fix for https://redmine.mellanox.com/issues/4248887. Extend the total time limit to include the time taken by pre/post-test hooks.

## Test Plan
1. Added tests.
2. Ran manually
```
$ python ./cloudaix.py dry-run --system-config conf/common/system/israel_1.toml --tests-dir conf/devops/verification/test/ --test-scenario conf/devops/verification/test_scenario/jax_gpt_nightly.toml
```