### PR TITLE
Updates and fixes for metadata collection

### DIFF
--- a/src/cloudai/systems/slurm/slurm-metadata.sh
+++ b/src/cloudai/systems/slurm/slurm-metadata.sh
@@ -20,11 +20,11 @@ hpcx_version = "${hpcx_version:-null}"
 
 [cuda]
 cuda_build_version = "${CUDA_BUILD_VERSION:-null}"
-cuda_runtime_version = "$(nvcc --version 2>/dev/null | grep -oP 'release \K[0-9]+\.[0-9]+(?=,)' || echo null)"
+cuda_runtime_version = "$(nvidia-smi 2>/dev/null | grep -oP "(?<=CUDA Version: )[\d\.]+" || echo null)"
 cuda_driver_version = "$(nvidia-smi 2>/dev/null | grep -oP "(?<=Driver Version: )[\d\.]+" || echo null)"
 
 [network]
-nics = "$(lspci 2>/dev/null | grep -E "Ethernet controller|Infiniband controller" | grep -v "BlueField" | awk -F": " '/Mellanox/ {found=1;print $NF;exit 0} END {if (!found) exit 1}' || echo null)"
+nics = "$(lspci 2>/dev/null | grep -E "Ethernet controller|Infiniband controller" | awk -F": " '/Mellanox/ {found=1;print $NF;exit 0} END {if (!found) exit 1}' || echo null)"
 switch_type = "${SWITCH:-null}"
 network_name = "${NETWORK:-null}"
 mofed_version = "$(command -v ofed_info >/dev/null && ofed_info -s 2>/dev/null | sed 's/:$//' || echo null)"

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -301,6 +301,9 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
     def _metadata_cmd(self, slurm_args: dict[str, Any], tr: TestRun) -> str:
         (tr.output_path.absolute() / "metadata").mkdir(parents=True, exist_ok=True)
         num_nodes, _ = self.system.get_nodes_by_spec(tr.num_nodes, tr.nodes)
+        metadata_script_path = "/cloudai_install"
+        if "image_path" not in slurm_args:
+            metadata_script_path = str(self.system.install_path.absolute())
         return " ".join(
             [
                 *self.gen_srun_prefix(slurm_args, tr),
@@ -309,7 +312,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
                 f"--output={tr.output_path.absolute() / 'metadata' / 'node-%N.toml'}",
                 f"--error={tr.output_path.absolute() / 'metadata' / 'nodes.err'}",
                 "bash",
-                "/cloudai_install/slurm-metadata.sh",
+                f"{metadata_script_path}/slurm-metadata.sh",
             ]
         )
 

--- a/tests/ref_data/sleep.sbatch
+++ b/tests/ref_data/sleep.sbatch
@@ -9,6 +9,6 @@ export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head
 
 srun --export=ALL --mpi=pmix --output=__OUTPUT_DIR__/output/mapping-stdout.txt --error=__OUTPUT_DIR__/output/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."
 
-srun --export=ALL --mpi=pmix --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
+srun --export=ALL --mpi=pmix --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash __OUTPUT_DIR__/install/slurm-metadata.sh
 
 srun --export=ALL --mpi=pmix sleep 5


### PR DESCRIPTION
## Summary
1. Do not filter out Bluefields for NICs' list.
2. Update how CUDA runtime version is fetched.
3. [Fixed](https://redmine.mellanox.com/issues/4402039) path to collection script for bare-metal runs (without container).

## Test Plan
1. CI
2. Run `sleep` scenario on EOS, collected metadata looks good.

## Additional Notes
—