### PR TITLE
Nemo Dry-Run/Run Fix

### DIFF
--- a/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nemo_run_report_generation_strategy.py
@@ -22,6 +22,7 @@ import pytest
 from cloudai import Test, TestRun
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.workloads.nemo_run import NeMoRunCmdArgs, NeMoRunReportGenerationStrategy, NeMoRunTestDefinition
+from cloudai.workloads.nemo_run.report_generation_strategy import extract_timings
 
 
 @pytest.fixture
@@ -154,3 +155,79 @@ def test_metrics(nemo_tr: TestRun, slurm_system: SlurmSystem, metric: str):
     nemo_tr.test.test_definition.agent_metric = metric
     value = nemo_tr.get_metric_value(slurm_system)
     assert value == 12.72090909090909
+
+
+def test_extract_timings_valid_file(tmp_path: Path) -> None:
+    stdout_file = tmp_path / "stdout.txt"
+    stdout_file.write_text(
+        "Training epoch 0, iteration 17/99 | train_step_timing in s: 12.64 | global_step: 17\n"
+        "Training epoch 0, iteration 18/99 | train_step_timing in s: 12.65 | global_step: 18\n"
+        "Training epoch 0, iteration 19/99 | train_step_timing in s: 12.66 | global_step: 19\n"
+    )
+
+    timings = extract_timings(stdout_file)
+    assert timings == [12.65, 12.66], "Timings extraction failed for valid file."
+
+
+def test_extract_timings_missing_file(tmp_path: Path) -> None:
+    stdout_file = tmp_path / "missing_stdout.txt"
+
+    timings = extract_timings(stdout_file)
+    assert timings == [], "Timings extraction should return an empty list for missing file."
+
+
+def test_extract_timings_invalid_content(tmp_path: Path) -> None:
+    stdout_file = tmp_path / "stdout.txt"
+    stdout_file.write_text("Invalid content without timing information\n")
+
+    timings = extract_timings(stdout_file)
+    assert timings == [], "Timings extraction should return an empty list for invalid content."
+
+
+def test_extract_timings_file_not_found(tmp_path: Path) -> None:
+    stdout_file = tmp_path / "nonexistent_stdout.txt"
+
+    timings = extract_timings(stdout_file)
+    assert timings == [], "Timings extraction should return an empty list when the file does not exist."
+
+
+def test_generate_report_no_timings(slurm_system: SlurmSystem, nemo_tr: TestRun, tmp_path: Path) -> None:
+    nemo_tr.output_path = tmp_path
+    stdout_file = nemo_tr.output_path / "stdout.txt"
+    stdout_file.write_text("No valid timing information\n")
+
+    strategy = NeMoRunReportGenerationStrategy(slurm_system, nemo_tr)
+    strategy.generate_report()
+
+    summary_file = nemo_tr.output_path / "report.txt"
+    assert not summary_file.exists(), "Report should not be generated if no valid timings are found."
+
+
+def test_generate_report_partial_timings(slurm_system: SlurmSystem, nemo_tr: TestRun, tmp_path: Path) -> None:
+    nemo_tr.output_path = tmp_path
+    stdout_file = nemo_tr.output_path / "stdout.txt"
+    stdout_file.write_text(
+        "Training epoch 0, iteration 17/99 | train_step_timing in s: 12.64 | global_step: 17\n"
+        "Invalid line without timing\n"
+        "Training epoch 0, iteration 18/99 | train_step_timing in s: 12.65 | global_step: 18\n"
+    )
+
+    strategy = NeMoRunReportGenerationStrategy(slurm_system, nemo_tr)
+    strategy.generate_report()
+
+    summary_file = nemo_tr.output_path / "report.txt"
+    assert summary_file.is_file(), "Report should be generated even with partial valid timings."
+
+    summary_content = summary_file.read_text().strip().split("\n")
+    assert len(summary_content) == 4, "Summary file should contain four lines (avg, median, min, max)."
+
+    expected_values = {
+        "Average": 12.645,
+        "Median": 12.645,
+        "Min": 12.64,
+        "Max": 12.65,
+    }
+
+    for line in summary_content:
+        key, value = line.split(": ")
+        assert pytest.approx(float(value), 0.01) == expected_values[key], f"{key} value mismatch."


### PR DESCRIPTION
## Summary
Nemo dry-run fails due to a refctor introduced in this PR https://github.com/NVIDIA/cloudai/pull/426
This PR fixes this bug.


## Test Plan
CI
Dry-Run

```
cloudai dry-run --system-config ../cloudaix/conf/common/system/xxx.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/dse_nemo_run_llama3_8b.toml 
[INFO] System Name: xxx
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nemo_run_llama3_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nemo_run_llama3_8b

Section Name: dse_nemo_run_llama3_8b_1
  Test Name: dse_nemo_run_llama3_8b
  Description: dse_nemo_run_llama3_8b
  No dependencies
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: dse_nemo_run_llama3_8b_1
[INFO] Running test: dse_nemo_run_llama3_8b_1
[INFO] Submitted slurm job: 0
[INFO] Job completed: dse_nemo_run_llama3_8b_1
[ERROR] results/nemo_run_llama3_8b_2025-04-01_19-25-32/dse_nemo_run_llama3_8b_1/0/1/stdout.txt not found
[ERROR] No valid step timings found. Returning METRIC_ERROR.
[INFO] Step 1: Observation: [-1.0], Reward: -1.0
[INFO] Running step 0 with action {'docker_image_url': 'nvcr.io/nvidia/nemo:24.12.rc3', 'task': 'pretrain', 'recipe_name': 'llama3_8b', 'num_layers': None, 'trainer.max_steps': 100, 'trainer.val_check_interval': 1000, 'trainer.num_nodes': 1, 'trainer.strategy.tensor_model_parallel_size': 1, 'trainer.strategy.pipeline_model_parallel_size': 1, 'trainer.strategy.context_parallel_size': 1, 'trainer.strategy.virtual_pipeline_model_parallel_size': None, 'trainer.plugins': None, 'trainer.callbacks': None, 'log.ckpt.save_on_train_epoch_end': False, 'log.ckpt.save_last': False, 'log.tensorboard': None, 'data.micro_batch_size': 1, 'data.global_batch_size': 256}
[INFO] Starting test: dse_nemo_run_llama3_8b_1
[INFO] Running test: dse_nemo_run_llama3_8b_1
[INFO] Submitted slurm job: 0
[INFO] Job completed: dse_nemo_run_llama3_8b_1
...
...
```

## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
