### PR TITLE
Refactor NeMoLauncher report generation to report avg, min, max, and median

### DIFF
--- a/src/cloudai/workloads/nemo_launcher/report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/report_generation_strategy.py
@@ -14,47 +14,88 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import logging
+import re
 from pathlib import Path
+from typing import List
 
+import numpy as np
 import pandas as pd
 
 from cloudai import ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
-from cloudai.report_generator.tool.tensorboard_data_reader import TensorBoardDataReader
 
 
 class NeMoLauncherReportGenerationStrategy(ReportGenerationStrategy):
-    """
-    Strategy for generating reports from NeMo launcher directories.
-
-    Now updated to handle TensorBoard log files and visualize data using Bokeh plots.
-    """
+    """Strategy for generating reports from NeMo launcher directories."""
 
     def can_handle_directory(self) -> bool:
-        for _, __, files in os.walk(self.test_run.output_path):
-            for file in files:
-                if file.startswith("events.out.tfevents"):
-                    return True
-        return False
+        run_dir = self.test_run.output_path / "run"
+        return (
+            run_dir.exists()
+            and run_dir.is_dir()
+            and any(file.name.startswith("log") and file.name.endswith(".out") for file in run_dir.iterdir())
+        )
+
+    def extract_train_step_timings(self) -> List[float]:
+        run_dir = self.test_run.output_path / "run"
+        log_file = next((file for file in run_dir.iterdir() if re.match(r"log-.*\.out", file.name)), None)
+
+        if not log_file:
+            logging.error("No valid log file found in the run directory")
+            return []
+
+        with open(log_file, "r") as f:
+            for line in f:
+                match = re.search(r"train_step_timing in s: \[([\d.,\s]+)\]", line)
+                if match:
+                    try:
+                        step_timings = [float(val) for val in match.group(1).split(",")]
+                        return self._filter_step_timings(step_timings)
+                    except ValueError:
+                        logging.error(f"Error parsing train step timings in {log_file}")
+                        return []
+
+        logging.error(f"No train step timings found in {log_file}")
+        return []
+
+    def _filter_step_timings(self, step_timings: List[float]) -> List[float]:
+        return step_timings[-20:] if len(step_timings) > 100 else step_timings
+
+    def generate_statistics_report(self, train_step_timings: List[float]) -> None:
+        if not train_step_timings:
+            return
+
+        stats = {
+            "avg": np.mean(train_step_timings),
+            "median": np.median(train_step_timings),
+            "min": np.min(train_step_timings),
+            "max": np.max(train_step_timings),
+        }
+
+        summary_file = self.test_run.output_path / "train_step_timing_report.txt"
+        with open(summary_file, "w") as f:
+            f.writelines([f"{key.capitalize()}: {value:.4f}\n" for key, value in stats.items()])
+
+    def generate_bokeh_report(self, train_step_timings: List[float]) -> None:
+        if not train_step_timings:
+            return
+
+        df = pd.DataFrame({"Step": range(1, len(train_step_timings) + 1), "train_step_timing in s": train_step_timings})
+
+        report_tool = BokehReportTool(self.test_run.output_path)
+        report_tool.add_linear_xy_line_plot(
+            title="Train Step Timing over Steps",
+            x_column="Step",
+            y_column="train_step_timing in s",
+            x_axis_label="Step",
+            df=df,
+            sol=self.test_run.sol,
+            color="black",
+        )
+        report_tool.finalize_report(Path("cloudai_nemo_launcher_bokeh_report.html"))
 
     def generate_report(self) -> None:
-        tags = ["train_step_timing in s"]
-        data_reader = TensorBoardDataReader(self.test_run.output_path)
-        report_tool = BokehReportTool(self.test_run.output_path)
-
-        for tag in tags:
-            data = data_reader.extract_data(tag)
-            if data:
-                df = pd.DataFrame(data, columns=["Step", tag])
-                report_tool.add_linear_xy_line_plot(
-                    title=f"{tag} over Time",
-                    x_column="Step",
-                    y_column=tag,
-                    x_axis_label="Step",
-                    df=df,
-                    sol=self.test_run.sol,
-                    color="black",
-                )
-
-        report_tool.finalize_report(Path("cloudai_nemo_launcher_bokeh_report.html"))
+        train_step_timings = self.extract_train_step_timings()
+        self.generate_statistics_report(train_step_timings)
+        self.generate_bokeh_report(train_step_timings)

--- a/tests/report_generation_strategy/test_nemo_launcher_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nemo_launcher_report_generation_strategy.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from cloudai import Test, TestRun
+from cloudai.systems.slurm.slurm_system import SlurmSystem
+from cloudai.workloads.nemo_launcher import NeMoLauncherReportGenerationStrategy
+
+
+@pytest.fixture
+def nemo_tr(tmp_path: Path) -> TestRun:
+    test = Test(
+        test_definition=Mock(),
+        test_template=Mock(),
+    )
+    tr = TestRun(name="nemo_launcher", test=test, num_nodes=1, nodes=[], output_path=tmp_path)
+
+    log_content = (
+        "[NeMo I 2025-03-04 02:58:29 perf_metrics_utils:56] train_step_timing in s: "
+        "[11.85, 6.98, 5.36, 4.55, 4.12, 2.18, 2.18, 2.18, 2.18, 2.12, "
+        "2.12, 2.12, 2.12, 2.12, 2.18, 2.18, 2.26, 2.45, 2.45, 2.39, "
+        "2.46, 2.46, 2.28, 2.28, 2.28, 2.22, 2.14, 2.14, 2.14, 2.14, "
+        "2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.14, "
+        "2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.14, 2.13, 2.13]\n"
+    )
+
+    run_dir = tr.output_path / "run"
+    run_dir.mkdir()
+    (run_dir / "log-20250304_025354:run_438199.out").write_text(log_content)
+
+    return tr
+
+
+@pytest.fixture
+def nemo_tr_large(tmp_path: Path) -> TestRun:
+    test = Test(
+        test_definition=Mock(),
+        test_template=Mock(),
+    )
+    tr = TestRun(name="nemo_launcher_large", test=test, num_nodes=1, nodes=[], output_path=tmp_path)
+
+    step_timings = [float(i) for i in range(150)]
+    log_content = f"[NeMo I 2025-03-04 02:58:29 perf_metrics_utils:56] train_step_timing in s: {step_timings}\n"
+
+    run_dir = tr.output_path / "run"
+    run_dir.mkdir()
+    (run_dir / "log-20250304_025354:run_438199.out").write_text(log_content)
+
+    return tr
+
+
+def test_nemo_launcher_can_handle_directory(slurm_system: SlurmSystem, nemo_tr: TestRun) -> None:
+    strategy = NeMoLauncherReportGenerationStrategy(slurm_system, nemo_tr)
+    assert strategy.can_handle_directory()
+
+
+def test_nemo_launcher_extract_train_step_timings(slurm_system: SlurmSystem, nemo_tr: TestRun) -> None:
+    strategy = NeMoLauncherReportGenerationStrategy(slurm_system, nemo_tr)
+    timings = strategy.extract_train_step_timings()
+
+    assert timings, "No train step timings extracted."
+    assert len(timings) == 50, "Expected 50 train step timing values."
+    assert timings[:3] == [11.85, 6.98, 5.36], "First three timing values do not match expected."
+
+
+def test_nemo_launcher_extract_train_step_timings_large(slurm_system: SlurmSystem, nemo_tr_large: TestRun) -> None:
+    strategy = NeMoLauncherReportGenerationStrategy(slurm_system, nemo_tr_large)
+    timings = strategy.extract_train_step_timings()
+
+    assert timings, "No train step timings extracted."
+    assert len(timings) == 20, "Expected last 20 train step timing values."
+    assert timings == list(range(130, 150)), "Filtered timings do not match expected."
+
+
+def test_nemo_launcher_generate_statistics_report(slurm_system: SlurmSystem, nemo_tr: TestRun) -> None:
+    strategy = NeMoLauncherReportGenerationStrategy(slurm_system, nemo_tr)
+    timings = strategy.extract_train_step_timings()
+    strategy.generate_statistics_report(timings)
+
+    summary_file = nemo_tr.output_path / "train_step_timing_report.txt"
+    assert summary_file.is_file(), "Summary report was not generated."
+
+    summary_content = summary_file.read_text().strip().split("\n")
+    assert len(summary_content) == 4, "Summary file should contain four lines (avg, median, min, max)."
+
+    expected_values = {
+        "avg": np.mean(timings),
+        "median": np.median(timings),
+        "min": np.min(timings),
+        "max": np.max(timings),
+    }
+
+    for line in summary_content:
+        key, value = line.lower().split(": ")
+        assert pytest.approx(float(value), 0.01) == expected_values[key], f"{key} value mismatch."
+
+
+def test_nemo_launcher_generate_bokeh_report(slurm_system: SlurmSystem, nemo_tr: TestRun) -> None:
+    strategy = NeMoLauncherReportGenerationStrategy(slurm_system, nemo_tr)
+    timings = strategy.extract_train_step_timings()
+    strategy.generate_bokeh_report(timings)
+
+    report_file = nemo_tr.output_path / "cloudai_nemo_launcher_bokeh_report.html"
+    assert report_file.is_file(), "Bokeh report was not generated."
+
+
+def test_nemo_launcher_generate_report(slurm_system: SlurmSystem, nemo_tr: TestRun) -> None:
+    strategy = NeMoLauncherReportGenerationStrategy(slurm_system, nemo_tr)
+    strategy.generate_report()
+
+    summary_file = nemo_tr.output_path / "train_step_timing_report.txt"
+    report_file = nemo_tr.output_path / "cloudai_nemo_launcher_bokeh_report.html"
+
+    assert summary_file.is_file(), "Summary report was not generated."
+    assert report_file.is_file(), "Bokeh report was not generated."


### PR DESCRIPTION
## Summary
Refactor NeMoLauncher report generation to report avg, min, max, and median. NeMoLauncher currently does not generate the same report as NeMoRun ([link](https://github.com/NVIDIA/cloudai/blob/7bdc060dd70ebf7fb7322136c36f7315c09dac48/src/cloudai/workloads/nemo_run/report_generation_strategy.py#L25)). The goal of this PR is to align the report format with NeMoRun by incorporating these statistical measures.

## Test Plan
1. CI passes
2. Ran on IL-1