### PR TITLE
 Migrate NCCL performance data parsing to performance report generator

### DIFF
--- a/tests/report_generation_strategy/test_nccl_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nccl_report_generation_strategy.py
@@ -105,3 +105,8 @@ def test_generate_performance_report(
     assert df.iloc[-1]["Size (B)"] == 12000000
     assert df.iloc[-1]["Algbw (GB/s) Out-of-place"] == 120.30
     assert df.iloc[-1]["Busbw (GB/s) Out-of-place"] == 130.40
+
+    # Ensure extracted values match expectations
+    assert df["gpu_type"].iloc[0] == "H100", "gpu_type was not extracted correctly."
+    assert df["num_devices_per_node"].iloc[0] == 8, "num_devices_per_node is incorrect."
+    assert df["num_ranks"].iloc[0] == 16, "num_ranks is incorrect."


### PR DESCRIPTION
## Summary
- Related PR: https://github.com/NVIDIA/cloudai/pull/407
- Related comment: https://github.com/NVIDIA/cloudai/pull/407#discussion_r1995328129

## Test Plan
1. CI passes
2. Ran on EOS
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nccl_test.toml
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nccl-test
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nccl-test

Section Name: Tests.1
  Test Name: nccl_test_all_reduce
  Description: all_reduce
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 2308225
[INFO] Job completed: Tests.1
[INFO] All test scenario results stored at: results/nccl-test_2025-03-14_09-41-18
[INFO] Generated scenario report at results/nccl-test_2025-03-14_09-41-18/nccl-test.html
[INFO] All test scenario execution attempts are complete. Please review the 'debug.log' file to confirm successful completion or to identify any issues.

$ ls
cloudai_nccl_test_bokeh_report.html  cloudai_nccl_test_prediction_csv_report.csv  mapping-stderr.txt  stderr.txt
cloudai_nccl_test_csv_report.csv     cloudai_sbatch_script.sh                     mapping-stdout.txt  stdout.txt

$ cat cloudai_nccl_test_csv_report.csv
Size (B),Count,Type,Redop,Root,Time (us) Out-of-place,Algbw (GB/s) Out-of-place,Busbw (GB/s) Out-of-place,#Wrong Out-of-place,Time (us) In-place,Algbw (GB/s) In-place,Busbw (GB/s) In-place,#Wrong In-place,Size Human-readable,gpu_type,num_devices_per_node,num_ranks
128,32,float,sum,-1,355.7,0.0,0.0,0,24.2,0.01,0.01,0,128B,H100,8,16
256,64,float,sum,-1,97.0,0.0,0.0,0,24.0,0.01,0.02,0,256B,H100,8,16
512,128,float,sum,-1,35.5,0.01,0.03,0,24.3,0.02,0.04,0,512B,H100,8,16
1024,256,float,sum,-1,25.0,0.04,0.08,0,24.8,0.04,0.08,0,1KB,H100,8,16
2048,512,float,sum,-1,26.8,0.08,0.14,0,25.7,0.08,0.15,0,2KB,H100,8,16
4096,1024,float,sum,-1,27.8,0.15,0.28,0,27.2,0.15,0.28,0,4KB,H100,8,16
8192,2048,float,sum,-1,29.7,0.28,0.52,0,28.4,0.29,0.54,0,8KB,H100,8,16
16384,4096,float,sum,-1,31.3,0.52,0.98,0,29.1,0.56,1.06,0,16KB,H100,8,16
32768,8192,float,sum,-1,31.5,1.04,1.95,0,29.8,1.1,2.06,0,32KB,H100,8,16
65536,16384,float,sum,-1,31.6,2.07,3.88,0,30.1,2.18,4.09,0,64KB,H100,8,16
131072,32768,float,sum,-1,35.6,3.68,6.91,0,34.4,3.81,7.14,0,128KB,H100,8,16
262144,65536,float,sum,-1,45.4,5.77,10.82,0,45.1,5.82,10.91,0,256KB,H100,8,16
524288,131072,float,sum,-1,108.9,4.81,9.02,0,68.9,7.61,14.28,0,512KB,H100,8,16

$ cat cloudai_nccl_test_prediction_csv_report.csv
message_size,predicted_dur,measured_dur,error_ratio
128,412.36,355.7,0.16
256,412.36,97.0,3.25
512,412.36,35.5,10.62
1024,412.36,25.0,15.49
2048,412.36,26.8,14.39
4096,412.36,27.8,13.83
8192,412.36,29.7,12.88
16384,412.36,31.3,12.17
32768,412.36,31.5,12.09
65536,412.36,31.6,12.05
131072,412.36,35.6,10.58
262144,412.36,45.4,8.08
524288,412.36,108.9,2.79
```