### PR TITLE
Consider only RUNNING state as running job

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -192,7 +192,7 @@ class SlurmSystem(BaseModel, System):
                 raise RuntimeError(error_message)
 
             job_state = stdout.strip()
-            if job_state in ["RUNNING", "PENDING"]:
+            if job_state == "RUNNING":
                 return True
 
             break

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -266,7 +266,7 @@ def test_is_job_completed(stdout: str, stderr: str, is_completed: bool, slurm_sy
     "stdout,stderr,is_running",
     [
         ("RUNNING", "", True),
-        ("PENDING", "", True),
+        ("PENDING", "", False),
         ("COMPLETED", "", False),
         ("FAILED", "", False),
         ("CANCELLED", "", False),


### PR DESCRIPTION
## Summary
When 'start_post_init' dependency is used in combination with group-based node list spec, main job might have longer startup time and dependency could allocate all available nodes.

## Test Plan
CI.

At this time it is very hard to create a good repro for the issue, we might need some follow up PRs to fix the problem.

## Additional Notes
—
