### PR TITLE
Support NCCL_TOPO_FILE in all SlurmCommandGenStrategy classes

### DIFF
--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -25,15 +25,8 @@ from cloudai.workloads.nccl_test import NCCLTestDefinition
 class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NCCL tests on Slurm systems."""
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
-        mounts: list[str] = []
-        env = tr.test.extra_env_vars | self.system.global_env_vars
-        if "NCCL_TOPO_FILE" in env:
-            nccl_topo_file = env["NCCL_TOPO_FILE"]
-            if isinstance(nccl_topo_file, str):
-                nccl_topo_file_path = Path(nccl_topo_file).resolve()
-                mounts.append(f"{nccl_topo_file_path}:{nccl_topo_file_path}")
-        return mounts
+    def _container_mounts(self, tr: TestRun) -> List[str]:
+        return []
 
     def _parse_slurm_args(
         self,

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -320,3 +320,10 @@ def test_ranks_mapping_cmd(strategy_fixture: SlurmCommandGenStrategy, testrun_fi
 
     result = strategy_fixture._ranks_mapping_cmd(slurm_args, testrun_fixture)
     assert result == expected_command
+
+
+def test_nccl_topo_mount(strategy_fixture: SlurmCommandGenStrategy, testrun_fixture: TestRun):
+    testrun_fixture.test.extra_env_vars["NCCL_TOPO_FILE"] = "/tmp/nccl_topo.txt"
+    mounts = strategy_fixture.container_mounts(testrun_fixture)
+    expected_mount = f"{Path('/tmp/nccl_topo.txt').resolve()}:{Path('/tmp/nccl_topo.txt').resolve()}"
+    assert expected_mount in mounts


### PR DESCRIPTION
## Summary
Support NCCL_TOPO_FILE in all SlurmCommandGenStrategy classes. Currently, NCCL_TOPO_FILE is only supported in NCCL tests. However, this should not be the case, and it should be supported by any Slurm command generation strategy. This PR moves the logic to the parent class, allowing other SlurmCommandGenStrategy implementations to mount NCCL_TOPO_FILE by default. This is one of the LLMB requirements.

## Test Plan
CI passes
* Passes `tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py`. It indicates that this change does not break NCCL_TOPO_FILE but only expands its support for general slurm command gen strategy.