### PR TITLE
Fix typo in src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py

### DIFF
--- a/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
@@ -98,7 +98,7 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if recipe_name not in supported_recipes:
             logging.warning(
                 f"Using default {recipe_name} in Nemo2.0. "
-                "Passing advance CLI options (e.g., factory fuctions) might not be fully supported in Nemo-Run CLI."
+                "Passing advance CLI options (e.g., factory functions) might not be fully supported in Nemo-Run CLI."
             )
 
         return recipe_name


### PR DESCRIPTION
## Summary
Fix typo in src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py

## Test Plan
CI passes