### PR TITLE
Fix system serialization

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -138,7 +138,7 @@ class SlurmSystem(BaseModel, System):
         return groups
 
     @field_serializer("install_path", "output_path")
-    def _path_serializer(cls, v: Path) -> str:
+    def _path_serializer(self, v: Path) -> str:
         return str(v)
 
     def update(self) -> None:

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -324,7 +324,9 @@ def test_is_job_running_exceeds_retries(slurm_system: SlurmSystem):
 def test_model_dump(slurm_system: SlurmSystem):
     sys_dict = slurm_system.model_dump()
     assert type(sys_dict["install_path"]) is str
+    assert sys_dict["install_path"] == str(slurm_system.install_path)
     assert type(sys_dict["output_path"]) is str
+    assert sys_dict["output_path"] == str(slurm_system.output_path)
     assert "cmd_shell" not in sys_dict
     recreated = SlurmSystem.model_validate(sys_dict)
     assert recreated.model_dump() == sys_dict


### PR DESCRIPTION
## Summary
Fix system serialization. Serialization method should not be a class method: https://docs.pydantic.dev/latest/api/functional_serializers/#pydantic.functional_serializers.field_serializer.

## Test Plan
CI.

## Additional Notes
Thanks @lilyw97 for reporting it.
