### PR TITLE
Use non-abs bin names for NCCL tests

### DIFF
--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -46,7 +46,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def generate_test_command(
         self, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> List[str]:
-        srun_command_parts = [f"/usr/local/bin/{cmd_args['subtest_name']}"]
+        srun_command_parts = [f"{cmd_args['subtest_name']}"]
         nccl_test_args = [
             "nthreads",
             "ngpus",


### PR DESCRIPTION
## Summary
Use non-abs bin names for NCCL tests.

## Test Plan
1. CI.
2. Run NCCL test scenario, all test passed and generated reports.

## Additional Notes
—
