### PR TITLE
Ensure unique NeMo Launcher job names using timestamp to avoid conflicts

### DIFF
--- a/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Union, cast
 
@@ -41,13 +42,13 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         self.final_cmd_args.pop("docker_image_url", None)
 
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
         if self.system.account:
-            self.final_cmd_args.update(
-                {
-                    "cluster.account": self.system.account,
-                    "cluster.job_name_prefix": f"{self.system.account}-cloudai.nemo:",
-                }
-            )
+            self.final_cmd_args["cluster.account"] = self.system.account
+            self.final_cmd_args["cluster.job_name_prefix"] = f"{self.system.account}-cloudai.nemo_{timestamp}:"
+        else:
+            self.final_cmd_args["cluster.job_name_prefix"] = f"{timestamp}:"
         self.final_cmd_args["cluster.gpus_per_node"] = self.system.gpus_per_node or "null"
 
         repo_path = (

--- a/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
@@ -50,9 +50,11 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if self.job_prefix is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             if self.system.account:
-                self.final_cmd_args["cluster.job_name_prefix"] = f"{self.system.account}-cloudai.nemo_{timestamp}:"
+                self.job_prefix = f"{self.system.account}-cloudai.nemo_{timestamp}"
             else:
-                self.final_cmd_args["cluster.job_name_prefix"] = f"{timestamp}:"
+                self.job_prefix = timestamp
+
+        self.final_cmd_args["cluster.job_name_prefix"] = f"{self.job_prefix}:"
 
         self.final_cmd_args["cluster.gpus_per_node"] = self.system.gpus_per_node or "null"
 

--- a/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
@@ -53,9 +53,9 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if self.job_prefix is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             if self.system.account:
-                self.job_prefix = f"{self.system.account}-cloudai.nemo_{timestamp}"
+                self.final_cmd_args["cluster.job_name_prefix"] = f"{self.system.account}-cloudai.nemo_{timestamp}:"
             else:
-                self.job_prefix = timestamp
+                self.final_cmd_args["cluster.job_name_prefix"] = f"{timestamp}:"
 
         self.final_cmd_args["cluster.gpus_per_node"] = self.system.gpus_per_node or "null"
 

--- a/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
@@ -17,10 +17,9 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from cloudai import TestRun
-from cloudai.systems.slurm import SlurmSystem
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 from cloudai.workloads.nemo_launcher import NeMoLauncherTestDefinition
 
@@ -28,9 +27,7 @@ from cloudai.workloads.nemo_launcher import NeMoLauncherTestDefinition
 class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NeMo Megatron Launcher on Slurm systems."""
 
-    def __init__(self, system: SlurmSystem, cmd_args: Dict[str, Any]) -> None:
-        super().__init__(system, cmd_args)
-        self.job_prefix = None
+    job_prefix: Optional[str] = None
 
     def _container_mounts(self, tr: TestRun) -> list[str]:
         # this strategy handles container mounts in a different way, so it is OK to return an empty list

--- a/tests/ref_data/nemo-launcher.sbatch
+++ b/tests/ref_data/nemo-launcher.sbatch
@@ -20,5 +20,6 @@ __OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d
  cluster.partition=main \
  training.trainer.num_nodes=1 \
  container=nvcr.io/nvidia/nemo:24.12.01 \
+ cluster.job_name_prefix=test_account-cloudai.nemo: \
  base_results_dir=__OUTPUT_DIR__/output \
  launcher_scripts_path=__OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -17,12 +17,12 @@
 import argparse
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple, Type
 from unittest.mock import Mock, patch
 
 import pytest
 
-from cloudai import Test, TestRun, TestScenario, TestTemplate
+from cloudai import CommandGenStrategy, Test, TestDefinition, TestRun, TestScenario, TestTemplate
 from cloudai.cli import handle_dry_run_and_run, setup_logging
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
@@ -115,8 +115,8 @@ def create_test_run(
     partial_tr: partial[TestRun],
     slurm_system: SlurmSystem,
     name: str,
-    test_definition,
-    command_gen_strategy,
+    test_definition: TestDefinition,
+    command_gen_strategy: Type[CommandGenStrategy],
 ) -> TestRun:
     tr = partial_tr(
         name=name,

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -287,3 +287,9 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
         ref = "\n".join(line for line in ref.splitlines() if line.strip())
 
     assert curr == ref
+
+    run_script = test_req[-1]
+    if run_script:
+        curr_run_script = Path(slurm_system.output_path / "run.sh").read_text()
+        ref_run_script = (Path(__file__).parent / "ref_data" / run_script).read_text()
+        assert curr_run_script == ref_run_script

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -265,7 +265,7 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
     tr = test_req[0]
 
     if isinstance(tr.test.test_template.command_gen_strategy, NeMoLauncherSlurmCommandGenStrategy):
-        tr.test.test_template.command_gen_strategy.job_prefix = "test_account-cloudai.nemo_fixed"
+        tr.test.test_template.command_gen_strategy.job_prefix = "test_account-cloudai.nemo"
 
     ref = (Path(__file__).parent / "ref_data" / test_req[1]).read_text().strip()
     ref = (

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -17,7 +17,7 @@
 import argparse
 from functools import partial
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional, Tuple
 from unittest.mock import Mock, patch
 
 import pytest
@@ -111,6 +111,104 @@ def partial_tr(slurm_system: SlurmSystem) -> partial[TestRun]:
     return partial(TestRun, num_nodes=1, nodes=[], output_path=slurm_system.output_path)
 
 
+def create_test_run(
+    partial_tr: partial[TestRun],
+    slurm_system: SlurmSystem,
+    name: str,
+    test_definition,
+    command_gen_strategy,
+) -> TestRun:
+    tr = partial_tr(
+        name=name,
+        test=Test(test_definition=test_definition, test_template=TestTemplate(slurm_system, name=name)),
+    )
+    tr.test.test_template.command_gen_strategy = command_gen_strategy(
+        slurm_system, tr.test.test_definition.cmd_args_dict
+    )
+    if isinstance(tr.test.test_template.command_gen_strategy, SlurmCommandGenStrategy):
+        tr.test.test_template.command_gen_strategy.job_name = Mock(return_value="job_name")
+    return tr
+
+
+def build_special_test_run(
+    partial_tr: partial[TestRun],
+    slurm_system: SlurmSystem,
+    param: str,
+    test_mapping: Dict[str, Callable[[], TestRun]],
+) -> Tuple[TestRun, str, Optional[str]]:
+    if "gpt" in param:
+        test_type = "gpt"
+        tr = create_test_run(
+            partial_tr,
+            slurm_system,
+            test_type,
+            GPTTestDefinition(
+                name=test_type,
+                description=test_type,
+                test_template_name=test_type,
+                cmd_args=GPTCmdArgs(fdl_config="fdl/config", docker_image_url="https://docker/url"),
+                extra_env_vars={"COMBINE_THRESHOLD": "1"},
+            ),
+            JaxToolboxSlurmCommandGenStrategy,
+        )
+    elif "grok" in param:
+        test_type = "grok"
+        tr = create_test_run(
+            partial_tr,
+            slurm_system,
+            test_type,
+            GrokTestDefinition(
+                name=test_type,
+                description=test_type,
+                test_template_name=test_type,
+                cmd_args=GrokCmdArgs(fdl_config="fdl/config", docker_image_url="https://docker/url"),
+                extra_env_vars={"COMBINE_THRESHOLD": "1"},
+            ),
+            JaxToolboxSlurmCommandGenStrategy,
+        )
+    elif "nemo-run" in param:
+        test_type = "nemo-run"
+        tr = create_test_run(
+            partial_tr,
+            slurm_system,
+            test_type,
+            NeMoRunTestDefinition(
+                name=test_type,
+                description=test_type,
+                test_template_name=test_type,
+                cmd_args=NeMoRunCmdArgs(
+                    docker_image_url="nvcr.io/nvidia/nemo:24.09", task="pretrain", recipe_name="llama_3b"
+                ),
+            ),
+            NeMoRunSlurmCommandGenStrategy,
+        )
+    elif "nemo-launcher" in param:
+        test_type = "nemo-launcher"
+        tr = create_test_run(
+            partial_tr,
+            slurm_system,
+            test_type,
+            NeMoLauncherTestDefinition(
+                name="nemo-launcher",
+                description="nemo-launcher",
+                test_template_name="nemo-launcher",
+                cmd_args=NeMoLauncherCmdArgs(),
+            ),
+            NeMoLauncherSlurmCommandGenStrategy,
+        )
+        assert isinstance(tr.test.test_template.command_gen_strategy, NeMoLauncherSlurmCommandGenStrategy)
+        tr.test.test_template.command_gen_strategy.job_prefix = "test_account-cloudai.nemo"
+    else:
+        raise ValueError(f"Unknown test type: {param}")
+
+    if "pre-test" in param:
+        pre_test_tr = test_mapping["nccl"]()
+        tr.pre_test = TestScenario(name=f"{pre_test_tr.name} NCCL pre-test", test_runs=[pre_test_tr])
+    if test_type in ("nemo-run", "nemo-launcher"):
+        return tr, f"{param}.sbatch", None
+    return tr, f"{param}.sbatch", f"{test_type}.run"
+
+
 @pytest.fixture(
     params=[
         "ucc",
@@ -127,46 +225,32 @@ def partial_tr(slurm_system: SlurmSystem) -> partial[TestRun]:
         "megatron-run",
     ]
 )
-def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -> tuple[TestRun, str, Optional[str]]:
-    def create_test_run(name, test_definition, command_gen_strategy):
-        tr = partial_tr(
-            name=name,
-            test=Test(test_definition=test_definition, test_template=TestTemplate(slurm_system, name=name)),
-        )
-        tr.test.test_template.command_gen_strategy = command_gen_strategy(
-            slurm_system, tr.test.test_definition.cmd_args_dict
-        )
-        if isinstance(tr.test.test_template.command_gen_strategy, SlurmCommandGenStrategy):
-            tr.test.test_template.command_gen_strategy.job_name = Mock(return_value="job_name")
-        return tr
-
-    test_mapping = {
+def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -> Tuple[TestRun, str, Optional[str]]:
+    test_mapping: Dict[str, Callable[[], TestRun]] = {
         "ucc": lambda: create_test_run(
+            partial_tr,
+            slurm_system,
             "ucc",
             UCCTestDefinition(name="ucc", description="ucc", test_template_name="ucc", cmd_args=UCCCmdArgs()),
             UCCTestSlurmCommandGenStrategy,
         ),
         "nccl": lambda: create_test_run(
+            partial_tr,
+            slurm_system,
             "nccl",
             NCCLTestDefinition(name="nccl", description="nccl", test_template_name="nccl", cmd_args=NCCLCmdArgs()),
             NcclTestSlurmCommandGenStrategy,
         ),
         "sleep": lambda: create_test_run(
+            partial_tr,
+            slurm_system,
             "sleep",
             SleepTestDefinition(name="sleep", description="sleep", test_template_name="sleep", cmd_args=SleepCmdArgs()),
             SleepSlurmCommandGenStrategy,
         ),
-        "nemo-launcher": lambda: create_test_run(
-            "nemo-launcher",
-            NeMoLauncherTestDefinition(
-                name="nemo-launcher",
-                description="nemo-launcher",
-                test_template_name="nemo-launcher",
-                cmd_args=NeMoLauncherCmdArgs(),
-            ),
-            NeMoLauncherSlurmCommandGenStrategy,
-        ),
         "slurm_container": lambda: create_test_run(
+            partial_tr,
+            slurm_system,
             "slurm_container",
             SlurmContainerTestDefinition(
                 name="slurm_container",
@@ -177,6 +261,8 @@ def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -
             SlurmContainerCommandGenStrategy,
         ),
         "megatron-run": lambda: create_test_run(
+            partial_tr,
+            slurm_system,
             "megatron-run",
             MegatronRunTestDefinition(
                 name="megatron-run",
@@ -194,67 +280,11 @@ def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -
         ),
     }
 
-    # Special cases for gpt and grok
-    if request.param.startswith("gpt-") or request.param.startswith("grok-") or request.param.startswith("nemo-run-"):
-        if "gpt" in request.param:
-            test_type = "gpt"
-            tr = create_test_run(
-                test_type,
-                GPTTestDefinition(
-                    name=test_type,
-                    description=test_type,
-                    test_template_name=test_type,
-                    cmd_args=GPTCmdArgs(fdl_config="fdl/config", docker_image_url="https://docker/url"),
-                    extra_env_vars={"COMBINE_THRESHOLD": "1"},
-                ),
-                JaxToolboxSlurmCommandGenStrategy,
-            )
-
-        elif "grok" in request.param:
-            test_type = "grok"
-            tr = create_test_run(
-                test_type,
-                GrokTestDefinition(
-                    name=test_type,
-                    description=test_type,
-                    test_template_name=test_type,
-                    cmd_args=GrokCmdArgs(fdl_config="fdl/config", docker_image_url="https://docker/url"),
-                    extra_env_vars={"COMBINE_THRESHOLD": "1"},
-                ),
-                JaxToolboxSlurmCommandGenStrategy,
-            )
-        elif "nemo-run" in request.param:
-            test_type = "nemo-run"
-            tr = create_test_run(
-                test_type,
-                NeMoRunTestDefinition(
-                    name=test_type,
-                    description=test_type,
-                    test_template_name=test_type,
-                    cmd_args=NeMoRunCmdArgs(
-                        docker_image_url="nvcr.io/nvidia/nemo:24.09", task="pretrain", recipe_name="llama_3b"
-                    ),
-                ),
-                NeMoRunSlurmCommandGenStrategy,
-            )
-        else:
-            raise ValueError(f"Unknown test type: {request.param}")
-
-        # Handle pre-test case
-        if "pre-test" in request.param:
-            pre_test_tr = test_mapping["nccl"]()
-            tr.pre_test = TestScenario(name=f"{pre_test_tr.name} NCCL pre-test", test_runs=[pre_test_tr])
-
-        if test_type == "nemo-run":
-            return (tr, f"{request.param}.sbatch", None)
-        else:
-            return (tr, f"{request.param}.sbatch", f"{test_type}.run")
-
-    # Default handler for simple mappings
+    if request.param.startswith(("gpt-", "grok-", "nemo-run-", "nemo-launcher")):
+        return build_special_test_run(partial_tr, slurm_system, request.param, test_mapping)
     if request.param in test_mapping:
         tr = test_mapping[request.param]()
-        return (tr, f"{request.param}.sbatch", None)
-
+        return tr, f"{request.param}.sbatch", None
     raise ValueError(f"Unknown test: {request.param}")
 
 
@@ -262,9 +292,6 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
     slurm_system.output_path.mkdir(parents=True, exist_ok=True)
 
     tr = test_req[0]
-
-    if isinstance(tr.test.test_template.command_gen_strategy, NeMoLauncherSlurmCommandGenStrategy):
-        tr.test.test_template.command_gen_strategy.job_prefix = "test_account-cloudai.nemo"
 
     ref = (Path(__file__).parent / "ref_data" / test_req[1]).read_text().strip()
     ref = (

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -276,7 +276,6 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
     sbatch_script = tr.test.test_template.gen_exec_command(tr).split()[-1]
     if "nemo-launcher" in test_req[1]:
         sbatch_script = slurm_system.output_path / "generated_command.sh"
-
     curr = Path(sbatch_script).read_text().strip()
 
     assert curr == ref

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import re
 from functools import partial
 from pathlib import Path
 from typing import Dict, Optional
@@ -258,6 +259,10 @@ def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -
     raise ValueError(f"Unknown test: {request.param}")
 
 
+def normalize_script(text: str) -> str:
+    return "\n".join(line.strip() for line in text.splitlines())
+
+
 def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, str]):
     slurm_system.output_path.mkdir(parents=True, exist_ok=True)
 
@@ -275,7 +280,12 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
         sbatch_script = slurm_system.output_path / "generated_command.sh"
     curr = Path(sbatch_script).read_text().strip()
 
-    assert curr == ref
+    if "nemo-launcher" in test_req[1]:
+        curr = re.sub(r"cluster\.job_name_prefix=\d{8}_\d{6}:\s*\\?\n?", "", curr, flags=re.MULTILINE)
+        ref = re.sub(r"cluster\.job_name_prefix=\d{8}_\d{6}:\s*\\?\n?", "", ref, flags=re.MULTILINE)
+    curr_norm = normalize_script(curr)
+    ref_norm = normalize_script(ref)
+    assert curr_norm == ref_norm, f"Mismatch:\nExpected:\n{ref_norm}\n\nActual:\n{curr_norm}"
 
     run_script = test_req[-1]
     if run_script:

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-import re
 from functools import partial
 from pathlib import Path
 from typing import Dict, Optional
@@ -279,12 +278,6 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
         sbatch_script = slurm_system.output_path / "generated_command.sh"
 
     curr = Path(sbatch_script).read_text().strip()
-
-    if "nemo-launcher" in test_req[1]:
-        curr = re.sub(r"^\s*cluster\.job_name_prefix=.*$", "", curr, flags=re.MULTILINE)
-        ref = re.sub(r"^\s*cluster\.job_name_prefix=.*$", "", ref, flags=re.MULTILINE)
-        curr = "\n".join(line for line in curr.splitlines() if line.strip())
-        ref = "\n".join(line for line in ref.splitlines() if line.strip())
 
     assert curr == ref
 


### PR DESCRIPTION
## Summary
When the NeMo Launcher submits multiple jobs, they have the same job name. However, on some Slurm systems, jobs with identical names remain pending even when sufficient nodes are available. To prevent this, I added a timestamp to the job name, allowing multiple jobs to run in parallel.

## Test Plan
1. CI passes
2. Ran on IL-1 and EOS