### PR TITLE
Prevent NeMoRunDataStoreReportGenerationStrategy from overriding metric logic

### DIFF
--- a/src/cloudai/workloads/nemo_run/data_store_report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_run/data_store_report_generation_strategy.py
@@ -21,7 +21,7 @@ import os
 import re
 import socket
 from pathlib import Path
-from typing import Dict, List, Tuple, cast
+from typing import ClassVar, Dict, List, Tuple, cast
 
 import numpy as np
 import toml
@@ -36,6 +36,8 @@ from .report_generation_strategy import extract_timings
 
 class NeMoRunDataStoreReportGenerationStrategy(ReportGenerationStrategy):
     """Report generation strategy for NeMo 2.0 data store."""
+
+    metrics: ClassVar[list[str]] = []
 
     @property
     def results_file(self) -> Path:


### PR DESCRIPTION
## Summary
Prevent NeMoRunDataStoreReportGenerationStrategy from overriding metric logic

- Bug reported by Srivatsan - https://nvidia.slack.com/archives/C088QU7CE3S/p1744919678215499
- Bug introduced by https://github.com/NVIDIA/cloudai/pull/464

**Root Cause**
The `reports` field in `TestRun` is defined as a `set`  
https://github.com/NVIDIA/cloudai/blob/a046d3b0b95191617c1aceaa093333aa2bc00c8d/src/cloudai/_core/test_scenario.py#L70
which means the iteration order is **non-deterministic**.

As a result, when a metric is requested (e.g., `"default"`), the selected report generation strategy may vary between runs.

By default, `NeMoRunDataStoreReportGenerationStrategy` does **not** define its own `metrics` class variable,  
so it inherits `metrics = ["default"]` from the base `ReportGenerationStrategy`  

https://github.com/NVIDIA/cloudai/blob/a046d3b0b95191617c1aceaa093333aa2bc00c8d/src/cloudai/_core/report_generation_strategy.py#L27

However, this strategy does **not implement** `get_metric()` meaningfully,  
so when it is selected, it returns `0.0` — leading to incorrect values in outputs like `trajectory.csv`.

https://github.com/NVIDIA/cloudai/blob/a046d3b0b95191617c1aceaa093333aa2bc00c8d/src/cloudai/_core/report_generation_strategy.py#L33

## Test Plan
1. CI passes
2. Run on EOS
```
$ python cloudaix.py run --system-config conf/staging/llmb/system/eos.toml   --tests-dir conf/staging/llmb/test   --test-scenario conf/staging/llmb/test_scenario/nemo2.0_llama3_70b_fp8.toml 
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nemo2.0_llama3_70b_fp8
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nemo2.0_llama3_70b_fp8

Section Name: Tests.1
  Test Name: nemo2.0_llama3_70b_fp8
  Description: nemo2.0_llama3_70b_fp8
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Running step 1 with action {'docker_image_url': 'nvcr.io/nvidia/nemo:25.04.rc2', 'task': 'pretrain', 'recipe_name': 'cloudai_llama3_70b_recipe', 'num_layers': 80, 'trainer.max_steps': 50, 'trainer.val_check_interval': 50, 'trainer.num_nodes': 16, 'trainer.strategy.tensor_model_parallel_size': 4, 'trainer.strategy.pipeline_model_parallel_size': 8, 'trainer.strategy.context_parallel_size': 1, 'trainer.strategy.virtual_pipeline_model_parallel_size': 5, 'trainer.plugins.fp8': 'hybrid', 'trainer.plugins.fp8_margin': 0, 'trainer.plugins.fp8_amax_history_len': 1024, 'trainer.plugins.fp8_amax_compute_algo': 'max', 'trainer.plugins.fp8_wgrad': None, 'trainer.plugins.fp8_params': True, 'trainer.plugins.grad_reduce_in_fp32': False, 'trainer.callbacks': None, 'log.ckpt': None, 'log.tensorboard': None, 'data.seq_length': 8192, 'data.micro_batch_size': 1, 'data.global_batch_size': 128}
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 2518414
[INFO] Job completed: Tests.1 (iteration 1 of 3)
[INFO] Step 1: Observation: [5.441163265306123], Reward: 0.1837842298128026
```
```
step,action,reward,observation
1,"{'docker_image_url': '/lustre/fsw/general_infra-rd_gsw/theo/docker_images/nvidia+nemo+25.04.rc2.sqsh', 'task': 'pretrain', 'recipe_name': 'cloudai_llama3_70b_recipe', 'num_layers': 80, 'trainer.max_steps': 100, 'trainer.val_check_interval': 100, 'trainer.num_nodes': 16, 'trainer.strategy.tensor_model_parallel_size': 4, 'trainer.strategy.pipeline_model_parallel_size': 8, 'trainer.strategy.context_parallel_size': 1, 'trainer.strategy.virtual_pipeline_model_parallel_size': 5, 'trainer.plugins.fp8': 'hybrid', 'trainer.plugins.fp8_margin': 0, 'trainer.plugins.fp8_amax_history_len': 1024, 'trainer.plugins.fp8_amax_compute_algo': 'max', 'trainer.plugins.fp8_wgrad': None, 'trainer.plugins.fp8_params': True, 'trainer.plugins.grad_reduce_in_fp32': False, 'trainer.callbacks': None, 'log.ckpt': None, 'log.tensorboard': None, 'data.seq_length': 8192, 'data.micro_batch_size': 1, 'data.global_batch_size': 128}",0.18204159650480134,[5.493250000000001]
```
https://drive.google.com/drive/folders/16zAHW2kfB76LLvYTLk-x5HXDn5zQKUV8?usp=sharing