### PR TITLE
Nemo2.0 fixes for Llama70b

### DIFF
--- a/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
+++ b/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
@@ -483,7 +483,7 @@ def cloudai_llama3_70b_recipe() -> run.Partial:
                 pipeline_dtype=torch.bfloat16,
                 ddp=run.Config(
                     DistributedDataParallelConfig,
-                    check_for_nan_in_grad=True,
+                    check_for_nan_in_grad=False,
                     grad_reduce_in_fp32=True,
                     overlap_grad_reduce=True,
                     overlap_param_gather=True,
@@ -521,12 +521,12 @@ def cloudai_llama3_70b_recipe() -> run.Partial:
             resume_past_end=True,
         ),
     )
+    recipe.model.config.vocab_size = 128256
     return recipe
 
 
 # LLAMA3 405B Recipe
 @run.cli.factory(target=llm.pretrain)
-@run.autoconvert
 def cloudai_llama3_405b_recipe() -> run.Partial:
     recipe = run.Partial(
         llm.pretrain,
@@ -536,7 +536,7 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
             seq_length=8192,
             micro_batch_size=1,
             global_batch_size=8,
-            tokenizer=null_tokenizer(128256),
+            tokenizer=null_tokenizer(vocab_size=128256),
         ),
         trainer=run.Config(
             nl.Trainer,
@@ -590,7 +590,6 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
 
 # NEMOTRON3 8B Recipe
 @run.cli.factory(target=llm.pretrain)
-@run.autoconvert
 def cloudai_nemotron3_8b_recipe() -> run.Partial:
     recipe = run.Partial(
         llm.pretrain,
@@ -741,7 +740,7 @@ def cloudai_nemotron4_340b_recipe() -> run.Partial:
             seq_length=4096,
             micro_batch_size=1,
             global_batch_size=8,
-            tokenizer=null_tokenizer(vocab_size=128256),
+            tokenizer=null_tokenizer(vocab_size=256000),
         ),
         trainer=run.Config(
             nl.Trainer,


### PR DESCRIPTION
## Summary
Running Llama3_70b causes an error with `Unexpected error: 'NoneType' object has no attribute 'vocab_size'`

The Vocab_size was set in the [GPT](https://github.com/NVIDIA/NeMo/blob/v2.3.0rc2/nemo/collections/llm/gpt/model/base.py) base model which was setting this value to `None`. Ideally this value should be same as the value in the tokenizer. 

This pR, exposes and sets the value in the `Llama3_70` recipe. 

There was another error related to collectives. This could be a node level issue.  The workaround we have is to set the `check_for_nan_in_grad` to `False`

```
Unexpected error: Rank 40, node cw-dfw-h100-002-295-026, device 0, iteration -1: Unexpected result nan (message='found NaN in local grad norm for bucket #0 in backward pass before data-parallel communication collective')
Unexpected error: Rank 42, node cw-dfw-h100-002-295-026, device 2, iteration -1: Unexpected result nan (message='found NaN in local grad norm for bucket #0 in backward pass before data-parallel communication collective')
Unexpected error: Rank 43, node cw-dfw-h100-002-295-026, device 3, iteration -1: Unexpected result nan (message='found NaN in local grad norm for bucket #0 in backward pass before data-parallel communication collective')
```

## Test Plan
CI/CD

Test on Real System
```
Training epoch 0, iteration 12/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 12 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.18 | consumed_samples: 1664
Training epoch 0, iteration 13/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 13 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.18 | consumed_samples: 1792
Training epoch 0, iteration 14/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 14 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.18 | consumed_samples: 1920
Training epoch 0, iteration 15/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 15 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.18 | consumed_samples: 2048
Training epoch 0, iteration 16/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 16 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.21 | consumed_samples: 2176
Training epoch 0, iteration 17/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 17 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.18 | consumed_samples: 2304
Training epoch 0, iteration 18/99 | lr: 0.0001 | global_batch_size: 128 | global_step: 18 | peak_memory_usage: 60660121600 | memory_allocated: 32035598336 | reduced_train_loss: nan | train_step_timing in s: 12.18 | consumed_samples: 2432

```

Logs: [Here](https://drive.google.com/drive/folders/1Tf263PIC3PfEHI79PPmImFtkESkUX6rY)


## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
