### PR TITLE
Register reports via Registry

### DIFF
--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -58,6 +58,7 @@ from .systems.slurm.slurm_system import SlurmSystem
 from .systems.standalone_system import StandaloneSystem
 from .workloads.chakra_replay import (
     ChakraReplayGradingStrategy,
+    ChakraReplayReportGenerationStrategy,
     ChakraReplaySlurmCommandGenStrategy,
     ChakraReplayTestDefinition,
 )
@@ -71,35 +72,48 @@ from .workloads.jax_toolbox import (
     GrokTestDefinition,
     JaxToolboxGradingStrategy,
     JaxToolboxJobStatusRetrievalStrategy,
+    JaxToolboxReportGenerationStrategy,
     JaxToolboxSlurmCommandGenStrategy,
     NemotronTestDefinition,
 )
-from .workloads.megatron_run import MegatronRunSlurmCommandGenStrategy, MegatronRunTestDefinition
+from .workloads.megatron_run import (
+    CheckpointTimingReportGenerationStrategy,
+    MegatronRunSlurmCommandGenStrategy,
+    MegatronRunTestDefinition,
+)
 from .workloads.nccl_test import (
     NCCLTestDefinition,
     NcclTestGradingStrategy,
     NcclTestJobStatusRetrievalStrategy,
     NcclTestKubernetesJsonGenStrategy,
+    NcclTestPerformanceReportGenerationStrategy,
     NcclTestSlurmCommandGenStrategy,
 )
 from .workloads.nemo_launcher import (
     NeMoLauncherGradingStrategy,
+    NeMoLauncherReportGenerationStrategy,
     NeMoLauncherSlurmCommandGenStrategy,
     NeMoLauncherSlurmJobIdRetrievalStrategy,
     NeMoLauncherTestDefinition,
 )
-from .workloads.nemo_run import NeMoRunSlurmCommandGenStrategy, NeMoRunTestDefinition
+from .workloads.nemo_run import NeMoRunReportGenerationStrategy, NeMoRunSlurmCommandGenStrategy, NeMoRunTestDefinition
 from .workloads.sleep import (
     SleepGradingStrategy,
     SleepKubernetesJsonGenStrategy,
+    SleepReportGenerationStrategy,
     SleepSlurmCommandGenStrategy,
     SleepStandaloneCommandGenStrategy,
     SleepTestDefinition,
 )
-from .workloads.slurm_container import SlurmContainerCommandGenStrategy, SlurmContainerTestDefinition
+from .workloads.slurm_container import (
+    SlurmContainerCommandGenStrategy,
+    SlurmContainerReportGenerationStrategy,
+    SlurmContainerTestDefinition,
+)
 from .workloads.ucc_test import (
     UCCTestDefinition,
     UCCTestGradingStrategy,
+    UCCTestReportGenerationStrategy,
     UCCTestSlurmCommandGenStrategy,
 )
 
@@ -229,6 +243,18 @@ Registry().add_test_definition("SlurmContainer", SlurmContainerTestDefinition)
 Registry().add_test_definition("MegatronRun", MegatronRunTestDefinition)
 
 Registry().add_agent("grid_search", GridSearchAgent)
+
+Registry().add_report(ChakraReplayTestDefinition, ChakraReplayReportGenerationStrategy)
+Registry().add_report(GPTTestDefinition, JaxToolboxReportGenerationStrategy)
+Registry().add_report(GrokTestDefinition, JaxToolboxReportGenerationStrategy)
+Registry().add_report(MegatronRunTestDefinition, CheckpointTimingReportGenerationStrategy)
+Registry().add_report(NCCLTestDefinition, NcclTestPerformanceReportGenerationStrategy)
+Registry().add_report(NeMoLauncherTestDefinition, NeMoLauncherReportGenerationStrategy)
+Registry().add_report(NeMoRunTestDefinition, NeMoRunReportGenerationStrategy)
+Registry().add_report(NemotronTestDefinition, JaxToolboxReportGenerationStrategy)
+Registry().add_report(SleepTestDefinition, SleepReportGenerationStrategy)
+Registry().add_report(SlurmContainerTestDefinition, SlurmContainerReportGenerationStrategy)
+Registry().add_report(UCCTestDefinition, UCCTestReportGenerationStrategy)
 
 __all__ = [
     "BaseAgent",

--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -302,31 +302,14 @@ class Registry(metaclass=Singleton):
         self.agents_map[name] = value
 
     def add_report(self, tdef_type: Type[TestDefinition], value: Type[ReportGenerationStrategy]) -> None:
-        """
-        Add a new report implementation mapping.
+        existing_reports = self.reports_map.get(tdef_type, set())
+        existing_reports.add(value)
+        self.update_report(tdef_type, existing_reports)
 
-        Args:
-            tdef_type (Type[TestDefinition]): The test definition type.
-            value (Type[ReportGenerationStrategy]): The report generation strategy implementation.
-
-        Raises:
-            ValueError: If the report generation strategy implementation already exists.
-        """
-        if not issubclass(value, ReportGenerationStrategy):
+    def update_report(self, tdef_type: Type[TestDefinition], reports: Set[Type[ReportGenerationStrategy]]) -> None:
+        if not any(issubclass(report, ReportGenerationStrategy) for report in reports):
             raise ValueError(
                 f"Invalid report generation strategy implementation for '{tdef_type}', "
                 "should be subclass of 'ReportGenerationStrategy'."
             )
-        if tdef_type not in self.reports_map:
-            self.reports_map.setdefault(tdef_type, set())
-        self.reports_map[tdef_type].add(value)
-
-    def update_report(self, tdef_type: Type[TestDefinition], reports: Set[Type[ReportGenerationStrategy]]) -> None:
-        """
-        Create or replace report implementation mapping.
-
-        Args:
-            tdef_type (Type[TestDefinition]): The test definition type.
-            reports (Set[Type[ReportGenerationStrategy]]): The report generation strategy implementations.
-        """
         self.reports_map[tdef_type] = reports

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -23,42 +23,15 @@ from typing import Any, Dict, List, Literal, Optional, Set, Type
 import toml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-from ..workloads.chakra_replay import ChakraReplayReportGenerationStrategy, ChakraReplayTestDefinition
-from ..workloads.jax_toolbox import (
-    GPTTestDefinition,
-    GrokTestDefinition,
-    JaxToolboxReportGenerationStrategy,
-    NemotronTestDefinition,
-)
-from ..workloads.megatron_run import CheckpointTimingReportGenerationStrategy, MegatronRunTestDefinition
 from ..workloads.nccl_test import (
     NCCLTestDefinition,
-    NcclTestPerformanceReportGenerationStrategy,
     NcclTestPredictionReportGenerationStrategy,
 )
-from ..workloads.nemo_launcher import NeMoLauncherReportGenerationStrategy, NeMoLauncherTestDefinition
-from ..workloads.nemo_run import NeMoRunReportGenerationStrategy, NeMoRunTestDefinition
-from ..workloads.sleep import SleepReportGenerationStrategy, SleepTestDefinition
-from ..workloads.slurm_container import SlurmContainerReportGenerationStrategy, SlurmContainerTestDefinition
-from ..workloads.ucc_test import UCCTestDefinition, UCCTestReportGenerationStrategy
 from .exceptions import TestScenarioParsingError, format_validation_error
+from .registry import Registry
 from .report_generation_strategy import ReportGenerationStrategy
 from .test import Test, TestDefinition
 from .test_scenario import TestDependency, TestRun, TestScenario
-
-DEFAULT_REPORTERS: dict[Type[TestDefinition], Set[Type[ReportGenerationStrategy]]] = {
-    ChakraReplayTestDefinition: {ChakraReplayReportGenerationStrategy},
-    GPTTestDefinition: {JaxToolboxReportGenerationStrategy},
-    GrokTestDefinition: {JaxToolboxReportGenerationStrategy},
-    MegatronRunTestDefinition: {CheckpointTimingReportGenerationStrategy},
-    NCCLTestDefinition: {NcclTestPerformanceReportGenerationStrategy},
-    NeMoLauncherTestDefinition: {NeMoLauncherReportGenerationStrategy},
-    NeMoRunTestDefinition: {NeMoRunReportGenerationStrategy},
-    NemotronTestDefinition: {JaxToolboxReportGenerationStrategy},
-    SleepTestDefinition: {SleepReportGenerationStrategy},
-    SlurmContainerTestDefinition: {SlurmContainerReportGenerationStrategy},
-    UCCTestDefinition: {UCCTestReportGenerationStrategy},
-}
 
 
 def parse_time_limit(limit: str) -> timedelta:
@@ -130,7 +103,7 @@ def calculate_total_time_limit(test_hooks: List[TestScenario], time_limit: Optio
 
 
 def get_reporters(test_info: "_TestRunTOML", tdef: TestDefinition) -> Set[Type[ReportGenerationStrategy]]:
-    reporters = DEFAULT_REPORTERS.get(type(tdef), set())
+    reporters = Registry().reports_map.get(type(tdef), set())
 
     if isinstance(tdef, NCCLTestDefinition) and tdef.predictor is not None:
         reporters.add(NcclTestPredictionReportGenerationStrategy)

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 import re
 from datetime import timedelta
@@ -103,7 +104,7 @@ def calculate_total_time_limit(test_hooks: List[TestScenario], time_limit: Optio
 
 
 def get_reporters(test_info: "_TestRunTOML", tdef: TestDefinition) -> Set[Type[ReportGenerationStrategy]]:
-    reporters = Registry().reports_map.get(type(tdef), set())
+    reporters = copy.deepcopy(Registry().reports_map.get(type(tdef), set()))
 
     if isinstance(tdef, NCCLTestDefinition) and tdef.predictor is not None:
         reporters.add(NcclTestPredictionReportGenerationStrategy)

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -21,11 +21,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from cloudai import CmdArgs, Test, TestRun, TestScenario, TestScenarioParser, TestScenarioParsingError
+from cloudai import CmdArgs, Registry, Test, TestRun, TestScenario, TestScenarioParser, TestScenarioParsingError
 from cloudai._core.report_generation_strategy import ReportGenerationStrategy
 from cloudai._core.test import TestDefinition
 from cloudai._core.test_scenario_parser import (
-    DEFAULT_REPORTERS,
     _TestRunTOML,
     _TestScenarioTOML,
     calculate_total_time_limit,
@@ -282,7 +281,8 @@ class TestReporters:
         assert len(reporters) == 0
 
     def test_default_reporters_size(self):
-        assert len(DEFAULT_REPORTERS) == 11
+        print(Registry().reports_map)
+        assert len(Registry().reports_map) == 11
 
     @pytest.mark.parametrize(
         "tdef,expected_reporters",
@@ -301,7 +301,7 @@ class TestReporters:
         ],
     )
     def test_custom_reporters(self, tdef: Type[TestDefinition], expected_reporters: Set[ReportGenerationStrategy]):
-        assert DEFAULT_REPORTERS[tdef] == expected_reporters
+        assert Registry().reports_map[tdef] == expected_reporters
 
 
 class TestReportMetricsDSE:

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -22,8 +22,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from cloudai import CmdArgs, Registry, Test, TestRun, TestScenario, TestScenarioParser, TestScenarioParsingError
+from cloudai._core.installables import GitRepo
 from cloudai._core.report_generation_strategy import ReportGenerationStrategy
-from cloudai._core.test import TestDefinition
+from cloudai._core.test import PredictorConfig, TestDefinition
 from cloudai._core.test_scenario_parser import (
     _TestRunTOML,
     _TestScenarioTOML,
@@ -43,6 +44,7 @@ from cloudai.workloads.nccl_test import (
     NcclTestPerformanceReportGenerationStrategy,
 )
 from cloudai.workloads.nccl_test.nccl import NCCLCmdArgs
+from cloudai.workloads.nccl_test.prediction_report_generation_strategy import NcclTestPredictionReportGenerationStrategy
 from cloudai.workloads.nemo_launcher import NeMoLauncherReportGenerationStrategy, NeMoLauncherTestDefinition
 from cloudai.workloads.nemo_run import NeMoRunReportGenerationStrategy, NeMoRunTestDefinition
 from cloudai.workloads.sleep import SleepReportGenerationStrategy, SleepTestDefinition
@@ -302,6 +304,19 @@ class TestReporters:
     )
     def test_custom_reporters(self, tdef: Type[TestDefinition], expected_reporters: Set[ReportGenerationStrategy]):
         assert Registry().reports_map[tdef] == expected_reporters
+
+    def test_get_reporters_nccl(self):
+        tr_model = _TestRunTOML(id="id", test_name="nccl", time_limit="01:00:00", weight=10, iterations=1, num_nodes=1)
+        tdef = NCCLTestDefinition(name="nccl", description="desc", test_template_name="tt", cmd_args=NCCLCmdArgs())
+        reporters = get_reporters(tr_model, tdef)
+        assert len(reporters) == 1
+        assert NcclTestPerformanceReportGenerationStrategy in reporters
+
+        tdef.predictor = PredictorConfig(git_repo=GitRepo(url="", commit=""))
+        reporters = get_reporters(tr_model, tdef)
+        assert len(reporters) == 2
+        assert NcclTestPerformanceReportGenerationStrategy in reporters
+        assert NcclTestPredictionReportGenerationStrategy in reporters
 
 
 class TestReportMetricsDSE:


### PR DESCRIPTION
## Summary
To unify internals and provide extensibility move to use `Registry` for registering reports.

## Test Plan
CI

## Additional Notes
—