### PR TITLE
Close the loop on policy update for smarter agents

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -119,7 +119,6 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace):
         exit(1)
 
     agent = agent_class(env)
-
     for step in range(agent.max_steps):
         result = agent.select_action()
         if result is None:
@@ -127,6 +126,8 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace):
         step, action = result
         test_run.step = step
         observation, reward, done, info = env.step(action)
+        feedback = {"trial_index": step, "value": reward}
+        agent.update_policy(feedback)
         logging.info(f"Step {step}: Observation: {observation}, Reward: {reward}")
 
 


### PR DESCRIPTION
## Summary
The autoconfigurator feature used in CloudAI so far were simple such as grid search and random walker whose policy was basically stateless and didn't required any policy updates using the feedback. For smarter agents where a policy update is required, it is important to close the loop where the feedback (reward signal) is passed back to the agent. 

This PR is required for smarter agents like BO used in this [PR](https://github.com/Mellanox/cloudaix/pull/175). 

## Test Plan
-CI
- Testing on real system (Please look at the test plan for this [PR](https://github.com/Mellanox/cloudaix/pull/175))

## Additional Notes

