### PR TITLE
Allow uint8 in NCCL ALLtoALL

### DIFF
--- a/src/cloudai/workloads/nccl_test/nccl.py
+++ b/src/cloudai/workloads/nccl_test/nccl.py
@@ -54,7 +54,7 @@ class NCCLCmdArgs(CmdArgs):
     maxbytes: str = "32M"
     stepbytes: str = "1M"
     op: Literal["sum", "prod", "min", "max", "avg", "all"] = "sum"
-    datatype: str = "float"
+    datatype: Literal["uint8", "float"] = "float"
     root: int = 0
     iters: int = 20
     warmup_iters: int = 5


### PR DESCRIPTION
## Summary
Allow the `datatype` field to be `uint8` along with `float`

## Test Plan
CI
Dry-run

```
(venv) $ cloudai dry-run --system-config ../cloudaix/conf/common/system/xxxx.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nccl_test.toml 
[INFO] System Name: xxxx
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nccl-test
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nccl-test

Section Name: Tests.1
  Test Name: nccl_test_all_gather
  Description: all_gather
  No dependencies
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test scenario execution.
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 0
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: results/nccl-test_xxxxxx
```

## Additional Notes

