### PR TITLE
Refactor: Use test definition's cmd_args for UCC command generation

### DIFF
--- a/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Union, cast
 from cloudai import TestRun
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 
-from .ucc import UCCTestDefinition
+from .ucc import UCCCmdArgs, UCCTestDefinition
 
 
 class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
@@ -45,21 +45,16 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def generate_test_command(
         self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> List[str]:
+        tdef: UCCTestDefinition = cast(UCCTestDefinition, tr.test.test_definition)
+        tdef_cmd_args: UCCCmdArgs = tdef.cmd_args
+
         srun_command_parts = ["/opt/hpcx/ucc/bin/ucc_perftest"]
-
-        # Add collective, minimum bytes, and maximum bytes options if available
-        if "collective" in cmd_args:
-            srun_command_parts.append(f"-c {cmd_args['collective']}")
-        if "b" in cmd_args:
-            srun_command_parts.append(f"-b {cmd_args['b']}")
-        if "e" in cmd_args:
-            srun_command_parts.append(f"-e {cmd_args['e']}")
-
-        # Append fixed string options for memory type and additional flags
+        srun_command_parts.append(f"-c {tdef_cmd_args.collective}")
+        srun_command_parts.append(f"-b {tdef_cmd_args.b}")
+        srun_command_parts.append(f"-e {tdef_cmd_args.e}")
         srun_command_parts.append("-m cuda")
         srun_command_parts.append("-F")
 
-        # Append any extra command-line arguments provided
         if tr.test.extra_cmd_args:
             srun_command_parts.append(tr.test.extra_cmd_args)
 

--- a/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
@@ -14,11 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Literal, Union, cast
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
+from cloudai._core.test import Test
+from cloudai._core.test_scenario import TestRun
 from cloudai.systems import SlurmSystem
 from cloudai.workloads.ucc_test import UCCCmdArgs, UCCTestDefinition, UCCTestSlurmCommandGenStrategy
 
@@ -29,11 +31,10 @@ class TestUCCTestSlurmCommandGenStrategy:
         return UCCTestSlurmCommandGenStrategy(slurm_system, {})
 
     @pytest.mark.parametrize(
-        "cmd_args, extra_cmd_args, expected_command",
+        "cmd_args_data, expected_command",
         [
             (
                 {"collective": "allgather", "b": 8, "e": "256M"},
-                "--max-steps 100",
                 [
                     "/opt/hpcx/ucc/bin/ucc_perftest",
                     "-c allgather",
@@ -41,12 +42,10 @@ class TestUCCTestSlurmCommandGenStrategy:
                     "-e 256M",
                     "-m cuda",
                     "-F",
-                    "--max-steps 100",
                 ],
             ),
             (
                 {"collective": "allreduce", "b": 4, "e": "8M"},
-                "",
                 [
                     "/opt/hpcx/ucc/bin/ucc_perftest",
                     "-c allreduce",
@@ -60,23 +59,39 @@ class TestUCCTestSlurmCommandGenStrategy:
     )
     def test_generate_test_command(
         self,
+        tmp_path: Path,
         cmd_gen_strategy: UCCTestSlurmCommandGenStrategy,
-        cmd_args: Dict[str, Union[str, List[str]]],
-        extra_cmd_args: str,
-        expected_command: List[str],
+        cmd_args_data: dict,
+        expected_command: list[str],
     ) -> None:
-        env_vars = {}
-        tr = Mock()
-        tr.test.extra_cmd_args = extra_cmd_args
-
-        mock_cmd_args = UCCCmdArgs(
-            collective=cast(Union[Literal["allgather"], Literal["allreduce"]], cmd_args["collective"]),
-            b=cast(int, cmd_args["b"]),
-            e=cmd_args.get("e", "8M"),
+        ucc_cmd_args = UCCCmdArgs(
+            collective=cmd_args_data["collective"],
+            b=cmd_args_data["b"],
+            e=cmd_args_data.get("e", "8M"),
         )
-        mock_test_definition = Mock(spec=UCCTestDefinition)
-        mock_test_definition.cmd_args = mock_cmd_args
-        tr.test.test_definition = mock_test_definition
 
-        command = cmd_gen_strategy.generate_test_command(env_vars, {}, tr)
+        test_def = UCCTestDefinition(
+            name="ucc_test",
+            description="UCC test",
+            test_template_name="default_template",
+            cmd_args=ucc_cmd_args,
+            extra_env_vars={},
+            extra_cmd_args={},
+        )
+
+        test_obj = Test(test_definition=test_def, test_template=Mock())
+
+        tr = TestRun(
+            test=test_obj,
+            num_nodes=1,
+            nodes=[],
+            output_path=tmp_path / "output",
+            name="test-job",
+        )
+
+        command = cmd_gen_strategy.generate_test_command(
+            test_def.extra_env_vars,
+            test_def.cmd_args.model_dump(),
+            tr,
+        )
         assert command == expected_command

--- a/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
@@ -95,7 +95,7 @@ class TestUCCTestSlurmCommandGenStrategy:
 
         command = cmd_gen_strategy.generate_test_command(
             test_def.extra_env_vars,
-            test_def.cmd_args.model_dump(),
+            test_def.cmd_args_dict,
             tr,
         )
         assert command == expected_command

--- a/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
@@ -31,10 +31,11 @@ class TestUCCTestSlurmCommandGenStrategy:
         return UCCTestSlurmCommandGenStrategy(slurm_system, {})
 
     @pytest.mark.parametrize(
-        "cmd_args_data, expected_command",
+        "cmd_args_data, extra_cmd_args, expected_command",
         [
             (
                 {"collective": "allgather", "b": 8, "e": "256M"},
+                {"--max-steps": "100"},
                 [
                     "/opt/hpcx/ucc/bin/ucc_perftest",
                     "-c allgather",
@@ -42,10 +43,12 @@ class TestUCCTestSlurmCommandGenStrategy:
                     "-e 256M",
                     "-m cuda",
                     "-F",
+                    "--max-steps=100",
                 ],
             ),
             (
                 {"collective": "allreduce", "b": 4, "e": "8M"},
+                {},
                 [
                     "/opt/hpcx/ucc/bin/ucc_perftest",
                     "-c allreduce",
@@ -62,6 +65,7 @@ class TestUCCTestSlurmCommandGenStrategy:
         tmp_path: Path,
         cmd_gen_strategy: UCCTestSlurmCommandGenStrategy,
         cmd_args_data: dict,
+        extra_cmd_args: dict,
         expected_command: list[str],
     ) -> None:
         ucc_cmd_args = UCCCmdArgs(
@@ -76,7 +80,7 @@ class TestUCCTestSlurmCommandGenStrategy:
             test_template_name="default_template",
             cmd_args=ucc_cmd_args,
             extra_env_vars={},
-            extra_cmd_args={},
+            extra_cmd_args=extra_cmd_args,
         )
 
         test_obj = Test(test_definition=test_def, test_template=Mock())


### PR DESCRIPTION
## Summary
Refactor: Use test definition's cmd_args for UCC command generation

## Test Plan
CI passes