### PR TITLE
New Constraint Check Nemo2.0

### DIFF
--- a/src/cloudai/workloads/nemo_run/nemo_run.py
+++ b/src/cloudai/workloads/nemo_run/nemo_run.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from pathlib import Path
 from typing import List, Optional, Union, cast
 
@@ -126,8 +125,12 @@ class NeMoRunTestDefinition(TestDefinition):
         num_nodes = cast(int, self.cmd_args.trainer.num_nodes)
         num_gpus = num_nodes * 8
         num_layers = cast(int, self.cmd_args.num_layers)
+        dp = num_gpus // (tp * pp * cp)
+        mbs = cast(int, self.cmd_args.data.micro_batch_size)
+        gbs = cast(int, self.cmd_args.data.global_batch_size)
 
         constraint1 = num_gpus % (tp * pp * cp) == 0
         constraint2 = True if vp is None else (num_layers // pp) % vp == 0
+        constraint3 = gbs % (mbs * dp) == 0
 
-        return constraint1 and constraint2
+        return constraint1 and constraint2 and constraint3


### PR DESCRIPTION
## Summary
During real system runs, we encountered a new error/condition that can be incorporated into the constraint checker.

```
Unexpected error: Global batch size must be divisible by the product of micro batch size and data parallel size
Unexpected error: Global batch size must be divisible by the product of micro batch size and data parallel size
```

We already have the `dp`, `gbs` and `mbs` values in the test definition and we should be able to easily check this condition in our constraint checker. This would allow us to catch these run time errors before it gets scheduled from the slurm queue. This PR adds this condition to the constraint checker.

## Test Plan
Dry Run with invalid config
odd number of micro_batch_size.
```
  [cmd_args.data]
  micro_batch_size = [8, 5]
  global_batch_size = [64, 128, 256]

  [cmd_args.trainer]
  max_steps = 100
  val_check_interval = 500
  num_nodes = 2
  callbacks = "combined_callbacks"

    [cmd_args.trainer.strategy]
    tensor_model_parallel_size = [4]
    pipeline_model_parallel_size = [1]
    context_parallel_size = [1]
```

```
$ cloudai dry-run --system-config ../cloudaix/conf/common/system/xxxx.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/dse_nemo_run_llama3_8b.toml 
```

Results

```
[INFO] System Name: xxx
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: constraint_check
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: constraint_check

Section Name: dse_nemo_run_llama3_8b_1
  Test Name: dse_nemo_run_nemotron_15b_fp8
  Description: dse_nemo_run_nemotron_15b_fp8
  No dependencies
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner

[INFO] Constraint check: False
[INFO] Constraint check failed. Skipping step.
[INFO] Step 4: Observation: [-1.0], Reward: -1.0
[INFO] Constraint check failed. Skipping step.
[INFO] Step 5: Observation: [-1.0], Reward: -1.0
[INFO] Constraint check failed. Skipping step.
[INFO] Step 6: Observation: [-1.0], Reward: -1.0
```
## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.