### PR TITLE
[WIP] Add DeepSeek-R1 support with test def, command gen, report

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -440,6 +440,55 @@ test_name = "nccl_test_all_reduce"
 time_limit = "00:20:00"
 ```
 
+## Downloading DeepSeek Weights
+To run DeepSeek R1 tests in CloudAI, you must download the model weights in advance. These weights are distributed via the NVIDIA NGC Registry and must be manually downloaded using the NGC CLI.
+
+### Step 1: Install NGC CLI
+Download and install the NGC CLI using the following commands:
+
+```bash
+wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/3.64.2/files/ngccli_linux.zip -O ngccli_linux.zip
+unzip ngccli_linux.zip
+chmod u+x ngc-cli/ngc
+echo "export PATH=\"$PATH:$(pwd)/ngc-cli\"" >> ~/.bash_profile && source ~/.bash_profile
+```
+
+This will make the `ngc` command available in your terminal.
+
+### Step 2: Configure NGC CLI
+Authenticate your CLI with your NGC API key by running:
+
+```bash
+ngc config set
+```
+
+When prompted, paste your API key, which you can obtain from [https://org.ngc.nvidia.com/setup](https://org.ngc.nvidia.com/setup).
+
+### Step 3: Download the Weights
+Navigate to the directory where you want the DeepSeek model weights to be stored, then run:
+
+```bash
+ngc registry model download-version nim/deepseek-ai/deepseek-r1-instruct:hf-5dde110-nim-fp8 --dest .
+```
+
+This command will create a folder named:
+
+```
+deepseek-r1-instruct_vhf-5dde110-nim-fp8/
+```
+
+inside your current directory.
+
+### Step 4: Verify the Download
+Ensure the full model has been downloaded by checking the folder size:
+
+```bash
+du -sh deepseek-r1-instruct_vhf-5dde110-nim-fp8
+```
+
+The expected size is approximately 642 GB. If it’s significantly smaller, remove the folder and re-run the download.
+
+
 ## Slurm specifics
 
 ### Extra srun and sbatch arguments

--- a/src/cloudai/__init__.py
+++ b/src/cloudai/__init__.py
@@ -74,6 +74,11 @@ from .workloads.common import (
     SlurmJobIdRetrievalStrategy,
     StandaloneJobIdRetrievalStrategy,
 )
+from .workloads.deepseek_r1 import (
+    DeepSeekR1ReportGenerationStrategy,
+    DeepSeekR1SlurmCommandGenStrategy,
+    DeepSeekR1TestDefinition,
+)
 from .workloads.jax_toolbox import (
     GPTTestDefinition,
     GrokTestDefinition,
@@ -109,6 +114,11 @@ from .workloads.nemo_run import (
     NeMoRunReportGenerationStrategy,
     NeMoRunSlurmCommandGenStrategy,
     NeMoRunTestDefinition,
+)
+from .workloads.nim import (
+    NimReportGenerationStrategy,
+    NimSlurmCommandGenStrategy,
+    NimTestDefinition,
 )
 from .workloads.sleep import (
     SleepGradingStrategy,
@@ -190,6 +200,8 @@ Registry().add_strategy(
         NeMoRunTestDefinition,
         SlurmContainerTestDefinition,
         MegatronRunTestDefinition,
+        NimTestDefinition,
+        DeepSeekR1TestDefinition,
     ],
     SlurmJobIdRetrievalStrategy,
 )
@@ -227,6 +239,8 @@ Registry().add_strategy(
         NeMoRunTestDefinition,
         SlurmContainerTestDefinition,
         MegatronRunTestDefinition,
+        NimTestDefinition,
+        DeepSeekR1TestDefinition,
     ],
     DefaultJobStatusRetrievalStrategy,
 )
@@ -252,6 +266,10 @@ Registry().add_strategy(
 Registry().add_strategy(
     CommandGenStrategy, [SlurmSystem], [SlurmContainerTestDefinition], SlurmContainerCommandGenStrategy
 )
+Registry().add_strategy(CommandGenStrategy, [SlurmSystem], [NimTestDefinition], NimSlurmCommandGenStrategy)
+Registry().add_strategy(
+    CommandGenStrategy, [SlurmSystem], [DeepSeekR1TestDefinition], DeepSeekR1SlurmCommandGenStrategy
+)
 
 Registry().add_installer("slurm", SlurmInstaller)
 Registry().add_installer("standalone", StandaloneInstaller)
@@ -276,7 +294,8 @@ Registry().add_test_definition("JaxToolboxGrok", GrokTestDefinition)
 Registry().add_test_definition("JaxToolboxNemotron", NemotronTestDefinition)
 Registry().add_test_definition("SlurmContainer", SlurmContainerTestDefinition)
 Registry().add_test_definition("MegatronRun", MegatronRunTestDefinition)
-
+Registry().add_test_definition("NIM", NimTestDefinition)
+Registry().add_test_definition("DeepSeekR1", DeepSeekR1TestDefinition)
 Registry().add_agent("grid_search", GridSearchAgent)
 
 Registry().add_report(ChakraReplayTestDefinition, ChakraReplayReportGenerationStrategy)
@@ -291,6 +310,8 @@ Registry().add_report(NemotronTestDefinition, JaxToolboxReportGenerationStrategy
 Registry().add_report(SleepTestDefinition, SleepReportGenerationStrategy)
 Registry().add_report(SlurmContainerTestDefinition, SlurmContainerReportGenerationStrategy)
 Registry().add_report(UCCTestDefinition, UCCTestReportGenerationStrategy)
+Registry().add_report(NimTestDefinition, NimReportGenerationStrategy)
+Registry().add_report(DeepSeekR1TestDefinition, DeepSeekR1ReportGenerationStrategy)
 
 Registry().add_scenario_report(PerTestReporter)
 Registry().add_scenario_report(StatusReporter)

--- a/src/cloudai/workloads/deepseek_r1/__init__.py
+++ b/src/cloudai/workloads/deepseek_r1/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .deepseek_r1 import DeepSeekR1CmdArgs, DeepSeekR1TestDefinition
+from .report_generation_strategy import DeepSeekR1ReportGenerationStrategy
+from .slurm_command_gen_strategy import DeepSeekR1SlurmCommandGenStrategy
+
+__all__ = [
+    "DeepSeekR1CmdArgs",
+    "DeepSeekR1ReportGenerationStrategy",
+    "DeepSeekR1SlurmCommandGenStrategy",
+    "DeepSeekR1TestDefinition",
+]

--- a/src/cloudai/workloads/deepseek_r1/deepseek_r1.py
+++ b/src/cloudai/workloads/deepseek_r1/deepseek_r1.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from cloudai import CmdArgs, DockerImage, Installable, TestDefinition
+
+
+class DeepSeekR1CmdArgs(CmdArgs):
+    """DeepSeekR1 test command arguments."""
+
+    docker_image_url: str = "nvcr.io/nim/deepseek-ai/deepseek-r1:1.7.2"
+
+
+class DeepSeekR1TestDefinition(TestDefinition):
+    """Test object for DeepSeekR1."""
+
+    cmd_args: DeepSeekR1CmdArgs
+    _docker_image: Optional[DockerImage] = None
+
+    @property
+    def docker_image(self) -> DockerImage:
+        if not self._docker_image:
+            self._docker_image = DockerImage(url=self.cmd_args.docker_image_url)
+        return self._docker_image
+
+    @property
+    def installables(self) -> list[Installable]:
+        return [self.docker_image]

--- a/src/cloudai/workloads/deepseek_r1/report_generation_strategy.py
+++ b/src/cloudai/workloads/deepseek_r1/report_generation_strategy.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudai import ReportGenerationStrategy
+
+
+class DeepSeekR1ReportGenerationStrategy(ReportGenerationStrategy):
+    """Report generation strategy for DeepSeekR1."""
+
+    def can_handle_directory(self) -> bool:
+        return False
+
+    def generate_report(self) -> None:
+        pass

--- a/src/cloudai/workloads/deepseek_r1/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/deepseek_r1/slurm_command_gen_strategy.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union, cast
+
+from cloudai import TestRun
+from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
+
+from .deepseek_r1 import DeepSeekR1TestDefinition
+
+
+class DeepSeekR1SlurmCommandGenStrategy(SlurmCommandGenStrategy):
+    """Command generation strategy for DeepSeekR1."""
+
+    def _container_mounts(self, tr: TestRun) -> List[str]:
+        tdef: DeepSeekR1TestDefinition = cast(DeepSeekR1TestDefinition, tr.test.test_definition)
+        model_name = tdef.extra_env_vars.get("NIM_MODEL_NAME")
+
+        if not isinstance(model_name, str) or not model_name.strip():
+            return []
+
+        host_path = Path(model_name)
+        if not host_path.is_dir():
+            raise FileNotFoundError(f"Model directory not found at: {host_path}")
+
+        return [f"{model_name}:{model_name}:ro"]
+
+    def _parse_slurm_args(
+        self,
+        job_name_prefix: str,
+        env_vars: Dict[str, Union[str, List[str]]],
+        cmd_args: Dict[str, Union[str, List[str]]],
+        tr: TestRun,
+    ) -> Dict[str, Any]:
+        base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
+
+        tdef: DeepSeekR1TestDefinition = cast(DeepSeekR1TestDefinition, tr.test.test_definition)
+        base_args.update({"image_path": tdef.docker_image.installed_path})
+
+        return base_args
+
+    def _append_sbatch_directives(
+        self, batch_script_content: List[str], args: Dict[str, Any], output_path: Path
+    ) -> None:
+        super()._append_sbatch_directives(batch_script_content, args, output_path)
+
+        batch_script_content.append("export HEAD_NODE=$SLURM_JOB_MASTER_NODE")
+        batch_script_content.append("export NIM_LEADER_IP_ADDRESS=$SLURM_JOB_MASTER_NODE")
+        batch_script_content.append(f"export NIM_NUM_COMPUTE_NODES={args['num_nodes']}")
+
+        ngc_api_key = self._read_ngc_api_key()
+        if ngc_api_key:
+            batch_script_content.append(f"export NGC_API_KEY={ngc_api_key}")
+        else:
+            batch_script_content.append("echo 'WARNING: Failed to load NGC API key'")
+
+    def _read_ngc_api_key(self) -> Optional[str]:
+        credentials_path = Path.home() / ".config" / "enroot" / ".credentials"
+        if not credentials_path.exists():
+            return None
+
+        try:
+            with credentials_path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("machine nvcr.io"):
+                        parts = line.strip().split()
+                        if "password" in parts:
+                            idx = parts.index("password")
+                            if idx + 1 < len(parts):
+                                return parts[idx + 1]
+        except Exception:
+            return None
+
+        return None
+
+    def generate_test_command(
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+    ) -> List[str]:
+        return ["/opt/nim/start_server.sh"]

--- a/src/cloudai/workloads/nim/__init__.py
+++ b/src/cloudai/workloads/nim/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .nim import NimCmdArgs, NimTestDefinition
+from .report_generation_strategy import NimReportGenerationStrategy
+from .slurm_command_gen_strategy import NimSlurmCommandGenStrategy
+
+__all__ = [
+    "NimCmdArgs",
+    "NimReportGenerationStrategy",
+    "NimSlurmCommandGenStrategy",
+    "NimTestDefinition",
+]

--- a/src/cloudai/workloads/nim/nim.py
+++ b/src/cloudai/workloads/nim/nim.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal, Optional
+
+from cloudai import CmdArgs, DockerImage, Installable, TestDefinition
+
+
+class NimCmdArgs(CmdArgs):
+    """NIM test command arguments."""
+
+    docker_image_url: str = "nvcr.io/nvidia/tritonserver:25.01-py3-sdk"
+    served_model_name: str
+    endpoint_type: Literal["chat"] = "chat"
+    service_kind: Literal["openai"] = "openai"
+    streaming: bool = True
+    leader_ip: str
+    port: int = 8000
+    num_prompts: int = 20
+    input_sequence_length: int = 128
+    output_sequence_length: int = 128
+    concurrency: int = 1
+    tokenizer: str
+
+
+class NimTestDefinition(TestDefinition):
+    """Test object for Nim."""
+
+    cmd_args: NimCmdArgs
+    _docker_image: Optional[DockerImage] = None
+
+    @property
+    def docker_image(self) -> DockerImage:
+        if not self._docker_image:
+            self._docker_image = DockerImage(url=self.cmd_args.docker_image_url)
+        return self._docker_image
+
+    @property
+    def installables(self) -> list[Installable]:
+        return [self.docker_image]

--- a/src/cloudai/workloads/nim/report_generation_strategy.py
+++ b/src/cloudai/workloads/nim/report_generation_strategy.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudai import ReportGenerationStrategy
+
+
+class NimReportGenerationStrategy(ReportGenerationStrategy):
+    """Report generation strategy for NIM."""
+
+    def can_handle_directory(self) -> bool:
+        return False
+
+    def generate_report(self) -> None:
+        pass

--- a/src/cloudai/workloads/nim/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nim/slurm_command_gen_strategy.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Union, cast
+
+from cloudai import TestRun
+from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
+
+from .nim import NimTestDefinition
+
+
+class NimSlurmCommandGenStrategy(SlurmCommandGenStrategy):
+    """Command generation strategy for NIM."""
+
+    def _container_mounts(self, tr: TestRun) -> List[str]:
+        return []
+
+    def _parse_slurm_args(
+        self,
+        job_name_prefix: str,
+        env_vars: Dict[str, Union[str, List[str]]],
+        cmd_args: Dict[str, Union[str, List[str]]],
+        tr: TestRun,
+    ) -> Dict[str, Any]:
+        base_args = super()._parse_slurm_args(job_name_prefix, env_vars, cmd_args, tr)
+
+        tdef: NimTestDefinition = cast(NimTestDefinition, tr.test.test_definition)
+        base_args.update({"image_path": tdef.docker_image.installed_path})
+
+        return base_args
+
+    def generate_test_command(
+        self,
+        env_vars: dict[str, Union[str, List[str]]],
+        cmd_args: dict[str, Union[str, List[str]]],
+        tr: TestRun,
+    ) -> List[str]:
+        test_definition = cast(NimTestDefinition, tr.test.test_definition)
+        args = test_definition.cmd_args
+
+        command = [
+            "genai-perf",
+            "profile",
+            "-m",
+            args.served_model_name,
+            "--endpoint-type",
+            args.endpoint_type,
+            "--service-kind",
+            args.service_kind,
+        ]
+
+        if args.streaming:
+            command.append("--streaming")
+
+        command += [
+            "-u",
+            f"{args.leader_ip}:{args.port}",
+            "--num-prompts",
+            str(args.num_prompts),
+            "--synthetic-input-tokens-mean",
+            str(args.input_sequence_length),
+            "--synthetic-input-tokens-stddev",
+            "0",
+            "--concurrency",
+            str(args.concurrency),
+            "--output-tokens-mean",
+            str(args.output_sequence_length),
+            "--extra-inputs",
+            f"max_tokens:{args.output_sequence_length}",
+            "--extra-inputs",
+            f"min_tokens:{args.output_sequence_length}",
+            "--extra-inputs",
+            "ignore_eos:true",
+            "--artifact-dir",
+            "/cloudai_run_results",
+            "--tokenizer",
+            args.tokenizer,
+            "--",
+            "-v",
+            f"--max-threads {args.concurrency}",
+            f"--request-count {args.num_prompts}",
+        ]
+
+        return command

--- a/tests/slurm_command_gen_strategy/test_deepseek_r1_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_deepseek_r1_slurm_command_gen_strategy.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import List
+from unittest.mock import Mock
+
+import pytest
+
+from cloudai._core.test import Test
+from cloudai._core.test_scenario import TestRun
+from cloudai.systems import SlurmSystem
+from cloudai.workloads.deepseek_r1 import (
+    DeepSeekR1CmdArgs,
+    DeepSeekR1SlurmCommandGenStrategy,
+    DeepSeekR1TestDefinition,
+)
+
+
+@pytest.fixture
+def cmd_gen_strategy(slurm_system: SlurmSystem) -> DeepSeekR1SlurmCommandGenStrategy:
+    return DeepSeekR1SlurmCommandGenStrategy(slurm_system, {})
+
+
+@pytest.mark.parametrize(
+    ("num_nodes", "nodes"),
+    [
+        (1, ["nodeA"]),
+        (3, ["n1", "n2", "n3"]),
+    ],
+)
+def test_parse_slurm_args_includes_image_path(
+    cmd_gen_strategy: DeepSeekR1SlurmCommandGenStrategy,
+    num_nodes: int,
+    nodes: List[str],
+) -> None:
+    cmd_args = DeepSeekR1CmdArgs()
+    tdef = DeepSeekR1TestDefinition(
+        name="dsr1",
+        description="desc",
+        test_template_name="tt",
+        cmd_args=cmd_args,
+        extra_env_vars={},
+    )
+    test = Test(test_definition=tdef, test_template=Mock())
+    tr = TestRun(name="run", test=test, nodes=nodes, num_nodes=num_nodes)
+    base_args = cmd_gen_strategy._parse_slurm_args("dsr1", {}, {}, tr)
+    assert base_args["image_path"] == tdef.docker_image.installed_path
+
+
+def test_append_sbatch_directives_no_credentials(
+    tmp_path: Path,
+    cmd_gen_strategy: DeepSeekR1SlurmCommandGenStrategy,
+) -> None:
+    os.environ["HOME"] = str(tmp_path / "home")
+    batch_lines: List[str] = []
+    args = {"num_nodes": 2, "node_list_str": ""}
+    cmd_gen_strategy._append_sbatch_directives(batch_lines, args, output_path=Path("/out"))
+    assert "export HEAD_NODE=$SLURM_JOB_MASTER_NODE" in batch_lines
+    assert "export NIM_LEADER_IP_ADDRESS=$SLURM_JOB_MASTER_NODE" in batch_lines
+    assert "export NIM_NUM_COMPUTE_NODES=2" in batch_lines
+    assert any("WARNING: Failed to load NGC API key" in line for line in batch_lines)
+
+
+def test_append_sbatch_directives_with_credentials(
+    tmp_path: Path,
+    cmd_gen_strategy: DeepSeekR1SlurmCommandGenStrategy,
+) -> None:
+    cred_dir = tmp_path / "home" / ".config" / "enroot"
+    cred_dir.mkdir(parents=True, exist_ok=True)
+    (cred_dir / ".credentials").write_text("machine nvcr.io login user password SECRET")
+    os.environ["HOME"] = str(tmp_path / "home")
+    batch_lines: List[str] = []
+    args = {"num_nodes": 5, "node_list_str": ""}
+    cmd_gen_strategy._append_sbatch_directives(batch_lines, args, output_path=Path("/out"))
+    assert "export NGC_API_KEY=SECRET" in batch_lines
+
+
+def test_generate_test_command_returns_startup_script(
+    cmd_gen_strategy: DeepSeekR1SlurmCommandGenStrategy,
+) -> None:
+    result = cmd_gen_strategy.generate_test_command({}, {}, Mock())
+    assert result == ["/opt/nim/start_server.sh"]

--- a/tests/slurm_command_gen_strategy/test_nim_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nim_slurm_command_gen_strategy.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+
+import pytest
+
+from cloudai._core.test import Test
+from cloudai._core.test_scenario import TestRun
+from cloudai.systems import SlurmSystem
+from cloudai.workloads.nim import NimCmdArgs, NimSlurmCommandGenStrategy, NimTestDefinition
+
+
+@pytest.fixture
+def strategy(slurm_system: SlurmSystem) -> NimSlurmCommandGenStrategy:
+    return NimSlurmCommandGenStrategy(slurm_system, {})
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        (
+            {
+                "served_model_name": "model",
+                "leader_ip": "10.0.0.1",
+                "tokenizer": "tok",
+            },
+            [
+                "genai-perf",
+                "profile",
+                "-m",
+                "model",
+                "--endpoint-type",
+                "chat",
+                "--service-kind",
+                "openai",
+                "--streaming",
+                "-u",
+                "10.0.0.1:8000",
+                "--num-prompts",
+                "20",
+                "--synthetic-input-tokens-mean",
+                "128",
+                "--synthetic-input-tokens-stddev",
+                "0",
+                "--concurrency",
+                "1",
+                "--output-tokens-mean",
+                "128",
+                "--extra-inputs",
+                "max_tokens:128",
+                "--extra-inputs",
+                "min_tokens:128",
+                "--extra-inputs",
+                "ignore_eos:true",
+                "--artifact-dir",
+                "/cloudai_run_results",
+                "--tokenizer",
+                "tok",
+                "--",
+                "-v",
+                "--max-threads=1",
+                "--request-count=20",
+            ],
+        )
+    ],
+)
+def test_default_command(strategy, kwargs, expected):
+    args = NimCmdArgs(**kwargs)
+    td = NimTestDefinition(name="nim", description="", test_template_name="", cmd_args=args)
+    tr = TestRun(name="run", test=Test(test_definition=td, test_template=Mock()), nodes=[], num_nodes=1)
+    assert strategy.generate_test_command({}, {}, tr) == expected
+
+
+def test_disable_streaming(strategy):
+    args = NimCmdArgs(
+        served_model_name="m",
+        leader_ip="1.2.3.2",
+        tokenizer="tk",
+        streaming=False,
+    )
+    td = NimTestDefinition(name="nim", description="", test_template_name="", cmd_args=args)
+    tr = TestRun(name="run", test=Test(test_definition=td, test_template=Mock()), nodes=[], num_nodes=1)
+    cmd = strategy.generate_test_command({}, {}, tr)
+    assert "--streaming" not in cmd
+
+
+def test_port_override(strategy):
+    args = NimCmdArgs(
+        served_model_name="m",
+        leader_ip="127.0.0.1",
+        port=9001,
+        tokenizer="tk",
+    )
+    td = NimTestDefinition(name="nim", description="", test_template_name="", cmd_args=args)
+    tr = TestRun(name="run", test=Test(test_definition=td, test_template=Mock()), nodes=[], num_nodes=1)
+    cmd = strategy.generate_test_command({}, {}, tr)
+    assert "-u" in cmd
+    assert "127.0.0.1:9001" in cmd

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,6 +41,10 @@ from cloudai.workloads.chakra_replay import (
 from cloudai.workloads.common import SlurmJobIdRetrievalStrategy, StandaloneJobIdRetrievalStrategy
 from cloudai.workloads.common.default_job_status_retrieval_strategy import DefaultJobStatusRetrievalStrategy
 from cloudai.workloads.common.lsf_job_id_retrieval_strategy import LSFJobIdRetrievalStrategy
+from cloudai.workloads.deepseek_r1 import (
+    DeepSeekR1SlurmCommandGenStrategy,
+    DeepSeekR1TestDefinition,
+)
 from cloudai.workloads.jax_toolbox import (
     GPTTestDefinition,
     GrokTestDefinition,
@@ -65,6 +69,10 @@ from cloudai.workloads.nemo_launcher import (
     NeMoLauncherTestDefinition,
 )
 from cloudai.workloads.nemo_run import NeMoRunSlurmCommandGenStrategy, NeMoRunTestDefinition
+from cloudai.workloads.nim import (
+    NimSlurmCommandGenStrategy,
+    NimTestDefinition,
+)
 from cloudai.workloads.sleep import (
     SleepGradingStrategy,
     SleepKubernetesJsonGenStrategy,
@@ -115,6 +123,8 @@ ALL_STRATEGIES = {
     (CommandGenStrategy, SlurmSystem, MegatronRunTestDefinition): MegatronRunSlurmCommandGenStrategy,
     (CommandGenStrategy, StandaloneSystem, SleepTestDefinition): SleepStandaloneCommandGenStrategy,
     (CommandGenStrategy, LSFSystem, SleepTestDefinition): SleepLSFCommandGenStrategy,
+    (CommandGenStrategy, SlurmSystem, NimTestDefinition): NimSlurmCommandGenStrategy,
+    (CommandGenStrategy, SlurmSystem, DeepSeekR1TestDefinition): DeepSeekR1SlurmCommandGenStrategy,
     (GradingStrategy, SlurmSystem, ChakraReplayTestDefinition): ChakraReplayGradingStrategy,
     (GradingStrategy, SlurmSystem, GPTTestDefinition): JaxToolboxGradingStrategy,
     (GradingStrategy, SlurmSystem, GrokTestDefinition): JaxToolboxGradingStrategy,
@@ -134,6 +144,8 @@ ALL_STRATEGIES = {
     (JobIdRetrievalStrategy, SlurmSystem, SlurmContainerTestDefinition): SlurmJobIdRetrievalStrategy,
     (JobIdRetrievalStrategy, SlurmSystem, UCCTestDefinition): SlurmJobIdRetrievalStrategy,
     (JobIdRetrievalStrategy, SlurmSystem, MegatronRunTestDefinition): SlurmJobIdRetrievalStrategy,
+    (JobIdRetrievalStrategy, SlurmSystem, NimTestDefinition): SlurmJobIdRetrievalStrategy,
+    (JobIdRetrievalStrategy, SlurmSystem, DeepSeekR1TestDefinition): SlurmJobIdRetrievalStrategy,
     (JobIdRetrievalStrategy, StandaloneSystem, SleepTestDefinition): StandaloneJobIdRetrievalStrategy,
     (JobIdRetrievalStrategy, LSFSystem, SleepTestDefinition): LSFJobIdRetrievalStrategy,
     (JobStatusRetrievalStrategy, KubernetesSystem, NCCLTestDefinition): DefaultJobStatusRetrievalStrategy,
@@ -149,6 +161,8 @@ ALL_STRATEGIES = {
     (JobStatusRetrievalStrategy, SlurmSystem, SlurmContainerTestDefinition): DefaultJobStatusRetrievalStrategy,
     (JobStatusRetrievalStrategy, SlurmSystem, UCCTestDefinition): DefaultJobStatusRetrievalStrategy,
     (JobStatusRetrievalStrategy, SlurmSystem, MegatronRunTestDefinition): DefaultJobStatusRetrievalStrategy,
+    (JobStatusRetrievalStrategy, SlurmSystem, NimTestDefinition): DefaultJobStatusRetrievalStrategy,
+    (JobStatusRetrievalStrategy, SlurmSystem, DeepSeekR1TestDefinition): DefaultJobStatusRetrievalStrategy,
     (JobStatusRetrievalStrategy, StandaloneSystem, SleepTestDefinition): DefaultJobStatusRetrievalStrategy,
     (JobStatusRetrievalStrategy, LSFSystem, SleepTestDefinition): DefaultJobStatusRetrievalStrategy,
     (JobStatusRetrievalStrategy, RunAISystem, NCCLTestDefinition): DefaultJobStatusRetrievalStrategy,
@@ -184,7 +198,7 @@ def test_installers():
 
 def test_definitions():
     test_defs = Registry().test_definitions_map
-    assert len(test_defs) == 11
+    assert len(test_defs) == 13
     for tdef in [
         ("UCCTest", UCCTestDefinition),
         ("NcclTest", NCCLTestDefinition),
@@ -197,6 +211,8 @@ def test_definitions():
         ("JaxToolboxNemotron", NemotronTestDefinition),
         ("SlurmContainer", SlurmContainerTestDefinition),
         ("MegatronRun", MegatronRunTestDefinition),
+        ("NIM", NimTestDefinition),
+        ("DeepSeekR1", DeepSeekR1TestDefinition),
     ]:
         assert test_defs[tdef[0]] == tdef[1]
 

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -32,6 +32,7 @@ from cloudai._core.test_scenario_parser import (
     get_reporters,
 )
 from cloudai.workloads.chakra_replay import ChakraReplayReportGenerationStrategy, ChakraReplayTestDefinition
+from cloudai.workloads.deepseek_r1 import DeepSeekR1ReportGenerationStrategy, DeepSeekR1TestDefinition
 from cloudai.workloads.jax_toolbox import (
     GPTTestDefinition,
     GrokTestDefinition,
@@ -51,6 +52,7 @@ from cloudai.workloads.nemo_run import (
     NeMoRunReportGenerationStrategy,
     NeMoRunTestDefinition,
 )
+from cloudai.workloads.nim import NimReportGenerationStrategy, NimTestDefinition
 from cloudai.workloads.sleep import SleepReportGenerationStrategy, SleepTestDefinition
 from cloudai.workloads.slurm_container import SlurmContainerReportGenerationStrategy, SlurmContainerTestDefinition
 from cloudai.workloads.ucc_test import UCCTestDefinition, UCCTestReportGenerationStrategy
@@ -287,7 +289,7 @@ class TestReporters:
         assert len(reporters) == 0
 
     def test_default_reporters_size(self):
-        assert len(Registry().reports_map) == 11
+        assert len(Registry().reports_map) == 13
 
     @pytest.mark.parametrize(
         "tdef,expected_reporters",
@@ -303,6 +305,8 @@ class TestReporters:
             (SleepTestDefinition, {SleepReportGenerationStrategy}),
             (SlurmContainerTestDefinition, {SlurmContainerReportGenerationStrategy}),
             (UCCTestDefinition, {UCCTestReportGenerationStrategy}),
+            (NimTestDefinition, {NimReportGenerationStrategy}),
+            (DeepSeekR1TestDefinition, {DeepSeekR1ReportGenerationStrategy}),
         ],
     )
     def test_custom_reporters(self, tdef: Type[TestDefinition], expected_reporters: Set[ReportGenerationStrategy]):


### PR DESCRIPTION
## Summary
Add DeepSeek-R1 support with test def, command gen, report

**TODOs**
* Download datasets
* Run servers & benchmarks in parallel.

**Design choices**
  * Separate test definition or not
    * LLMB's approach: https://gitlab-master.nvidia.com/unified-cloud-benchmarking/llm-benchmarking-collection/-/blob/25.03-dev/inf_nim/deepseek-r1/launch.sh?ref_type=heads
    * My approach: separate server / client.
  * Installation
      * Install NGC-CLI or not
      * Install weights or not
  * Run
     * Sweeping arguments in a single run
     * Passing the master node IP address.

## Test Plan
1. CI passes
2. TODO: Run on EOS
```
$ python cloudaix.py install\
    --system-config conf/staging/llmb/system/eos.toml\
    --tests-dir conf/staging/llmb/test   

$ python cloudaix.py run --system-config conf/staging/llmb/system/aws.toml\
     --tests-dir conf/staging/llmb/test\
    --test-scenario conf/staging/llmb/test_scenario/deepseek_r1.toml 
```