### PR TITLE
Always mount current output dir as /cloudai_run_results

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -393,6 +393,16 @@ test_name = "nccl_test_all_reduce"
 time_limit = "00:20:00"
 ```
 
+## Slurm specifics
+
+### Container mounts
+CloudAI runs all slurm jobs using containers. To simplify file system related tasks, CloudAI mounts the following directories into the container:
+1. Test output directory (`<output_path>/<scenario_name_with_timestamp>/<test_name>/<iteration>`, like `results/scenario_2024-06-18_17-40-13/Tests.1/0`) is mounted as `/cloudai_run_results`.
+2. Test specific mounts can be mounted in-code.
+
+#### Dev details
+`SlurmCommandGenStrategy` defines abstract method `_container_mounts(tr: TestRun)` that must be implemented by every subclass. This method is used in `SlurmCommandGenStrategy.container_mounts(tr: TestRun)` (defined as `@final`) where mounts like `/cloudai_run_results` and test specific mounts are added.
+
 ## Troubleshooting
 In this section, we will guide you through identifying the root cause of issues, determining whether they stem from system infrastructure or a bug in CloudAI. Users should closely follow the USER_GUIDE.md and README.md for installation, tests, and test scenarios.
 

--- a/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/chakra_replay/slurm_command_gen_strategy.py
@@ -24,18 +24,19 @@ from cloudai.test_definitions.chakra_replay import ChakraReplayTestDefinition
 class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for ChakraReplay on Slurm systems."""
 
+    def _container_mounts(self, tr: TestRun) -> list[str]:
+        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, tr.test.test_definition)
+        if tdef.cmd_args.trace_path:
+            return [f"{tdef.cmd_args.trace_path}:{tdef.cmd_args.trace_path}"]
+        return []
+
     def _parse_slurm_args(
         self, job_name_prefix: str, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> Dict[str, Any]:
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
 
         tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, tr.test.test_definition)
-        base_args.update(
-            {
-                "image_path": tdef.docker_image.installed_path,
-                "container_mounts": f"{tdef.cmd_args.trace_path}:{tdef.cmd_args.trace_path}",
-            }
-        )
+        base_args.update({"image_path": tdef.docker_image.installed_path})
 
         return base_args
 

--- a/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_launcher/slurm_command_gen_strategy.py
@@ -26,6 +26,10 @@ from cloudai.test_definitions.nemo_launcher import NeMoLauncherTestDefinition
 class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NeMo Megatron Launcher on Slurm systems."""
 
+    def _container_mounts(self, tr: TestRun) -> list[str]:
+        # this strategy handles container mounts in a different way, so it is OK to return an empty list
+        return []
+
     def gen_exec_command(self, tr: TestRun) -> str:
         self._prepare_environment(tr.test.cmd_args, tr.test.extra_env_vars, tr.output_path)
 

--- a/src/cloudai/schema/test_template/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/nemo_run/slurm_command_gen_strategy.py
@@ -25,6 +25,9 @@ from cloudai.test_definitions.nemo_run import NeMoRunTestDefinition
 class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NeMo 2.0 on Slurm systems."""
 
+    def _container_mounts(self, tr: TestRun) -> list[str]:
+        return []
+
     def _parse_slurm_args(
         self, job_name_prefix: str, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> Dict[str, Any]:

--- a/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/sleep/slurm_command_gen_strategy.py
@@ -23,6 +23,9 @@ from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for Sleep on Slurm systems."""
 
+    def _container_mounts(self, tr: TestRun) -> list[str]:
+        return []
+
     def generate_test_command(
         self, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> List[str]:

--- a/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/schema/test_template/ucc_test/slurm_command_gen_strategy.py
@@ -24,6 +24,9 @@ from cloudai.test_definitions.ucc import UCCTestDefinition
 class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for UCC tests on Slurm systems."""
 
+    def _container_mounts(self, tr: TestRun) -> List[str]:
+        return []
+
     def _parse_slurm_args(
         self, job_name_prefix: str, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> Dict[str, Any]:

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -65,7 +65,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         Function returns CommandGenStrategy specific container mounts as well as default ones
         that should always be used.
         """
-        return [f"{tr.output_path}:/cloudai_run_results", *self._container_mounts(tr)]
+        return [f"{tr.output_path.absolute()}:/cloudai_run_results", *self._container_mounts(tr)]
 
     def gen_exec_command(self, tr: TestRun) -> str:
         env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)

--- a/src/cloudai/test_definitions/slurm_container.py
+++ b/src/cloudai/test_definitions/slurm_container.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Optional
 
 from cloudai import CmdArgs, Installable, TestDefinition

--- a/src/cloudai/test_definitions/slurm_container.py
+++ b/src/cloudai/test_definitions/slurm_container.py
@@ -64,14 +64,6 @@ class SlurmContainerTestDefinition(TestDefinition):
 
         return self._mcore_git_repo
 
-    def container_mounts(self, root: Path) -> list[str]:
-        repo_path = self.git_repo.installed_path or root / self.git_repo.repo_name
-        mcore_vfm_path = self.mcore_vfm_git_repo.installed_path or root / self.mcore_vfm_git_repo.repo_name
-        return [
-            f"{repo_path.absolute()}:/work",
-            f"{mcore_vfm_path.absolute()}:/opt/megatron-lm",
-        ]
-
     @property
     def installables(self) -> list[Installable]:
         return [self.docker_image, self.git_repo, self.mcore_vfm_git_repo]

--- a/tests/ref_data/gpt-no-hook.sbatch
+++ b/tests/ref_data/gpt-no-hook.sbatch
@@ -18,5 +18,5 @@ echo "Loading container with srun command"
     -o __OUTPUT_DIR__/output/output-%j-%n-%t.txt \
     -e __OUTPUT_DIR__/output/error-%j-%n-%t.txt \
     --container-name=cont \
-    --container-mounts=__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
+    --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
     /opt/paxml/workspace/run.sh

--- a/tests/ref_data/gpt-pre-test.sbatch
+++ b/tests/ref_data/gpt-pre-test.sbatch
@@ -8,7 +8,7 @@ export COMBINE_THRESHOLD=1
 export PER_GPU_COMBINE_THRESHOLD=0
 export XLA_FLAGS="--xla_gpu_all_gather_combine_threshold_bytes=$COMBINE_THRESHOLD --xla_gpu_all_reduce_combine_threshold_bytes=$COMBINE_THRESHOLD --xla_gpu_reduce_scatter_combine_threshold_bytes=$PER_GPU_COMBINE_THRESHOLD"
 
-srun --output=__OUTPUT_DIR__/output/pre_test/nccl/stdout.txt --error=__OUTPUT_DIR__/output/pre_test/nccl/stderr.txt --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
+srun --output=__OUTPUT_DIR__/output/pre_test/nccl/stdout.txt --error=__OUTPUT_DIR__/output/pre_test/nccl/stderr.txt --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=__OUTPUT_DIR__/output/pre_test/nccl:/cloudai_run_results /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
 SUCCESS_0=$(grep -q "Avg bus bandwidth" __OUTPUT_DIR__/output/pre_test/nccl/stdout.txt && echo 1 || echo 0)
 PRE_TEST_SUCCESS=$( [ $SUCCESS_0 -eq 1 ] && echo 1 || echo 0 )
 if [ $PRE_TEST_SUCCESS -eq 1 ]; then
@@ -22,6 +22,6 @@ if [ $PRE_TEST_SUCCESS -eq 1 ]; then
     -o __OUTPUT_DIR__/output/output-%j-%n-%t.txt \
     -e __OUTPUT_DIR__/output/error-%j-%n-%t.txt \
     --container-name=cont \
-    --container-mounts=__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
+    --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
     /opt/paxml/workspace/run.sh
 fi

--- a/tests/ref_data/grok-no-hook.sbatch
+++ b/tests/ref_data/grok-no-hook.sbatch
@@ -18,5 +18,5 @@ echo "Loading container with srun command"
     -o __OUTPUT_DIR__/output/output-%j-%n-%t.txt \
     -e __OUTPUT_DIR__/output/error-%j-%n-%t.txt \
     --container-name=cont \
-    --container-mounts=__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
+    --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
     /opt/paxml/workspace/run.sh

--- a/tests/ref_data/grok-pre-test.sbatch
+++ b/tests/ref_data/grok-pre-test.sbatch
@@ -8,7 +8,7 @@ export COMBINE_THRESHOLD=1
 export PER_GPU_COMBINE_THRESHOLD=0
 export XLA_FLAGS="--xla_disable_hlo_passes=rematerialization --xla_dump_hlo_pass_re=.* --xla_gpu_all_gather_combine_threshold_bytes=$COMBINE_THRESHOLD --xla_gpu_all_reduce_combine_threshold_bytes=$COMBINE_THRESHOLD --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_enable_highest_priority_async_stream=true --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_pipelined_all_gather=true --xla_gpu_enable_pipelined_all_reduce=true --xla_gpu_enable_pipelined_reduce_scatter=true --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_triton_gemm=false --xla_gpu_enable_triton_softmax_fusion=false --xla_gpu_enable_while_loop_double_buffering=true --xla_gpu_graph_level=0 --xla_gpu_pgle_profile_file_or_directory_path=/opt/paxml/workspace/pgle_output_profile.pbtxt --xla_gpu_reduce_scatter_combine_threshold_bytes=$PER_GPU_COMBINE_THRESHOLD --xla_gpu_run_post_layout_collective_pipeliner=false --xla_gpu_use_memcpy_local_p2p=false"
 
-srun --output=__OUTPUT_DIR__/output/pre_test/nccl/stdout.txt --error=__OUTPUT_DIR__/output/pre_test/nccl/stderr.txt --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
+srun --output=__OUTPUT_DIR__/output/pre_test/nccl/stdout.txt --error=__OUTPUT_DIR__/output/pre_test/nccl/stderr.txt --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=__OUTPUT_DIR__/output/pre_test/nccl:/cloudai_run_results /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
 SUCCESS_0=$(grep -q "Avg bus bandwidth" __OUTPUT_DIR__/output/pre_test/nccl/stdout.txt && echo 1 || echo 0)
 PRE_TEST_SUCCESS=$( [ $SUCCESS_0 -eq 1 ] && echo 1 || echo 0 )
 if [ $PRE_TEST_SUCCESS -eq 1 ]; then
@@ -22,6 +22,6 @@ if [ $PRE_TEST_SUCCESS -eq 1 ]; then
     -o __OUTPUT_DIR__/output/output-%j-%n-%t.txt \
     -e __OUTPUT_DIR__/output/error-%j-%n-%t.txt \
     --container-name=cont \
-    --container-mounts=__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
+    --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/output:/opt/paxml/workspace/ \
     /opt/paxml/workspace/run.sh
 fi

--- a/tests/ref_data/nccl.sbatch
+++ b/tests/ref_data/nccl.sbatch
@@ -8,4 +8,4 @@
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
 
-srun --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
+srun --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0

--- a/tests/ref_data/nemo-run-no-hook.sbatch
+++ b/tests/ref_data/nemo-run-no-hook.sbatch
@@ -8,4 +8,4 @@
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
 
-srun --mpi=pmix --container-image=nvcr.io/nvidia/nemo:24.09 nemo llm pretrain --factory llama_3b -y trainer.num_nodes=1
+srun --mpi=pmix --container-image=nvcr.io/nvidia/nemo:24.09 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results nemo llm pretrain --factory llama_3b -y trainer.num_nodes=1

--- a/tests/ref_data/nemo-run-pre-test.sbatch
+++ b/tests/ref_data/nemo-run-pre-test.sbatch
@@ -8,9 +8,9 @@
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
 
-srun --output=__OUTPUT_DIR__/output/pre_test/nccl/stdout.txt --error=__OUTPUT_DIR__/output/pre_test/nccl/stderr.txt --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
+srun --output=__OUTPUT_DIR__/output/pre_test/nccl/stdout.txt --error=__OUTPUT_DIR__/output/pre_test/nccl/stderr.txt --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=__OUTPUT_DIR__/output/pre_test/nccl:/cloudai_run_results /usr/local/bin/all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 32M --maxbytes 32M --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0
 SUCCESS_0=$(grep -q "Avg bus bandwidth" __OUTPUT_DIR__/output/pre_test/nccl/stdout.txt && echo 1 || echo 0)
 PRE_TEST_SUCCESS=$( [ $SUCCESS_0 -eq 1 ] && echo 1 || echo 0 )
 if [ $PRE_TEST_SUCCESS -eq 1 ]; then
-    srun --mpi=pmix --container-image=nvcr.io/nvidia/nemo:24.09 nemo llm pretrain --factory llama_3b -y trainer.num_nodes=1
+    srun --mpi=pmix --container-image=nvcr.io/nvidia/nemo:24.09 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results nemo llm pretrain --factory llama_3b -y trainer.num_nodes=1
 fi

--- a/tests/ref_data/slurm_container.sbatch
+++ b/tests/ref_data/slurm_container.sbatch
@@ -8,4 +8,4 @@
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
 
-srun --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/install/url__commit_hash:/work,__OUTPUT_DIR__/install/repo__mcore_vfm_commit_hash:/opt/megatron-lm,__OUTPUT_DIR__/output:/cloudai_run_results --no-container-mount-home bash -c "pwd ; ls"
+srun --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install/url__commit_hash:/work,__OUTPUT_DIR__/install/repo__mcore_vfm_commit_hash:/opt/megatron-lm --no-container-mount-home bash -c "pwd ; ls"

--- a/tests/ref_data/ucc.sbatch
+++ b/tests/ref_data/ucc.sbatch
@@ -8,4 +8,4 @@
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
 
-srun --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 /opt/hpcx/ucc/bin/ucc_perftest -c alltoall -b 1 -e 8M -m cuda -F
+srun --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results /opt/hpcx/ucc/bin/ucc_perftest -c alltoall -b 1 -e 8M -m cuda -F

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -272,6 +272,7 @@ def test_pre_test_post_test_combinations(
 
 
 def test_default_container_mounts(strategy_fixture: SlurmCommandGenStrategy, testrun_fixture: TestRun):
+    testrun_fixture.output_path = Path("./")
     mounts = strategy_fixture.container_mounts(testrun_fixture)
     assert len(mounts) == 1
     assert mounts[0] == f"{testrun_fixture.output_path.absolute()}:/cloudai_run_results"

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -26,10 +26,15 @@ from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 from tests.conftest import create_autospec_dataclass
 
 
+class MySlurmCommandGenStrategy(SlurmCommandGenStrategy):
+    def _container_mounts(self, tr: TestRun) -> List[str]:
+        return []
+
+
 @pytest.fixture
 def strategy_fixture(slurm_system: SlurmSystem) -> SlurmCommandGenStrategy:
     cmd_args: Dict[str, Union[str, List[str]]] = {"test_arg": "test_value"}
-    strategy = SlurmCommandGenStrategy(slurm_system, cmd_args)
+    strategy = MySlurmCommandGenStrategy(slurm_system, cmd_args)
     return strategy
 
 
@@ -129,7 +134,7 @@ def test_time_limit(time_limit: Optional[str], strategy_fixture: SlurmCommandGen
 def test_raises_if_no_default_partition(slurm_system: SlurmSystem):
     slurm_system.default_partition = ""
     with pytest.raises(ValueError) as exc_info:
-        SlurmCommandGenStrategy(slurm_system, {})
+        MySlurmCommandGenStrategy(slurm_system, {})
     assert (
         "Default partition not set in the Slurm system object. "
         "The 'default_partition' attribute should be properly defined in the Slurm "

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -269,3 +269,9 @@ def test_pre_test_post_test_combinations(
 
     for expected_line in expected_script_lines:
         assert expected_line in script_content, f"Expected '{expected_line}' in generated script but it was missing."
+
+
+def test_default_container_mounts(strategy_fixture: SlurmCommandGenStrategy, testrun_fixture: TestRun):
+    mounts = strategy_fixture.container_mounts(testrun_fixture)
+    assert len(mounts) == 1
+    assert mounts[0] == f"{testrun_fixture.output_path.absolute()}:/cloudai_run_results"

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -19,9 +19,11 @@ from unittest.mock import Mock
 
 import pytest
 
+from cloudai._core.test import Test
 from cloudai._core.test_scenario import TestRun
 from cloudai.schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 from cloudai.systems import SlurmSystem
+from cloudai.test_definitions.nccl import NCCLCmdArgs, NCCLTestDefinition
 from tests.conftest import create_autospec_dataclass
 
 
@@ -65,11 +67,12 @@ class TestNcclTestSlurmCommandGenStrategy:
         nodes: List[str],
         expected_result: Dict[str, Any],
     ) -> None:
-        tr = create_autospec_dataclass(TestRun)
-        tr.nodes = nodes
-        tr.num_nodes = num_nodes
-        slurm_args = cmd_gen_strategy._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
-        assert slurm_args["container_mounts"] == expected_result["container_mounts"]
+        nccl = NCCLTestDefinition(
+            name="name", description="desc", test_template_name="tt", cmd_args=NCCLCmdArgs(), extra_env_vars=env_vars
+        )
+        t = Test(test_definition=nccl, test_template=Mock())
+        tr = TestRun(name="t1", test=t, nodes=nodes, num_nodes=num_nodes)
+        assert expected_result["container_mounts"] in cmd_gen_strategy.container_mounts(tr)
 
     @pytest.mark.parametrize(
         "cmd_args, extra_cmd_args, expected_command",

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -24,7 +24,6 @@ from cloudai._core.test_scenario import TestRun
 from cloudai.schema.test_template.nccl_test.slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 from cloudai.systems import SlurmSystem
 from cloudai.test_definitions.nccl import NCCLCmdArgs, NCCLTestDefinition
-from tests.conftest import create_autospec_dataclass
 
 
 class TestNcclTestSlurmCommandGenStrategy:


### PR DESCRIPTION
## Summary
1. Always mount current output dir as `/cloudai_run_results`.
2. Introduce `container_mounts(tr)` (final) and `_container_mounts(tr)` (abstract) as part of `SlurmCommandGenStrategy`.
3. Updated tests to match new behavior.

## Test Plan
1. CI.
2. For JAX tests current output dir is mounted twice: as `/cloudai_run_results` and as `tdef.cmd_args.setup_flags.docker_workspace_dir`. This is a bit confusing, but works. I ran `srun -n 1 --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=$PWD:/out1,$PWD:/out2 bash` and created files via both mounts, works fine.
3. Run NemoRun and NCCL on IL1.

## Additional Notes
Nemo Launcher doesn't support new mount as its behavior is significantly different.
