### PR TITLE
Support extra_env_vars contains space

### DIFF
--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -359,5 +359,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         for key in sorted(env_vars.keys()):
             value = env_vars[key]
             formatted_value = str(value["default"]) if isinstance(value, dict) and "default" in value else str(value)
+            if " " in formatted_value:
+                formatted_value = f'"{formatted_value}"'
             formatted_vars.append(f"export {key}={formatted_value}")
         return "\n".join(formatted_vars)


### PR DESCRIPTION

## Summary
The new flag in NCCL test, NCCL_TEST_SPLIT, it's value will contains space, for example `MOD 8`
If we dump to script as `export NCCL_TEST_SPLIT = MOD 8` it will run into error
Need to be dumped as `export NCCL_TEST_SPLIT = "MOD 8"`
