### PR TITLE
Bug fix in src/cloudai/cli/handlers.py

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -134,7 +134,7 @@ def handle_non_dse_job(runner: Runner, args: argparse.Namespace) -> None:
     if args.mode == "run":
         generate_reports(runner.runner.system, runner.runner.test_scenario, runner.runner.scenario_root)
 
-    logging.info(f"All jobs are complete. For more details, please review the '{args.log_file}'.")
+    logging.info("All jobs are complete.")
 
 
 def register_signal_handlers(signal_handler: Callable) -> None:


### PR DESCRIPTION
## Summary
Bug fix in src/cloudai/cli/handlers.py

https://github.com/Mellanox/cloudaix/actions/runs/14270984623/job/40003899181?pr=199
```
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/home/runner/work/cloudaix/cloudaix/utils/dgx.py", line 414, in <module>
    main()
  File "/home/runner/work/cloudaix/cloudaix/utils/dgx.py", line 409, in main
    rc = cli.run()
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/cloudai/cli/cli.py", line 162, in run
    return self.handlers[args.mode](args)
  File "/home/runner/work/cloudaix/cloudaix/utils/dgx.py", line 353, in handle_dgx_run
    handle_dry_run_and_run(args_namespace)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/cloudai/cli/handlers.py", line 208, in handle_dry_run_and_run
    handle_non_dse_job(runner, args)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/cloudai/cli/handlers.py", line 137, in handle_non_dse_job
    logging.info(f"All jobs are complete. For more details, please review the '{args.log_file}'.")
AttributeError: 'Namespace' object has no attribute 'log_file'
```

## Test Plan
Tested with CI by switching requirements.txt