### PR TITLE
Fix tarball name to preserve full directory name with dots intact

### DIFF
--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -184,7 +184,7 @@ class TarballReporter(Reporter):
         return tr.test.test_template.get_job_status(tr.output_path).is_successful
 
     def create_tarball(self, directory: Path) -> None:
-        tarball_path = directory.with_suffix(".tgz")
+        tarball_path = Path(str(directory) + ".tgz")
         with tarfile.open(tarball_path, "w:gz") as tar:
             tar.add(directory, arcname=directory.name)
         logging.info(f"Created tarball at {tarball_path}")


### PR DESCRIPTION
## Summary
I realized that CloudAI creates `nemo2.tgz` for `nemo2.0_llama3_70b_fp8_2025-04-16_14-27-45`. This is a bug fix for the bug.

## Test Plan
1. CI passes
2. Ran on EOS.
```
$ python cloudaix.py run --system-config conf/staging/llmb/system/eos.toml   --tests-dir conf/staging/llmb/test   --test-scenario conf/staging/llmb/test_scenario/nemo2.0_llama3_70b_fp8.toml 

[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nemo2.0_llama3_70b_fp8
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nemo2.0_llama3_70b_fp8

Section Name: Tests.1
  Test Name: nemo2.0_llama3_70b_fp8
  Description: nemo2.0_llama3_70b_fp8
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 2510430
[ERROR] Job 2510430 for test Tests.1 failed: Missing success indicators in results/nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07/Tests.1/0/stderr.txt: 'max_steps=', 'reached'. These keywords are expected to be present in stderr.txt when the NeMo training job completes successfully. Please review the full stderr output. Ensure that the NeMo training ran to completion and the logger output wasn't suppressed. If the issue persists, contact the system administrator.
[INFO] Terminating all jobs...
[INFO] Terminating job 2510430 for test Tests.1
[INFO] All jobs have been killed.
[INFO] All test scenario results stored at: results/nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07
[WARNING] Skipping 'results/nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07/Tests.1/0', can't handle with strategy=NeMoRunReportGenerationStrategy.
[WARNING] Skipping 'results/nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07/Tests.1/0', can't handle with strategy=NeMoRunDataStoreReportGenerationStrategy.
[INFO] Generated scenario report at results/nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07/nemo2.0_llama3_70b_fp8.html
[INFO] Created tarball at results/nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07.tgz
[INFO] All jobs are complete.
```

```
nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07  nemo2.0_llama3_70b_fp8_2025-04-16_15-46-07.tgz
```