### PR TITLE
Fix premature runner exit by looping until all jobs are complete

### DIFF
--- a/conf/common/test_scenario/sleep.toml
+++ b/conf/common/test_scenario/sleep.toml
@@ -20,7 +20,6 @@ name = "sleep-scenario"
 id = "Tests.1"
 time_limit = "00:01:00"
 test_name = "sleep_10"
-iterations = "3"
 
 [[Tests]]
 id = "Tests.2"

--- a/conf/common/test_scenario/sleep.toml
+++ b/conf/common/test_scenario/sleep.toml
@@ -20,6 +20,7 @@ name = "sleep-scenario"
 id = "Tests.1"
 time_limit = "00:01:00"
 test_name = "sleep_10"
+iterations = "3"
 
 [[Tests]]
 id = "Tests.2"

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -83,18 +83,16 @@ class BaseRunner(ABC):
             return
 
         total_tests = len(self.test_scenario.test_runs)
-        completed_jobs_count = 0
-
         dependency_free_trs = self.find_dependency_free_tests()
         for tr in dependency_free_trs:
             await self.submit_test(tr)
 
         logging.debug(f"Total tests: {total_tests}, dependency free tests: {[tr.name for tr in dependency_free_trs]}")
-        while completed_jobs_count < total_tests:
+        while self.jobs:
             await self.check_start_post_init_dependencies()
-            completed_jobs_count += await self.monitor_jobs()
+            completed_jobs_count = await self.monitor_jobs()
             logging.debug(
-                f"Completed jobs: {completed_jobs_count}, total tests: {total_tests}, "
+                f"Completed jobs in this cycle: {completed_jobs_count}, remaining jobs: {len(self.jobs)}, "
                 f"sleeping for {self.monitor_interval} seconds"
             )
             await asyncio.sleep(self.monitor_interval)

--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -90,11 +90,8 @@ class BaseRunner(ABC):
         logging.debug(f"Total tests: {total_tests}, dependency free tests: {[tr.name for tr in dependency_free_trs]}")
         while self.jobs:
             await self.check_start_post_init_dependencies()
-            completed_jobs_count = await self.monitor_jobs()
-            logging.debug(
-                f"Completed jobs in this cycle: {completed_jobs_count}, remaining jobs: {len(self.jobs)}, "
-                f"sleeping for {self.monitor_interval} seconds"
-            )
+            await self.monitor_jobs()
+            logging.debug(f"sleeping for {self.monitor_interval} seconds")
             await asyncio.sleep(self.monitor_interval)
 
     async def submit_test(self, tr: TestRun):


### PR DESCRIPTION
## Summary
Because of a bug in the base runner class implementation, even when I set the number of iterations to 3, only the first iteration completes successfully. Although the second iteration is submitted, it is not properly monitored.

## Test Plan
```
$ python cloudaix.py run --system-config conf/staging/llmb/system/oci.toml   --tests-dir conf/staging/
llmb/test   --test-scenario conf/staging/llmb/test_scenario/nccl_test.toml 
[INFO] System Name: OCI
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nccl-test
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nccl-test

Section Name: Tests.1
  Test Name: nccl_test_all_reduce
  Description: all_reduce
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 477811
[INFO] Job completed: Tests.1 (iteration 1 of 3)
[INFO] Re-running job for iteration 1
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 477827
[INFO] Job completed: Tests.1 (iteration 2 of 3)
[INFO] Re-running job for iteration 2
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 477897
[INFO] Job completed: Tests.1 (iteration 3 of 3)
[INFO] All test scenario results stored at: results/nccl-test_2025-04-17_16-41-46
[INFO] Generated scenario report at results/nccl-test_2025-04-17_16-41-46/nccl-test.html
[INFO] All jobs are complete.
```