### PR TITLE
Refactor: Use test definition's cmd_args for sleep command generation

### DIFF
--- a/src/cloudai/workloads/sleep/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/kubernetes_json_gen_strategy.py
@@ -19,13 +19,16 @@ from typing import Any, Dict, cast
 from cloudai import JsonGenStrategy, TestRun
 from cloudai.systems import KubernetesSystem
 
+from .sleep import SleepCmdArgs, SleepTestDefinition
+
 
 class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
     """JSON generation strategy for Sleep on Kubernetes systems."""
 
     def gen_json(self, tr: TestRun) -> Dict[Any, Any]:
-        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
-        sec = self.final_cmd_args["seconds"]
+        tdef: SleepTestDefinition = cast(SleepTestDefinition, tr.test.test_definition)
+        tdef_cmd_args: SleepCmdArgs = tdef.cmd_args
+        sec = tdef_cmd_args.seconds
 
         kubernetes_system = cast(KubernetesSystem, self.system)
 
@@ -50,5 +53,4 @@ class SleepKubernetesJsonGenStrategy(JsonGenStrategy):
                 },
             },
         }
-
         return job_spec

--- a/src/cloudai/workloads/sleep/lsf_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/lsf_command_gen_strategy.py
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union
+from typing import Dict, List, Union, cast
 
 from cloudai import TestRun
 from cloudai.systems.lsf.strategy import LSFCommandGenStrategy
+
+from .sleep import SleepCmdArgs, SleepTestDefinition
 
 
 class SleepLSFCommandGenStrategy(LSFCommandGenStrategy):
@@ -29,4 +31,6 @@ class SleepLSFCommandGenStrategy(LSFCommandGenStrategy):
     def generate_test_command(
         self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> List[str]:
-        return [f'sleep {cmd_args["seconds"]}']
+        tdef: SleepTestDefinition = cast(SleepTestDefinition, tr.test.test_definition)
+        tdef_cmd_args: SleepCmdArgs = tdef.cmd_args
+        return [f"sleep {tdef_cmd_args.seconds}"]

--- a/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
@@ -14,18 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import cast
 
 from cloudai import CommandGenStrategy, TestRun
 
+from .sleep import SleepCmdArgs, SleepTestDefinition
+
 
 class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
-    """
-    Command generation strategy for the Sleep test on standalone systems.
-
-    This strategy generates a command to execute a sleep operation with specified duration on standalone systems.
-    """
+    """Command generation strategy for the Sleep test on standalone systems."""
 
     def gen_exec_command(self, tr: TestRun) -> str:
-        self.final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
-        sec = self.final_cmd_args["seconds"]
+        tdef: SleepTestDefinition = cast(SleepTestDefinition, tr.test.test_definition)
+        tdef_cmd_args: SleepCmdArgs = tdef.cmd_args
+        sec = tdef_cmd_args.seconds
         return f"sleep {sec}"


### PR DESCRIPTION
## Summary
Refactor: Use test definition's cmd_args for sleep command generation

## Test Plan
CI passes