### PR TITLE
Allow multiple DSE cases in a scenario

### DIFF
--- a/conf/common/test_scenario/dse_nccl_all_gather.toml
+++ b/conf/common/test_scenario/dse_nccl_all_gather.toml
@@ -24,3 +24,9 @@ id = "Tests.1"
 test_name = "dse_nccl_all_gather"
 num_nodes = "2"
 time_limit = "00:20:00"
+
+[[Tests]]
+id = "Tests.2"
+test_name = "dse_nccl_all_gather"
+num_nodes = "2"
+time_limit = "00:20:00"

--- a/conf/common/test_scenario/dse_nccl_all_gather.toml
+++ b/conf/common/test_scenario/dse_nccl_all_gather.toml
@@ -24,9 +24,3 @@ id = "Tests.1"
 test_name = "dse_nccl_all_gather"
 num_nodes = "2"
 time_limit = "00:20:00"
-
-[[Tests]]
-id = "Tests.2"
-test_name = "dse_nccl_all_gather"
-num_nodes = "2"
-time_limit = "00:20:00"

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -79,7 +79,7 @@ class TestRun:
         Returns
             bool: True if more iterations are pending, False otherwise.
         """
-        return self.current_iteration < self.iterations
+        return self.current_iteration + 1 < self.iterations
 
     @property
     def metric_reporter(self) -> Optional[Type["ReportGenerationStrategy"]]:


### PR DESCRIPTION
## Summary
1. Allow multiple DSE cases in a single scenario. Do not allow mixing DSE and non-DSE cases.
2. Increment iteration only when it is needed, update `has_more_iterations()` logic.
3. Write step number (not iteration number) into trajectory file.

## Test Plan
1. CI
2. Manual on CW:
  a. Run DSE scenario with two cases (based on `dse_nccl_all_gather.toml`).
  b. Run DSE scenario with a single case (original `dse_nccl_all_gather.toml`).
  c. Run `ucc_test.toml`

## Additional Notes
—