### PR TITLE
Update output path for DSE runs

### DIFF
--- a/src/cloudai/_core/configurator/base_gym.py
+++ b/src/cloudai/_core/configurator/base_gym.py
@@ -67,13 +67,12 @@ class BaseGym(ABC):
         pass
 
     @abstractmethod
-    def step(self, action: Any, step: int) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
-            step (int): Step number.
 
         Returns:
             Tuple: A tuple containing:

--- a/src/cloudai/_core/configurator/base_gym.py
+++ b/src/cloudai/_core/configurator/base_gym.py
@@ -67,12 +67,13 @@ class BaseGym(ABC):
         pass
 
     @abstractmethod
-    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any, step: int) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
+            step (int): Step number.
 
         Returns:
             Tuple: A tuple containing:

--- a/src/cloudai/_core/configurator/cloudai_gym.py
+++ b/src/cloudai/_core/configurator/cloudai_gym.py
@@ -109,12 +109,13 @@ class CloudAIGymEnv(BaseGym):
         info = {}
         return observation, info
 
-    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any, step: int) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
+            step (int): Step number.
 
         Returns:
             Tuple: A tuple containing:
@@ -136,17 +137,18 @@ class CloudAIGymEnv(BaseGym):
             return [-1.0], -1.0, True, {}
 
         logging.info(f"Running step {self.test_run.step} with action {action}")
-        self.runner.runner.test_scenario.test_runs = [copy.deepcopy(self.test_run)]
+        new_tr = copy.deepcopy(self.test_run)
+        new_tr.step = step
+        self.runner.runner.test_scenario.test_runs = [new_tr]
         asyncio.run(self.runner.run())
+        self.test_run = self.runner.runner.test_scenario.test_runs[0]
 
         observation = self.get_observation(action)
         reward = self.compute_reward(observation)
-        done = False
-        info = {}
 
         self.write_trajectory(self.test_run.step, action, reward, observation)
 
-        return observation, reward, done, info
+        return observation, reward, False, {}
 
     def render(self, mode: str = "human"):
         """

--- a/src/cloudai/_core/configurator/cloudai_gym.py
+++ b/src/cloudai/_core/configurator/cloudai_gym.py
@@ -109,13 +109,12 @@ class CloudAIGymEnv(BaseGym):
         info = {}
         return observation, info
 
-    def step(self, action: Any, step: int) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
-            step (int): Step number.
 
         Returns:
             Tuple: A tuple containing:
@@ -138,7 +137,6 @@ class CloudAIGymEnv(BaseGym):
 
         logging.info(f"Running step {self.test_run.step} with action {action}")
         new_tr = copy.deepcopy(self.test_run)
-        new_tr.step = step
         self.runner.runner.test_scenario.test_runs = [new_tr]
         asyncio.run(self.runner.run())
         self.test_run = self.runner.runner.test_scenario.test_runs[0]

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -108,8 +108,7 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace):
             if result is None:
                 break
             step, action = result
-            test_run.step = step
-            observation, reward, done, info = env.step(action)
+            observation, reward, done, info = env.step(action, step)
             feedback = {"trial_index": step, "value": reward}
             agent.update_policy(feedback)
             logging.info(f"Step {step}: Observation: {observation}, Reward: {reward}")

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -108,7 +108,8 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace):
             if result is None:
                 break
             step, action = result
-            observation, reward, done, info = env.step(action, step)
+            env.test_run.step = step
+            observation, reward, done, info = env.step(action)
             feedback = {"trial_index": step, "value": reward}
             agent.update_policy(feedback)
             logging.info(f"Step {step}: Observation: {observation}, Reward: {reward}")

--- a/src/cloudai/workloads/nemo_run/report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_run/report_generation_strategy.py
@@ -99,6 +99,7 @@ class NeMoRunReportGenerationStrategy(ReportGenerationStrategy):
             f.write("Max: {max}\n".format(max=stats["max"]))
 
     def get_metric(self, metric: str) -> float:
+        logging.debug(f"Getting metric {metric} from {self.results_file.absolute()}")
         step_timings = extract_timings(self.results_file)
         if not step_timings:
             return METRIC_ERROR

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def slurm_system(tmp_path: Path) -> SlurmSystem:
         ],
     )
     system.scheduler = "slurm"
-    system.monitor_interval = 10
+    system.monitor_interval = 0
     return system
 
 

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -246,7 +246,8 @@ def test_tr_output_path(setup_env: tuple[TestRun, Runner]):
     env = CloudAIGymEnv(test_run=test_run, runner=runner)
     agent = GridSearchAgent(env)
 
-    _, result = agent.select_action()
-    env.step(result, 42)
+    _, action = agent.select_action()
+    env.test_run.step = 42
+    env.step(action)
 
     assert env.test_run.output_path.name == "42"


### PR DESCRIPTION
## Summary
Fix an issue when output_path wasn't updated for test run object. Thanks @srivatsankrishnan for reporting this issue.

## Test Plan
1. CI (extended)
2. Manual dry-run, got a failure for `cloudai dry-run --system-config conf/common/system/example_slurm_cluster.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/dse_nemo_run_llama3_8b.toml`, but it is unrelated:
    ```bash
    File "/Users/andreyma/workspace/nvidia/cloudai/src/cloudai/workloads/nemo_run/nemo_run.py", line 143, in constraint_check
        constraint3 = gbs % (mbs * dp) == 0
    ZeroDivisionError: integer division or modulo by zero
    ```
3. Run `cloudai run --system-config ../cw.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/dse_nemo_run_llama3_8b.toml` on CW:
```bash
2025-04-11 04:47:52,204 - INFO - Running step 0 with action {'docker_image_url': 'nvcr.io/nvidia/nemo:24.12.rc3', 'task': 'pretrain', 'recipe_name': 'llama3_8b', 'num_layers': None, 'trainer.max_steps': 100, 'trainer.val_check_interval': 1000, 'trainer.num_nodes': 1, 'trainer.strategy.tensor_model_parallel_size': 1, 'trainer.strategy.pipeline_model_parallel_size': 1, 'trainer.strategy.context_parallel_size': 1, 'trainer.strategy.virtual_pipeline_model_parallel_size': None, 'trainer.plugins': None, 'trainer.callbacks': None, 'log.ckpt.save_on_train_epoch_end': False, 'log.ckpt.save_last': False, 'log.tensorboard': None, 'data.micro_batch_size': 1, 'data.global_batch_size': 128}
2025-04-11 04:47:52,250 - INFO - Starting test: dse_nemo_run_llama3_8b_1
2025-04-11 04:47:52,250 - INFO - Running test: dse_nemo_run_llama3_8b_1
...
2025-04-11 04:52:54,425 - DEBUG - All jobs finished successfully.
2025-04-11 04:52:54,430 - DEBUG - Getting metric default from /PATH/cloudai/results/nemo_run_llama3_8b_2025-04-11_04-47-52/dse_nemo_run_llama3_8b_1/0/1/stdout.txt
2025-04-11 04:52:54,440 - DEBUG - No train_step_timing found in results/nemo_run_llama3_8b_2025-04-11_04-47-52/dse_nemo_run_llama3_8b_1/0/1/stdout.txt
2025-04-11 04:52:54,441 - DEBUG - Writing trajectory into results/nemo_run_llama3_8b_2025-04-11_04-47-52/dse_nemo_run_llama3_8b_1/0/trajectory.csv (exists: False)
2025-04-11 04:52:54,447 - INFO - Step 1: Observation: [-1.0], Reward: -1.0
2025-04-11 04:52:54,448 - INFO - Running step 1 with action {'docker_image_url': 'nvcr.io/nvidia/nemo:24.12.rc3', 'task': 'pretrain', 'recipe_name': 'llama3_8b', 'num_layers': None, 'trainer.max_steps': 100, 'trainer.val_check_interval': 1000, 'trainer.num_nodes': 1, 'trainer.strategy.tensor_model_parallel_size': 1, 'trainer.strategy.pipeline_model_parallel_size': 1, 'trainer.strategy.context_parallel_size': 1, 'trainer.strategy.virtual_pipeline_model_parallel_size': None, 'trainer.plugins': None, 'trainer.callbacks': None, 'log.ckpt.save_on_train_epoch_end': False, 'log.ckpt.save_last': False, 'log.tensorboard': None, 'data.micro_batch_size': 1, 'data.global_batch_size': 256}
2025-04-11 04:52:54,546 - INFO - Starting test: dse_nemo_run_llama3_8b_1
2025-04-11 04:52:54,547 - INFO - Running test: dse_nemo_run_llama3_8b_1
...
```

`No train_step_timing found in` is real, execution failed I see some errors coming from NCCL: `[Accept failed Resource temporarily unavailable](cw-dfw-h100-004-104-026:3132825:3139333 [5] proxy.cc:1458 NCCL WARN [Service thread] Accept failed Resource temporarily unavailable)`. But file is correct.

## Additional Notes
—