### PR TITLE
Fix is_running for slurm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,3 @@ jobs:
           # this checks that all TOMLs are valid, Test Scenarios are checked _only_ the tests in the specified directory
           cloudai verify-configs --tests-dir conf/common/test conf/common
           cloudai verify-configs --strict --tests-dir conf/release/spcx/l40s/test conf/release/spcx/l40s
-
-          cloudai dry-run --system-config conf/common/system/example_slurm_cluster.toml \
-            --tests-dir conf/common/test/ \
-            --test-scenario conf/common/test_scenario/ucc_test.toml \
-            --output-dir ./results

--- a/conf/common/test_scenario/sleep.toml
+++ b/conf/common/test_scenario/sleep.toml
@@ -14,14 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name = "test_scenario_example"
+name = "sleep-scenario"
 
 [[Tests]]
 id = "Tests.1"
+time_limit = "00:01:00"
 test_name = "sleep_10"
 
 [[Tests]]
 id = "Tests.2"
+time_limit = "00:01:00"
 test_name = "sleep_5"
   [[Tests.dependencies]]
   type = "start_post_init"
@@ -29,6 +31,7 @@ test_name = "sleep_5"
 
 [[Tests]]
 id = "Tests.3"
+time_limit = "00:01:00"
 test_name = "sleep_5"
   [[Tests.dependencies]]
   type = "start_post_comp"
@@ -36,6 +39,7 @@ test_name = "sleep_5"
 
 [[Tests]]
 id = "Tests.4"
+time_limit = "00:01:00"
 test_name = "sleep_20"
   [[Tests.dependencies]]
   type = "end_post_comp"

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -85,14 +85,18 @@ class BaseRunner(ABC):
         total_tests = len(self.test_scenario.test_runs)
         completed_jobs_count = 0
 
-        dependency_free_tests = self.find_dependency_free_tests()
-        for tr in dependency_free_tests:
+        dependency_free_trs = self.find_dependency_free_tests()
+        for tr in dependency_free_trs:
             await self.submit_test(tr)
 
-        logging.debug(f"Total tests: {total_tests}, dependency free tests: {len(dependency_free_tests)}")
+        logging.debug(f"Total tests: {total_tests}, dependency free tests: {[tr.name for tr in dependency_free_trs]}")
         while completed_jobs_count < total_tests:
             await self.check_start_post_init_dependencies()
             completed_jobs_count += await self.monitor_jobs()
+            logging.debug(
+                f"Completed jobs: {completed_jobs_count}, total tests: {total_tests}, "
+                f"sleeping for {self.monitor_interval} seconds"
+            )
             await asyncio.sleep(self.monitor_interval)
 
     async def submit_test(self, tr: TestRun):
@@ -147,8 +151,8 @@ class BaseRunner(ABC):
 
         for tr, job in items:
             is_running, is_completed = self.system.is_job_running(job), self.system.is_job_completed(job)
+            logging.debug(f"start_post_init for test {tr.name} ({is_running=}, {is_completed=}, {self.mode=})")
             if self.mode == "dry-run" or is_running or is_completed:
-                logging.debug(f"start_post_init for test {tr.name} ({is_running=}, {is_completed=}, {self.mode=})")
                 await self.check_and_schedule_start_post_init_dependent_tests(tr)
 
     async def check_and_schedule_start_post_init_dependent_tests(self, started_test_run: TestRun):

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -89,6 +89,7 @@ class BaseRunner(ABC):
         for tr in dependency_free_tests:
             await self.submit_test(tr)
 
+        logging.debug(f"Total tests: {total_tests}, dependency free tests: {len(dependency_free_tests)}")
         while completed_jobs_count < total_tests:
             await self.check_start_post_init_dependencies()
             completed_jobs_count += await self.monitor_jobs()
@@ -145,7 +146,9 @@ class BaseRunner(ABC):
         items = list(self.testrun_to_job_map.items())
 
         for tr, job in items:
-            if self.mode == "dry-run" or self.system.is_job_running(job) or self.system.is_job_completed(job):
+            is_running, is_completed = self.system.is_job_running(job), self.system.is_job_completed(job)
+            if self.mode == "dry-run" or is_running or is_completed:
+                logging.debug(f"start_post_init for test {tr.name} ({is_running=}, {is_completed=}, {self.mode=})")
                 await self.check_and_schedule_start_post_init_dependent_tests(tr)
 
     async def check_and_schedule_start_post_init_dependent_tests(self, started_test_run: TestRun):
@@ -220,8 +223,11 @@ class BaseRunner(ABC):
         """
         successful_jobs_count = 0
 
+        logging.debug(f"Monitoring {len(self.jobs)} jobs")
         for job in list(self.jobs):
-            if self.mode == "dry-run" or self.system.is_job_completed(job):
+            is_completed = self.system.is_job_completed(job)
+            if self.mode == "dry-run" or is_completed:
+                logging.debug(f"Job {job.id} for test {job.test_run.name} completed ({self.mode=}, {is_completed=})")
                 await self.job_completion_callback(job)
 
                 if self.mode == "dry-run":

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -185,6 +185,7 @@ class SlurmSystem(BaseModel, System):
 
         while retry_count < retry_threshold:
             stdout, stderr = self.cmd_shell.execute(command).communicate()
+            logging.debug(f"Job running: {command=} {stdout=} {stderr=}")
 
             if "Socket timed out" in stderr or "slurm_load_jobs error" in stderr:
                 retry_count += 1
@@ -198,8 +199,8 @@ class SlurmSystem(BaseModel, System):
                 logging.error(error_message)
                 raise RuntimeError(error_message)
 
-            job_state = stdout.strip()
-            if job_state == "RUNNING":
+            job_states = stdout.strip().split()
+            if "RUNNING" in job_states:
                 return True
 
             break
@@ -232,6 +233,7 @@ class SlurmSystem(BaseModel, System):
 
         while retry_count < retry_threshold:
             stdout, stderr = self.cmd_shell.execute(command).communicate()
+            logging.debug(f"Job completed: {command=} {stdout=} {stderr=}")
 
             if "Socket timed out" in stderr or "slurm_load_jobs error" in stderr:
                 retry_count += 1

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -510,7 +510,6 @@ class SlurmSystem(BaseModel, System):
         """
         logging.debug(f"Executing command: {command}")
         stdout, stderr = self.cmd_shell.execute(command).communicate()
-        logging.debug(f"Command output: {stdout}")
         if stderr:
             logging.error(f"Error executing command '{command}': {stderr}")
         return stdout, stderr

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -272,6 +272,7 @@ def test_is_job_completed(stdout: str, stderr: str, is_completed: bool, slurm_sy
         ("CANCELLED", "", False),
         ("TIMEOUT", "", False),
         ("", "error", False),
+        ("   RUNNING \n   RUNNING \n   RUNNING \n COMPLETED \n    FAILED \n   RUNNING \n", "", True),
     ],
 )
 def test_is_job_running(stdout: str, stderr: str, is_running: bool, slurm_system: SlurmSystem):


### PR DESCRIPTION
## Summary
1. Fixed `is_job_running` for slurm system, extended logging to simplify debug for such cases.
2. Removed dry-run test with slurm system from CI, `sacct` is used as a real binary now.

## Test Plan
1. CI (extended)
3. Manual runs of sleep scenario, issues were mostly related to `start_post_init` dependency.

## Additional Notes
—