### PR TITLE
Enforce either paralleism or mesh dimensions

### DIFF
--- a/src/cloudai/test_definitions/gpt.py
+++ b/src/cloudai/test_definitions/gpt.py
@@ -28,6 +28,8 @@ class GPTFdl(JaxFdl):
     """GPT FDL configuration."""
 
     num_groups: int = 64
+    ici_mesh_shape: Union[str, list[str]] = "'[1, 1, 8, 1]'"
+    dcn_mesh_shape: Union[str, list[str]] = "'[1, 8, 1, 1]'"
 
 
 class GPTXLAFlags(XLAFlags):

--- a/src/cloudai/test_definitions/nemotron.py
+++ b/src/cloudai/test_definitions/nemotron.py
@@ -33,6 +33,8 @@ class NemotronFdl(JaxFdl):
     num_gpus: Union[int, list[int]] = 8
     percore_batch_size: Union[float, list[float]] = 0.25  # type: ignore
     use_repeated_layer: Union[bool, list[bool]] = True
+    ici_mesh_shape: Union[str, list[str]] = "[1, 1, 1, 1]"
+    dcn_mesh_shape: Union[str, list[str]] = "[1, 1, 1, 1]"
 
 
 class NemotrolXLAFlags(XLAFlags):
@@ -54,6 +56,7 @@ class NemotronCmdArgs(GrokCmdArgs):
 
     xla_flags: NemotrolXLAFlags = Field(default_factory=NemotrolXLAFlags)
     setup_flags: NemotronSetupFlags = Field(default_factory=NemotronSetupFlags)  # type: ignore
+    fdl: NemotronFdl = Field(default_factory=NemotronFdl)
 
 
 class NemotronTestDefinition(GrokTestDefinition):

--- a/tests/test_test_definitions.py
+++ b/tests/test_test_definitions.py
@@ -23,10 +23,10 @@ import toml
 from cloudai import Parser, Registry
 from cloudai.test_definitions import ChakraReplayCmdArgs, NCCLCmdArgs, NCCLTestDefinition
 from cloudai.test_definitions.chakra_replay import ChakraReplayTestDefinition
-from cloudai.test_definitions.gpt import GPTCmdArgs, GPTTestDefinition
-from cloudai.test_definitions.grok import GrokCmdArgs, GrokTestDefinition
+from cloudai.test_definitions.gpt import GPTCmdArgs, GPTFdl, GPTTestDefinition
+from cloudai.test_definitions.grok import GrokCmdArgs, GrokFdl, GrokTestDefinition
 from cloudai.test_definitions.nemo_launcher import NeMoLauncherCmdArgs, NeMoLauncherTestDefinition
-from cloudai.test_definitions.nemotron import NemotronCmdArgs, NemotronTestDefinition
+from cloudai.test_definitions.nemotron import NemotronCmdArgs, NemotronFdl, NemotronTestDefinition
 from cloudai.test_definitions.ucc import UCCCmdArgs, UCCTestDefinition
 from tests.conftest import MyTestDefinition
 
@@ -92,19 +92,31 @@ def test_chakra_docker_image_is_required():
             name="gpt",
             description="desc",
             test_template_name="gpt",
-            cmd_args=GPTCmdArgs(fdl_config="", docker_image_url="fake://url/gpt"),
+            cmd_args=GPTCmdArgs(
+                fdl_config="",
+                docker_image_url="fake://url/gpt",
+                fdl=GPTFdl(ici_mesh_shape="[1, 1, 1, 1]", dcn_mesh_shape="[1, 1, 1, 1]"),
+            ),
         ),
         GrokTestDefinition(
             name="grok",
             description="desc",
             test_template_name="grok",
-            cmd_args=GrokCmdArgs(docker_image_url="fake://url/grok"),
+            cmd_args=GrokCmdArgs(
+                docker_image_url="fake://url/grok",
+                fdl_config="",
+                fdl=GrokFdl(ici_mesh_shape="[1, 1, 1, 1]", dcn_mesh_shape="[1, 1, 1, 1]"),
+            ),
         ),
         NemotronTestDefinition(
             name="nemotron",
             description="desc",
             test_template_name="nemotron",
-            cmd_args=NemotronCmdArgs(docker_image_url="fake://url/nemotron"),
+            cmd_args=NemotronCmdArgs(
+                docker_image_url="fake://url/nemotron",
+                fdl_config="",
+                fdl=NemotronFdl(ici_mesh_shape="[1, 1, 1, 1]", dcn_mesh_shape="[1, 1, 1, 1]"),
+            ),
         ),
         NeMoLauncherTestDefinition(
             name="nemo", description="desc", test_template_name="nemo", cmd_args=NeMoLauncherCmdArgs()


### PR DESCRIPTION
## Summary

For benchmarking in Jaxtoolbox, the users usually specify the `ici` and `dcn` mesh shapes. However, for DSE, the users will directly specify the parallelism mapping dimensions. For each parallelism dimension, there are many ways to construct the mesh shapes which will be handled by the agent in the DSE.

This PR enforces the requirement that for benchmarking/DSE, the user can directly specify parallelism mapping or mesh shapes directly but not both at the same time. 

## Test Plan
* CI/CD
* Pydantic validation on dry-run command


## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
