### PR TITLE
Remove redundant system initialization in LSF and Slurm installers

### DIFF
--- a/src/cloudai/installer/lsf_installer.py
+++ b/src/cloudai/installer/lsf_installer.py
@@ -18,7 +18,6 @@ import logging
 
 from cloudai import BaseInstaller, DockerImage, File, GitRepo, Installable, InstallStatusResult, PythonExecutable
 from cloudai.installer.slurm_installer import SlurmInstaller
-from cloudai.systems import LSFSystem
 
 
 class LSFInstaller(BaseInstaller):
@@ -33,16 +32,6 @@ class LSFInstaller(BaseInstaller):
     """
 
     PREREQUISITES = ("bsub", "bjobs", "bhosts", "lsid", "lsload")
-
-    def __init__(self, system: LSFSystem):
-        """
-        Initialize the LSFInstaller with a system object.
-
-        Args:
-            system (LSFSystem): The system schema object.
-        """
-        super().__init__(system)
-        self.system = system
 
     @property
     def slurm_installer(self) -> SlurmInstaller:

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -55,7 +55,6 @@ class SlurmInstaller(BaseInstaller):
             system (SlurmSystem): The system schema object.
         """
         super().__init__(system)
-        self.system = system
         self.docker_image_cache_manager = DockerImageCacheManager(system)
 
     def _check_prerequisites(self) -> InstallStatusResult:


### PR DESCRIPTION
## Summary
Remove redundant system initialization in LSF and Slurm installers.
Please refer to https://github.com/NVIDIA/cloudai/blob/7e5056ad957f845992c0fc429ed3f35d5be0a992/src/cloudai/_core/base_installer.py#L48

## Test Plan
CI passes