### PR TITLE
Collect more metadata for slurm jobs

### DIFF
--- a/src/cloudai/systems/slurm/metadata.py
+++ b/src/cloudai/systems/slurm/metadata.py
@@ -66,6 +66,10 @@ class MetadataSlurm(BaseModel):
     cluster_name: str
     node_list: str
     num_nodes: str
+    ntasks_per_node: str
+    ntasks: str
+    nnodes: str
+    job_id: str
 
 
 class SlurmSystemMetadata(BaseModel):

--- a/src/cloudai/systems/slurm/slurm-metadata.sh
+++ b/src/cloudai/systems/slurm/slurm-metadata.sh
@@ -38,4 +38,8 @@ commit_sha = "${NCCL_COMMIT_SHA:-null}"
 cluster_name = "${SLURM_CLUSTER_NAME:-null}"
 node_list = "${SLURM_NODELIST:-null}"
 num_nodes = "${SLURM_NNODES:-null}"
+ntasks_per_node = "${SLURM_NTASKS_PER_NODE:-null}"
+ntasks = "${SLURM_NTASKS:-null}"
+nnodes = "${SLURM_NNODES:-null}"
+job_id = "${SLURM_JOBID:-null}"
 EOF

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -28,6 +28,17 @@ from ...util import CommandShell
 from .slurm_node import SlurmNode, SlurmNodeState
 
 
+class SlurmJobMetadata(BaseModel):
+    """Represents the metadata of a Slurm job."""
+
+    job_id: int
+    job_name: str
+    job_state: str
+    elapsed_time_sec: int
+    srun_cmd: str
+    test_cmd: str
+
+
 def parse_node_list(node_list: str) -> List[str]:
     """
     Expand a list of node names (with ranges) into a flat list of individual node names, keeping leading zeroes.
@@ -260,6 +271,31 @@ class SlurmSystem(BaseModel, System):
             raise RuntimeError(error_message)
 
         return False
+
+    def get_job_status(self, job: BaseJob, retry_threshold: int = 3) -> Optional[tuple[str, str, str]]:
+        retry_count = 0
+        command = f"sacct -j {job.id} --format=JobName,State,ElapsedRAW --delimiter=',' -p --noheader"
+
+        while retry_count < retry_threshold:
+            stdout, stderr = self.cmd_shell.execute(command).communicate()
+            logging.debug(f"Job status: {command=} {stdout=} {stderr=}")
+
+            if "Socket timed out" in stderr or "slurm_load_jobs error" in stderr:
+                retry_count += 1
+                logging.warning(f"Retrying job status check (attempt {retry_count}/{retry_threshold})")
+                continue
+
+            if stderr:
+                error_message = f"Error checking job status: {stderr}"
+                logging.error(error_message)
+                raise RuntimeError(error_message)
+
+            # sacct produces a single line per job, first line is for overall job
+            job_states = stdout.strip().splitlines()[0]
+            data = job_states.split(",")
+            return data[0], data[1], data[2]
+
+        return None
 
     def kill(self, job: BaseJob) -> None:
         """

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -288,6 +288,35 @@ def test_is_job_running(stdout: str, stderr: str, is_running: bool, slurm_system
         assert slurm_system.is_job_running(job) is is_running
 
 
+@pytest.mark.parametrize(
+    "stdout,stderr, expected",
+    [
+        ("", "error", None),
+        (  # a real stdout example
+            """coreai_dlalgo_llm-TestTemplate.20250414_004818,COMPLETED,144,
+batch,COMPLETED,144,
+extern,COMPLETED,144,
+bash,COMPLETED,23,
+bash,COMPLETED,29,
+all_reduce_perf_mpi,COMPLETED,46,""",
+            "",
+            ("coreai_dlalgo_llm-TestTemplate.20250414_004818", "COMPLETED", "144"),
+        ),
+    ],
+)
+def test_get_job_status(slurm_system: SlurmSystem, stdout: str, stderr: str, expected: tuple):
+    job = BaseJob(test_run=Mock(), id=1)
+    pp = Mock()
+    pp.communicate = Mock(return_value=(stdout, stderr))
+    slurm_system.cmd_shell.execute = Mock(return_value=pp)
+
+    if stderr:
+        with pytest.raises(RuntimeError):
+            slurm_system.get_job_status(job)
+    else:
+        assert slurm_system.get_job_status(job) == expected
+
+
 def test_is_job_running_with_retries(slurm_system: SlurmSystem):
     job = BaseJob(test_run=Mock(), id=1)
     command = f"sacct -j {job.id} --format=State --noheader"


### PR DESCRIPTION
## Summary
1. Collect more information for `SlurmSystemMetadata.slurm`
2. Dump slurm job information once job is completed.

## Test Plan
1. CI (expanded)
3. Local dry-run
4. Real run via NCCL perf runner on EOS, `slurm-job.toml` example
```toml
job_id = 2493012
job_name = "coreai_dlalgo_llm-TestTemplate.20250414_024225"
job_state = "COMPLETED"
elapsed_time_sec = 126
srun_cmd = "srun --export=ALL --mpi=pmix --container-image=PATH/_install/nvcr.io_nvidia__pytorch__25.02-py3.sqsh --container-mounts=PATH/cloudaix/results/nccl-perf_2025-04-14_02-42-25/all_reduce/0/1:/cloudai_run_results,PATH/_install:/cloudai_install all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 8 --maxbytes 16G --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0 --stepfactor 2 --local_register 0"
test_cmd = "all_reduce_perf_mpi --nthreads 1 --ngpus 1 --minbytes 8 --maxbytes 16G --stepbytes 1M --op sum --datatype float --root 0 --iters 20 --warmup_iters 5 --agg_iters 1 --average 1 --parallel_init 0 --check 1 --blocking 0 --cudagraph 0 --stepfactor 2 --local_register 0"
```

## Additional Notes
—
