### PR TITLE
[WIP][LLMB] NCCL trace collection example

### DIFF
--- a/conf/common/system/eos.toml
+++ b/conf/common/system/eos.toml
@@ -1,0 +1,20 @@
+name = "EOS"
+scheduler = "slurm"
+
+install_path = "./install"
+output_path = "./results"
+default_partition = "batch"
+
+account = "coreai_dlalgo_ci"
+distribution = "block"
+
+ntasks_per_node = 8
+
+[[partitions]]
+name = "backfill"
+
+[[partitions]]
+name = "batch"
+
+[[partitions]]
+name = "hp"

--- a/conf/common/test/nemo_run_llama3_8b.toml
+++ b/conf/common/test/nemo_run_llama3_8b.toml
@@ -28,7 +28,7 @@ recipe_name = "llama3_8b"
   global_batch_size = 128
 
   [cmd_args.trainer]
-  max_steps = 100
+  max_steps = 35
   val_check_interval = 1000
   num_nodes = 1
 
@@ -40,3 +40,9 @@ recipe_name = "llama3_8b"
   [cmd_args.log.ckpt]
   save_on_train_epoch_end = false
   save_last = false
+
+[extra_env_vars]
+NCCL_DEBUG = "INFO"
+NCCL_DEBUG_SUBSYS = "COLL,P2P,NET"
+NCCL_DEBUG_FILE = "/cloudai_run_results/nccl_trace.txt"
+NCCL_TOPO_DUMP_FILE = "/cloudai_run_results/nccl_topo.xml"

--- a/conf/common/test_scenario/nemo_run_llama3_8b.toml
+++ b/conf/common/test_scenario/nemo_run_llama3_8b.toml
@@ -21,12 +21,3 @@ id = "nemo_run_llama3_8b_1"
 test_name = "nemo_run_llama3_8b"
 num_nodes = "1"
 time_limit = "00:30:00"
-
-[[Tests]]
-id = "nemo_run_llama3_8b_2"
-test_name = "nemo_run_llama3_8b"
-num_nodes = "2"
-time_limit = "00:30:00"
-  [[Tests.dependencies]]
-  type = "start_post_comp"
-  id = "nemo_run_llama3_8b_1"


### PR DESCRIPTION
## Summary
NCCL trace collection example

Requirements: https://nvidia.slack.com/archives/C08J8DTU212/p1744116890459999

## Test Plan
1. CI passes
2. Ran on EOS
```
$ cloudai run --system-config conf/common/system/eos.toml --tests-dir conf/common/test --test-scenario ./conf/common/test_scenario/nemo_run_llama3_8b.toml
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nemo_run_llama3_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nemo_run_llama3_8b

Section Name: nemo_run_llama3_8b_1
  Test Name: nemo_run_llama3_8b
  Description: dse_nemo_run_llama3_8b
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: nemo_run_llama3_8b_1
[INFO] Running test: nemo_run_llama3_8b_1
[INFO] Submitted slurm job: 2461270
[INFO] Job completed: nemo_run_llama3_8b_1 (iteration 1 of 1)
[INFO] All test scenario results stored at: results/nemo_run_llama3_8b_2025-04-08_10-31-19
[INFO] Generated scenario report at results/nemo_run_llama3_8b_2025-04-08_10-31-19/nemo_run_llama3_8b.html
[INFO] All jobs are complete.
```

```
$ pwd
/lustre/fsw/general_infra-rd_gsw/theo/cloudai/results/nemo_run_llama3_8b_2025-04-08_10-31-19/nemo_run_llama3_8b_1/0

$ ls
cloudai_sbatch_script.sh  mapping-stderr.txt  mapping-stdout.txt  metadata  nccl_topo.xml  nccl_trace.txt  nemorun-workspace  report.txt  stderr.txt  stdout.txt

$ head nccl_trace.txt 
eos0181:4185005:4185005 [3] NCCL INFO NCCL version 2.22.3+cuda12.6
eos0181:4185009:4189351 [7] NCCL INFO Plugin Path : /opt/hpcx/nccl_rdma_sharp_plugin/lib/libnccl-net.so
eos0181:4185009:4189351 [7] NCCL INFO P2P plugin v8 IBext_v8
eos0181:4185009:4189351 [7] NCCL INFO NET/IB : Using [0]mlx5_0:1/IB/SHARP [1]mlx5_3:1/IB/SHARP [2]mlx5_4:1/IB/SHARP [3]mlx5_5:1/IB/SHARP [4]mlx5_6:1/IB/SHARP [5]mlx5_9:1/IB/SHARP [6]mlx5_10:1/IB/SHARP [7]mlx5_11:1/IB/SHARP ; OOB ibp24s0:172.16.64.191<0>
eos0181:4185009:4189351 [7] NCCL INFO NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA 0 'mlx5_0
eos0181:4185009:4189351 [7] NCCL INFO NET/IB : GPU Direct RDMA (DMABUF) enabled for HCA 0 'mlx5_0
eos0181:4185002:4189345 [0] NCCL INFO NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA 0 'mlx5_0
eos0181:4185002:4189345 [0] NCCL INFO NET/IB : GPU Direct RDMA (DMABUF) enabled for HCA 0 'mlx5_0
eos0181:4185002:4189345 [0] NCCL INFO NET/IBext_v8 : GPU Direct RDMA Enabled for HCA 0 'mlx5_0'
eos0181:4185002:4189345 [0] NCCL INFO NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA 1 'mlx5_3
```