### PR TITLE
Fix: Include CANCELLED+ state in completed job status check

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -247,7 +247,7 @@ class SlurmSystem(BaseModel, System):
             if "RUNNING" in job_states:
                 return False
 
-            if any(state in ["COMPLETED", "FAILED", "CANCELLED", "TIMEOUT"] for state in job_states):
+            if any(state in ["COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "CANCELLED+"] for state in job_states):
                 return True
 
             break


### PR DESCRIPTION
## Summary
Fix: Include CANCELLED+ state in completed job status check
Identified this bug while working on https://github.com/NVIDIA/cloudai/pull/459 on EOS
```
$ sacct -j 2453846 --format=State --noheader
CANCELLED+ 
```

## Test Plan
1. CI passes
2. Tested on EOS with https://github.com/NVIDIA/cloudai/pull/459 