### PR TITLE
Reporting for encoded logs

### DIFF
--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -101,5 +101,9 @@ class Reporter:
                 if not rgs.can_handle_directory():
                     logging.warning(f"Skipping '{tr.output_path}', can't handle with " f"strategy={reporter.__name__}.")
                     continue
-
-                rgs.generate_report()
+                try:
+                    rgs.generate_report()
+                except Exception as e:
+                    logging.error(
+                        f"Error generating report for '{tr.output_path}' with strategy={reporter.__name__}: {e}"
+                    )

--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -104,6 +104,6 @@ class Reporter:
                 try:
                     rgs.generate_report()
                 except Exception as e:
-                    logging.error(
+                    logging.warning(
                         f"Error generating report for '{tr.output_path}' with strategy={reporter.__name__}: {e}"
                     )

--- a/src/cloudai/workloads/nemo_run/report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_run/report_generation_strategy.py
@@ -74,5 +74,3 @@ class NeMoRunReportGenerationStrategy(ReportGenerationStrategy):
             f.write("Median: {median}\n".format(median=stats["median"]))
             f.write("Min: {min}\n".format(min=stats["min"]))
             f.write("Max: {max}\n".format(max=stats["max"]))
-
-        logging.info(f"Report generated at {summary_file}")

--- a/src/cloudai/workloads/nemo_run/report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_run/report_generation_strategy.py
@@ -41,7 +41,7 @@ class NeMoRunReportGenerationStrategy(ReportGenerationStrategy):
         train_step_timings = []
         step_timings = []
 
-        with open(stdout_file, "r") as f:
+        with open(stdout_file, "r", encoding="utf-8", errors="ignore") as f:
             for line in f:
                 if "train_step_timing in s:" in line:
                     try:
@@ -74,3 +74,5 @@ class NeMoRunReportGenerationStrategy(ReportGenerationStrategy):
             f.write("Median: {median}\n".format(median=stats["median"]))
             f.write("Min: {min}\n".format(min=stats["min"]))
             f.write("Max: {max}\n".format(max=stats["max"]))
+
+        logging.info(f"Report generated at {summary_file}")

--- a/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
@@ -69,6 +69,31 @@ def nemo_tr(tmp_path: Path) -> TestRun:
     return tr
 
 
+@pytest.fixture
+def nemo_tr_encoded(tmp_path: Path) -> TestRun:
+    test = Test(
+        test_definition=NeMoRunTestDefinition(
+            name="nemo",
+            description="desc",
+            test_template_name="t",
+            cmd_args=NeMoRunCmdArgs(docker_image_url="docker://url", task="task", recipe_name="recipe"),
+        ),
+        test_template=Mock(),
+    )
+    tr = TestRun(name="nemo", test=test, num_nodes=1, nodes=[], output_path=tmp_path)
+
+    stdout_content = (
+        "┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n"
+        "┃[1;35m [0m[1;35mArgument Name   [0m[1;35m [0m┃[1;35m [0m[1;35mResolved Value"
+        "┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n"
+        "│[2m [0m[2mdata            [0m[2m [0m│ [1;35mMockDataModule[0m[1m([0m[33mseq_length["
+    )
+
+    (tr.output_path / "stdout.txt").write_text(stdout_content)
+
+    return tr
+
+
 def test_nemo_can_handle_directory(slurm_system: SlurmSystem, nemo_tr: TestRun) -> None:
     strategy = NeMoRunReportGenerationStrategy(slurm_system, nemo_tr)
     assert strategy.can_handle_directory()

--- a/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
@@ -87,6 +87,11 @@ def nemo_tr_encoded(tmp_path: Path) -> TestRun:
         "┃[1;35m [0m[1;35mArgument Name   [0m[1;35m [0m┃[1;35m [0m[1;35mResolved Value"
         "┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n"
         "│[2m [0m[2mdata            [0m[2m [0m│ [1;35mMockDataModule[0m[1m([0m[33mseq_length["
+        "Training epoch 0, iteration 17/99 | lr: 2.699e-06 | global_batch_size: 128 | global_step: 17 | "
+        "reduced_train_loss: 11.03 | train_step_timing in s: 12.64 | consumed_samples: 2304\n"
+        "Training epoch 0, iteration 18/99 | lr: 2.849e-06 | global_batch_size: 128 | global_step: 18 | "
+        "reduced_train_loss: 11.03 | train_step_timing in s: 12.64 | consumed_samples: 2432\n"
+        "Training epoch 0, iteration 19/99 | lr: 2.999e-06 | global_batch_size: 128 | global_step: 19 | "
     )
 
     (tr.output_path / "stdout.txt").write_text(stdout_content)
@@ -119,3 +124,26 @@ def test_nemo_generate_report(slurm_system: SlurmSystem, nemo_tr: TestRun) -> No
     for line in summary_content:
         key, value = line.split(": ")
         assert pytest.approx(float(value), 0.01) == expected_values[key], f"{key} value mismatch."
+
+
+def test_nemo_generate_report_encoded(slurm_system: SlurmSystem, nemo_tr_encoded: TestRun) -> None:
+    strategy = NeMoRunReportGenerationStrategy(slurm_system, nemo_tr_encoded)
+    strategy.generate_report()
+
+    summary_file = nemo_tr_encoded.output_path / "report.txt"
+    assert summary_file.is_file(), "Summary report was not generated."
+
+    summary_content = summary_file.read_text(encoding="utf-8", errors="ignore").strip().split("\n")
+    assert len(summary_content) == 4, "Summary file should contain four lines (avg, median, min, max)."
+
+    expected_values = {
+        "Average": 12.74,
+        "Median": 12.65,
+        "Min": 12.63,
+        "Max": 12.64,
+    }
+
+    for line in summary_content:
+        key, value = line.split(": ")
+        assert pytest.approx(float(value), 0.01) == expected_values[key], f"{key} value mismatch."
+

--- a/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
@@ -146,4 +146,3 @@ def test_nemo_generate_report_encoded(slurm_system: SlurmSystem, nemo_tr_encoded
     for line in summary_content:
         key, value = line.split(": ")
         assert pytest.approx(float(value), 0.01) == expected_values[key], f"{key} value mismatch."
-


### PR DESCRIPTION
## Summary
We saw an issue during NemoRun but this could apply to any scenario where the generated stdout has encoded symbols. In Nemo I think this is trigged from the some of the environment variables such as [this](https://github.com/NVIDIA/cloudai/blob/main/conf/common/test/dse_nemo_run_nemotron_15b_fp8.toml#L56) or [this](https://github.com/NVIDIA/cloudai/blob/main/conf/common/test/dse_nemo_run_nemotron_15b_fp8.toml#L65).

The behavior we would like to enforce for these is it should not crash and run to the next test scenario or next step in DSE'ble job.

Example of encoded logs could look like this

```
│[2m                  [0m│     [33mfp8_amax_history_len[0m=[1;36m1024[0m,                            │
│[2m                  [0m│     [33mfp8_amax_compute_algo[0m=[32m'max'[0m,                          │
│[2m                  [0m│     [33mfp8_params[0m=[3;92mTrue[0m[1m)[0m,                                     │
│[2m                  [0m│   [33mstrategy[0m=[1;35mMegatronStrategy[0m[1m([0m                              │
│[2m                  [0m│     [33mtensor_model_parallel_size[0m=[1;36m4[0m,                         │
│[2m                  [0m│     [33mpipeline_model_parallel_size[0m=[1;36m1[0m,                       │
│[2m                  [0m│     [33mvirtual_pipeline_model_parallel_size[0m=[3;35mNone[0m,            │
│[2m                  [0m│     [33mcontext_parallel_size[0m=[1;36m1[0m,                              │
│[2m                  [0m│     [33msequence_parallel[0m=[3;91mFalse[0m,                              │
│[2m                  [0m│     [33mddp[0m=[1;35mDistributedDataParallelConfig[0m[1m([0m                    │
│[2m                  [0m│       [33mgrad_reduce_in_fp32[0m=[3;92mTrue[0m,                           │
```

Two levels of protection for these
* have a try catch at per report generation level. This could provide coverage for any unknown issue with report generation
* For NemoRun atleast, we have a way to ignore errors due to `utf-8`

## Test Plan
CI/Unit test

## Additional Notes
Branches from this [PR](https://github.com/NVIDIA/cloudai/pull/408). So ideally, once the PR 408 merges, we should see only changes in relevant reporter files.
