### PR TITLE
Support 'unknown' cmd args in NCCL cmd generation

### DIFF
--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -34,7 +34,11 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return mounts
 
     def _parse_slurm_args(
-        self, job_name_prefix: str, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self,
+        job_name_prefix: str,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, Union[str, List[str]]],
+        tr: TestRun,
     ) -> Dict[str, Any]:
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
 
@@ -44,30 +48,22 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return base_args
 
     def generate_test_command(
-        self, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self,
+        env_vars: Dict[str, str],
+        cmd_args: Dict[str, Union[str, List[str]]],
+        tr: TestRun,
     ) -> List[str]:
-        srun_command_parts = [f"{cmd_args['subtest_name']}"]
-        nccl_test_args = [
-            "nthreads",
-            "ngpus",
-            "minbytes",
-            "maxbytes",
-            "stepbytes",
-            "op",
-            "datatype",
-            "root",
-            "iters",
-            "warmup_iters",
-            "agg_iters",
-            "average",
-            "parallel_init",
-            "check",
-            "blocking",
-            "cudagraph",
-        ]
+        tdef: NCCLTestDefinition = cast(NCCLTestDefinition, tr.test.test_definition)
+        srun_command_parts = [f"{tdef.cmd_args.subtest_name}"]
+        nccl_test_args = tdef.cmd_args.model_dump().keys()
         for arg in nccl_test_args:
-            if arg in cmd_args:
-                srun_command_parts.append(f"--{arg} {cmd_args[arg]}")
+            if arg in {"docker_image_url", "subtest_name"}:
+                continue
+
+            if len(arg) > 1:
+                srun_command_parts.append(f"--{arg} {getattr(tdef.cmd_args, arg)}")
+            else:
+                srun_command_parts.append(f"-{arg} {getattr(tdef.cmd_args, arg)}")
 
         if tr.test.extra_cmd_args:
             srun_command_parts.append(tr.test.extra_cmd_args)

--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -34,11 +34,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return mounts
 
     def _parse_slurm_args(
-        self,
-        job_name_prefix: str,
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, Union[str, List[str]]],
-        tr: TestRun,
+        self, job_name_prefix: str, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> Dict[str, Any]:
         base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
 
@@ -48,10 +44,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return base_args
 
     def generate_test_command(
-        self,
-        env_vars: Dict[str, str],
-        cmd_args: Dict[str, Union[str, List[str]]],
-        tr: TestRun,
+        self, env_vars: Dict[str, str], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> List[str]:
         tdef: NCCLTestDefinition = cast(NCCLTestDefinition, tr.test.test_definition)
         srun_command_parts = [f"{tdef.cmd_args.subtest_name}"]

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -73,38 +73,22 @@ class TestNcclTestSlurmCommandGenStrategy:
         assert expected_result["container_mounts"] in cmd_gen_strategy.container_mounts(tr)
 
     @pytest.mark.parametrize(
-        "cmd_args, extra_cmd_args, expected_command",
+        "args",
         [
-            (
-                {"subtest_name": "all_reduce_perf", "nthreads": "4", "ngpus": "2"},
-                "--max-steps 100",
-                [
-                    "all_reduce_perf",
-                    "--nthreads 4",
-                    "--ngpus 2",
-                    "--max-steps 100",
-                ],
-            ),
-            (
-                {"subtest_name": "all_reduce_perf", "op": "sum", "datatype": "float"},
-                "",
-                [
-                    "all_reduce_perf",
-                    "--op sum",
-                    "--datatype float",
-                ],
-            ),
+            {"nthreads": "4", "ngpus": "2"},
+            {"R": "1", "G": "0"},
         ],
     )
     def test_generate_test_command(
-        self,
-        cmd_gen_strategy: NcclTestSlurmCommandGenStrategy,
-        cmd_args: Dict[str, Union[str, List[str]]],
-        extra_cmd_args: str,
-        expected_command: List[str],
+        self, cmd_gen_strategy: NcclTestSlurmCommandGenStrategy, args: dict[str, Union[str, list[str]]]
     ) -> None:
-        env_vars = {}
-        tr = Mock()
-        tr.test.extra_cmd_args = extra_cmd_args
-        command = cmd_gen_strategy.generate_test_command(env_vars, cmd_args, tr)
-        assert command == expected_command
+        cmd_args: NCCLCmdArgs = NCCLCmdArgs.model_validate({**{"docker_image_url": "fake_image_url"}, **args})
+        nccl = NCCLTestDefinition(name="name", description="desc", test_template_name="tt", cmd_args=cmd_args)
+        t = Test(test_definition=nccl, test_template=Mock())
+        tr = TestRun(name="t1", test=t, nodes=[], num_nodes=1)
+
+        cmd = cmd_gen_strategy.generate_test_command({}, {}, tr)
+
+        for arg in args:
+            cli_key = f"--{arg}" if len(arg) > 1 else f"-{arg}"
+            assert f"{cli_key} {args[arg]}" in cmd


### PR DESCRIPTION
## Summary
Support 'unknown' cmd args in NCCL cmd generation by getting list of args from actual CmdArgs object.

## Test Plan
1. CI

## Additional Notes
—