### PR TITLE
Return None when main test has no time limit in calculate_total_time_limit

### DIFF
--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -85,13 +85,10 @@ def format_time_limit(total_time: timedelta) -> str:
 
 
 def calculate_total_time_limit(test_hooks: List[TestScenario], time_limit: Optional[str] = None) -> Optional[str]:
-    total_time = timedelta()
-
-    if time_limit:
-        total_time += parse_time_limit(time_limit)
-    else:
+    if not time_limit:
         return None
 
+    total_time = parse_time_limit(time_limit)
     total_time += sum(
         (
             parse_time_limit(test_run.time_limit)

--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -84,11 +84,13 @@ def format_time_limit(total_time: timedelta) -> str:
     return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
-def calculate_total_time_limit(test_hooks: List[TestScenario], time_limit: Optional[str] = None) -> str:
+def calculate_total_time_limit(test_hooks: List[TestScenario], time_limit: Optional[str] = None) -> Optional[str]:
     total_time = timedelta()
 
     if time_limit:
         total_time += parse_time_limit(time_limit)
+    else:
+        return None
 
     total_time += sum(
         (

--- a/tests/test_test_scenario_parser.py
+++ b/tests/test_test_scenario_parser.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import create_autospec
+
+import pytest
+
+from cloudai._core.test import Test
+from cloudai._core.test_scenario import TestRun, TestScenario
+from cloudai._core.test_scenario_parser import calculate_total_time_limit
+from tests.conftest import MyTestDefinition
+
+
+class DummyTestRun(TestRun):
+    def __init__(self, time_limit: str) -> None:
+        dummy_test = create_autospec(Test, instance=True)
+        dummy_test.name = "dummy_test"
+        dummy_test.test_definition = MyTestDefinition
+        super().__init__(
+            name="dummy_run",
+            test=dummy_test,
+            num_nodes=1,
+            nodes=[],
+            output_path=Path(""),
+            iterations=1,
+            current_iteration=0,
+            step=0,
+            time_limit=time_limit,
+            sol=None,
+            weight=0.0,
+            ideal_perf=1.0,
+            dependencies={},
+            pre_test=None,
+            post_test=None,
+            reports=set(),
+        )
+
+
+class DummyHook(TestScenario):
+    def __init__(self, test_runs: List[TestRun]) -> None:
+        super().__init__(name="dummy", test_runs=test_runs)
+
+
+@pytest.fixture
+def dummy_hook() -> DummyHook:
+    return DummyHook([DummyTestRun("30m"), DummyTestRun("45m")])
+
+
+@pytest.mark.parametrize(
+    "test_hooks, time_limit, expected",
+    [
+        ([], None, None),
+        ([], "1h", "01:00:00"),
+        ([DummyHook([DummyTestRun("30m")])], "1h", "01:30:00"),
+        ([DummyHook([DummyTestRun("15m")]), DummyHook([DummyTestRun("45m")])], "1h", "02:00:00"),
+        ([DummyHook([DummyTestRun("1h")])], "1-00:00:00", "1-01:00:00"),
+    ],
+)
+def test_calculate_total_time_limit(
+    test_hooks: List[TestScenario], time_limit: Optional[str], expected: Optional[str]
+) -> None:
+    assert calculate_total_time_limit(test_hooks, time_limit) == expected

--- a/tests/test_test_scenario_parser.py
+++ b/tests/test_test_scenario_parser.py
@@ -30,7 +30,9 @@ class DummyTestRun(TestRun):
     def __init__(self, time_limit: str) -> None:
         dummy_test = create_autospec(Test, instance=True)
         dummy_test.name = "dummy_test"
-        dummy_test.test_definition = MyTestDefinition
+        dummy_test.test_definition = MyTestDefinition(
+            name="dummy_test", description="dummy_test", test_template_name="dummy_test", cmd_args={}
+        )
         super().__init__(
             name="dummy_run",
             test=dummy_test,
@@ -60,6 +62,7 @@ class DummyHook(TestScenario):
     "test_hooks, time_limit, expected",
     [
         ([], None, None),
+        ([DummyHook([DummyTestRun("30m")])], None, None),
         ([], "1h", "01:00:00"),
         ([DummyHook([DummyTestRun("30m")])], "1h", "01:30:00"),
         ([DummyHook([DummyTestRun("15m")]), DummyHook([DummyTestRun("45m")])], "1h", "02:00:00"),

--- a/tests/test_test_scenario_parser.py
+++ b/tests/test_test_scenario_parser.py
@@ -56,11 +56,6 @@ class DummyHook(TestScenario):
         super().__init__(name="dummy", test_runs=test_runs)
 
 
-@pytest.fixture
-def dummy_hook() -> DummyHook:
-    return DummyHook([DummyTestRun("30m"), DummyTestRun("45m")])
-
-
 @pytest.mark.parametrize(
     "test_hooks, time_limit, expected",
     [


### PR DESCRIPTION
## Summary
Return None when main test has no time limit in calculate_total_time_limit

Bug fix for https://redmine.mellanox.com/issues/4387329

Test Scenario
```name = "nccl-test"

pre_test = "nccl_test"

[[Tests]]
id = "Tests.1"
test_name = "nccl_test_all_reduce"
num_nodes = "2"
```

Final Sbatch Script
```
#!/bin/bash
#SBATCH --job-name=TestTemplate_20250403_155315
#SBATCH -N 2
#SBATCH --output=results/nccl-test_2025-04-03_15-53-15/Tests.1/0/stdout.txt
#SBATCH --error=results/nccl-test_2025-04-03_15-53-15/Tests.1/0/stderr.txt
#SBATCH --partition=partition_1
#SBATCH --gpus-per-node=8
#SBATCH --gres=gpu:8
#SBATCH --ntasks-per-node=8
#SBATCH --time=00:20:00

export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export MELLANOX_VISIBLE_DEVICES=0,3,4,5,6,9,10,11
export NCCL_IB_GID_INDEX=3
export NCCL_IB_QPS_PER_CONNECTION=4
export NCCL_IB_TIMEOUT=20
srun --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install --output=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0/mapping-stdout.txt --error=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."

srun --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install --ntasks=2 --ntasks-per-node=1 --output=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0/metadata/node-%N.toml --error=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh

srun --output=results/nccl-test_2025-04-03_15-53-15/Tests.1/0/pre_test/nccl_test_all_gather/stdout.txt --error=results/nccl-test_2025-04-03_15-53-15/Tests.1/0/pre_test/nccl_test_all_gather/stderr.txt --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0/pre_test/nccl_test_all_gather:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install all_gather_perf_mpi --nthreads 1 --ngpus 1 --minbytes 128 --maxbytes 4G --stepbytes 1M --op sum --datatype float --root 0 --iters 100 --warmup_iters 50 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0 --stepfactor 2
SUCCESS_0=$(grep -q "Avg bus bandwidth" results/nccl-test_2025-04-03_15-53-15/Tests.1/0/pre_test/nccl_test_all_gather/stdout.txt && echo 1 || echo 0)
PRE_TEST_SUCCESS=$( [ $SUCCESS_0 -eq 1 ] && echo 1 || echo 0 )
if [ $PRE_TEST_SUCCESS -eq 1 ]; then
    srun --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-53-15/Tests.1/0:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 128 --maxbytes 16G --stepbytes 1M --op sum --datatype float --root 0 --iters 100 --warmup_iters 50 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0 --stepfactor 2
fi
```

## Test Plan
```
$ cloudai dry-run\
    --system-config conf/common/system/example_slurm_cluster.toml \
    --tests-dir conf/common/test\
    --test-scenario conf/common/test_scenario/nccl_test.toml
```

Final Sbatch Script
```
#!/bin/bash
#SBATCH --job-name=TestTemplate_20250403_155235
#SBATCH -N 2
#SBATCH --output=results/nccl-test_2025-04-03_15-52-35/Tests.1/0/stdout.txt
#SBATCH --error=results/nccl-test_2025-04-03_15-52-35/Tests.1/0/stderr.txt
#SBATCH --partition=partition_1
#SBATCH --gpus-per-node=8
#SBATCH --gres=gpu:8
#SBATCH --ntasks-per-node=8

export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export MELLANOX_VISIBLE_DEVICES=0,3,4,5,6,9,10,11
export NCCL_IB_GID_INDEX=3
export NCCL_IB_QPS_PER_CONNECTION=4
export NCCL_IB_TIMEOUT=20
srun --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install --output=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0/mapping-stdout.txt --error=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."

srun --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install --ntasks=2 --ntasks-per-node=1 --output=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0/metadata/node-%N.toml --error=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh

srun --output=results/nccl-test_2025-04-03_15-52-35/Tests.1/0/pre_test/nccl_test_all_gather/stdout.txt --error=results/nccl-test_2025-04-03_15-52-35/Tests.1/0/pre_test/nccl_test_all_gather/stderr.txt --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0/pre_test/nccl_test_all_gather:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install all_gather_perf_mpi --nthreads 1 --ngpus 1 --minbytes 128 --maxbytes 4G --stepbytes 1M --op sum --datatype float --root 0 --iters 100 --warmup_iters 50 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0 --stepfactor 2
SUCCESS_0=$(grep -q "Avg bus bandwidth" results/nccl-test_2025-04-03_15-52-35/Tests.1/0/pre_test/nccl_test_all_gather/stdout.txt && echo 1 || echo 0)
PRE_TEST_SUCCESS=$( [ $SUCCESS_0 -eq 1 ] && echo 1 || echo 0 )
if [ $PRE_TEST_SUCCESS -eq 1 ]; then
    srun --export=ALL --mpi=pmix --container-image=nvcr.io/nvidia/pytorch:24.02-py3 --container-mounts=/Users/theo/cloudai/results/nccl-test_2025-04-03_15-52-35/Tests.1/0:/cloudai_run_results,/Users/theo/cloudai/install_dir:/cloudai_install all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 128 --maxbytes 16G --stepbytes 1M --op sum --datatype float --root 0 --iters 100 --warmup_iters 50 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0 --stepfactor 2
fi
```