### PR TITLE
Add support for extra sbatch args via system model

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -395,6 +395,33 @@ time_limit = "00:20:00"
 
 ## Slurm specifics
 
+### Extra srun and sbatch arguments
+CloudAI forms sbatch script and srun commands following internal rules. Users can affect the generation but setting special arguments in System TOML file.
+
+For example (in a System TOML file):,
+```toml
+extra_sbatch_args = [
+  "--section=4",
+  "--other-arg val"
+]
+```
+will result in sbatch file content like this:
+```bash
+... # CloudAI set sbatch arguments
+#SBATCH --section=4
+#SBATCH --other-arg val
+...
+```
+
+Another example (in a System TOML file):
+```toml
+extra_srun_args = "--arg=val --other-arg=other-val"
+```
+will result in srun command inside sbatch script like this:
+```bash
+srun ... --arg=val --other-arg=other-val ...
+```
+
 ### Container mounts
 CloudAI runs all slurm jobs using containers. To simplify file system related tasks, CloudAI mounts the following directories into the container:
 1. Test output directory (`<output_path>/<scenario_name_with_timestamp>/<test_name>/<iteration>`, like `results/scenario_2024-06-18_17-40-13/Tests.1/0`) is mounted as `/cloudai_run_results`.

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -136,6 +136,7 @@ class SlurmSystem(BaseModel, System):
     monitor_interval: int = 1
     cmd_shell: CommandShell = CommandShell()
     extra_srun_args: Optional[str] = None
+    extra_sbatch_args: list[str] = []
 
     @property
     def groups(self) -> Dict[str, Dict[str, List[SlurmNode]]]:

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -318,6 +318,9 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         if "time_limit" in args:
             batch_script_content.append(f"#SBATCH --time={args['time_limit']}")
 
+        for arg in self.system.extra_sbatch_args:
+            batch_script_content.append(f"#SBATCH {arg}")
+
         batch_script_content.append(
             "\nexport SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)"
         )

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -276,3 +276,13 @@ def test_default_container_mounts(strategy_fixture: SlurmCommandGenStrategy, tes
     mounts = strategy_fixture.container_mounts(testrun_fixture)
     assert len(mounts) == 1
     assert mounts[0] == f"{testrun_fixture.output_path.absolute()}:/cloudai_run_results"
+
+
+def test_append_sbatch_directives(strategy_fixture: SlurmCommandGenStrategy, tmp_path: Path):
+    content: list[str] = []
+    strategy_fixture.system.extra_sbatch_args = ["--section=4", "--other-arg 1"]
+    strategy_fixture._append_sbatch_directives(content, {"node_list_str": ""}, tmp_path)
+
+    assert f"#SBATCH --partition={strategy_fixture.system.default_partition}" in content
+    for arg in strategy_fixture.system.extra_sbatch_args:
+        assert f"#SBATCH {arg}" in content


### PR DESCRIPTION
## Summary
Add support for extra sbatch args via system model.

For example (in a System TOML file):,
```toml
extra_sbatch_args = [
  "--section=4",
  "--other-arg val"
]
```
will result in sbatch file content like this:
```bash
... # CloudAI set sbatch arguments
#SBATCH --section=4
#SBATCH --other-arg val
...
```

## Test Plan
CI

## Additional Notes
—
