### PR TITLE
Updates for slurm metadata

### DIFF
--- a/src/cloudai/systems/slurm/metadata.py
+++ b/src/cloudai/systems/slurm/metadata.py
@@ -31,7 +31,8 @@ class MetadataSystem(BaseModel):
 class MetadataMPI(BaseModel):
     """Represents the MPI metadata."""
 
-    ompi_version: str
+    mpi_type: str
+    mpi_version: str
     hpcx_version: str
 
 
@@ -68,7 +69,6 @@ class MetadataSlurm(BaseModel):
     num_nodes: str
     ntasks_per_node: str
     ntasks: str
-    nnodes: str
     job_id: str
 
 

--- a/src/cloudai/systems/slurm/slurm-metadata.sh
+++ b/src/cloudai/systems/slurm/slurm-metadata.sh
@@ -15,7 +15,8 @@ cpu_model_name = "$(lscpu 2>/dev/null | grep "Model name:" | sed 's/Model name:[
 cpu_arch_type = "$(lscpu 2>/dev/null | grep "Architecture:" | sed 's/Architecture:[[:space:]]*//' || echo null)"
 
 [mpi]
-ompi_version = "$(mpirun --version 2>/dev/null | grep -oP "(?<=\(Open MPI\) )[^\s]+$" || echo null)"
+mpi_type = "$(mpirun --version 2>/dev/null | grep -i "open mpi" -q && echo openmpi || echo null)"
+mpi_version = "$(mpirun --version 2>/dev/null | grep -oP "(?<=\(Open MPI\) )[^\s]+$" || echo null)"
 hpcx_version = "${hpcx_version:-null}"
 
 [cuda]
@@ -40,6 +41,5 @@ node_list = "${SLURM_NODELIST:-null}"
 num_nodes = "${SLURM_NNODES:-null}"
 ntasks_per_node = "${SLURM_NTASKS_PER_NODE:-null}"
 ntasks = "${SLURM_NTASKS:-null}"
-nnodes = "${SLURM_NNODES:-null}"
 job_id = "${SLURM_JOBID:-null}"
 EOF


### PR DESCRIPTION
## Summary
1. `ompi_version` --> `mpi_version`
2. + `mpi_type`
3. - `nnodes` (duplicated of `num_nodes`).

## Test Plan
1. CI
2. Real run on CW, metadata looks valid.

## Additional Notes
—
