### PR TITLE
Base Config for NemoRun LLama3-8b

### DIFF
--- a/conf/common/test/nemo_run_llama3_8b.toml
+++ b/conf/common/test/nemo_run_llama3_8b.toml
@@ -15,17 +15,27 @@
 # limitations under the License.
 
 name = "nemo_run_llama3_8b"
-description = "nemo_run_llama3_8b"
+description = "dse_nemo_run_llama3_8b"
 test_template_name = "NeMoRun"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:24.09"
+docker_image_url = "nvcr.io/nvidia/nemo:24.12.rc3"
 task = "pretrain"
 recipe_name = "llama3_8b"
 
+  [cmd_args.data]
+  micro_batch_size = 1
+  global_batch_size = 128
+
   [cmd_args.trainer]
-  max_steps = 5
+  max_steps = 100
   val_check_interval = 1000
+  num_nodes = 1
+
+    [cmd_args.trainer.strategy]
+    tensor_model_parallel_size = 1
+    pipeline_model_parallel_size = 1
+    context_parallel_size = 2
 
   [cmd_args.log.ckpt]
   save_on_train_epoch_end = false


### PR DESCRIPTION
## Summary
This is the config tested on docker (nvcr.io/nvidia/nemo:24.12.rc3) thats used by one of the customers. For other customers and other docker url, need to see how to support. 

## Test Plan
CI
Tested on real system
```
cloudai run --system-config ../cloudaix/conf/common/system/xxxx --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nemo_run_llama3_8b.toml 
[INFO] System Name: xxxx
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nemo_run_llama3_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nemo_run_llama3_8b

Section Name: nemo_run_llama3_8b_1
  Test Name: nemo_run_llama3_8b
  Description: dse_nemo_run_llama3_8b
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: nemo_run_llama3_8b_1
[INFO] Running test: nemo_run_llama3_8b_1
[INFO] Submitted slurm job: xxx
```
## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
