### PR TITLE
[WIP] NSys/Predictor Bug Reproducer

### DIFF
--- a/src/cloudai/_core/test_parser.py
+++ b/src/cloudai/_core/test_parser.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import logging
+import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union, cast
 
@@ -87,6 +88,8 @@ class TestParser:
         return extras | set([f"{prefix}.{k}" for k in m.model_extra])
 
     def load_test_definition(self, data: dict, strict: bool = False) -> TestDefinition:
+        traceback.print_stack()
+        print(data)
         test_template_name = data.get("test_template_name", "")
         registry = Registry()
         if test_template_name not in registry.test_definitions_map:
@@ -95,6 +98,7 @@ class TestParser:
 
         try:
             test_def = registry.test_definitions_map[test_template_name].model_validate(data)
+            print("Printing test_def", test_def)
         except ValidationError as e:
             logging.error(f"Failed to parse test spec: '{self.current_file}'")
             for err in e.errors(include_url=False):


### PR DESCRIPTION
## Summary  
When `[predictor]` is present in `conf/common/test/nccl_test_all_reduce.toml`, it works.  
When `[predictor]` is present in `conf/common/test/nccl_test_all_gather.toml`, it does not work.  

Use this branch for CloudAI.  
Use [this pull request](https://github.com/Mellanox/cloudaix/pull/180) for CloudAIX.  

```
$ python cloudaix.py install --system-config conf/common/system/eos.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nccl_test.toml
```

You will notice that the predictor installation is skipped when `[predictor]` is set in `conf/common/test/nccl_test_all_gather.toml`.  

Upon reviewing the log messages, you will find that the test definition object is overwritten by the hook TOML.  

The same design flaw applies to nsys as well: https://github.com/NVIDIA/cloudai/blob/2ec57ae0bf69c04b20bbb8ea590a267ce1cfe2a5/src/cloudai/_core/test.py#L152

This bug was introduced by https://github.com/NVIDIA/cloudai/pull/407 but please note that this was implemented by following the nsys field design.