### PR TITLE
Correctly handle values with spaces for env vars

### DIFF
--- a/tests/ref_data/nemo-launcher.sbatch
+++ b/tests/ref_data/nemo-launcher.sbatch
@@ -1,3 +1,4 @@
+VAR="$(scontrol show hostname \"${SLURM_STEP_NODELIST}\" | head -n1)" \
 __OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022-venv/bin/python \
  __OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts/main.py \
  cluster.gpus_per_node=null \
@@ -22,4 +23,5 @@ __OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d
  container=nvcr.io/nvidia/nemo:24.12.01 \
  cluster.job_name_prefix=test_account-cloudai.nemo: \
  base_results_dir=__OUTPUT_DIR__/output \
- launcher_scripts_path=__OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts
+ launcher_scripts_path=__OUTPUT_DIR__/install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022/launcher_scripts \
+ +env_vars.VAR="$(scontrol show hostname \"${SLURM_STEP_NODELIST}\" | head -n1)"

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
@@ -66,8 +66,8 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         [
             (
                 [
-                    "TEST_VAR_1=value1",
-                    "+env_vars.TEST_VAR_1=value1",
+                    'TEST_VAR_1="value1"',
+                    '+env_vars.TEST_VAR_1="value1"',
                     'stages=["training"]',
                     "cluster.gpus_per_node=null",
                     "cluster.partition=main",
@@ -227,23 +227,13 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
 
         assert " \\\n " in written_content, "Command should contain line breaks when written to the file"
         assert "python" in written_content, "Logged command should start with 'python'"
-        assert "TEST_VAR_1=value1" in written_content, "Logged command should contain environment variables"
+        assert 'TEST_VAR_1="value1"' in written_content, "Logged command should contain environment variables"
         assert "training.trainer.num_nodes=2" in written_content, "Command should contain the number of nodes"
 
         assert str((tdef.python_executable.venv_path / "bin" / "python").absolute()) in written_content
         assert (
             f"launcher_scripts_path={(repo_path / tdef.cmd_args.launcher_script).parent.absolute()} " in written_content
         )
-
-    def test_no_line_breaks_in_executed_command(
-        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun, tmp_path: Path
-    ) -> None:
-        test_run.output_path = tmp_path / "output_dir"
-        test_run.output_path.mkdir()
-
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
-
-        assert "\n" not in cmd, "Executed command should not contain line breaks"
 
     def test_container_mounts_with_nccl_topo_file(
         self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun
@@ -262,4 +252,4 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         env: dict[str, str | list[str]] = {"VAR1": "value with spaces", "VAR2": r"$(cmd \$vv| cmd)"}
         cmd = cmd_gen_strategy._gen_env_vars_str(env)
 
-        assert cmd == 'VAR1="value with spaces" VAR2="$(cmd \\$vv| cmd)"'
+        assert cmd == 'VAR1="value with spaces" \\\nVAR2="$(cmd \\$vv| cmd)" \\\n'

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
@@ -255,3 +255,11 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
 
         expected_mount = f'container_mounts=["{nccl_topo_file_path}:{nccl_topo_file_path}"]'
         assert expected_mount in cmd
+
+    def test_env_vars_with_spaces(
+        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun
+    ) -> None:
+        env: dict[str, str | list[str]] = {"VAR1": "value with spaces", "VAR2": r"$(cmd \$vv| cmd)"}
+        cmd = cmd_gen_strategy._gen_env_vars_str(env)
+
+        assert cmd == 'VAR1="value with spaces" VAR2="$(cmd \\$vv| cmd)"'

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -206,6 +206,7 @@ def build_special_test_run(
                 description="nemo-launcher",
                 test_template_name="nemo-launcher",
                 cmd_args=NeMoLauncherCmdArgs(),
+                extra_env_vars={"VAR": r"$(scontrol show hostname \"${SLURM_STEP_NODELIST}\" | head -n1)"},
             ),
             NeMoLauncherSlurmCommandGenStrategy,
         )


### PR DESCRIPTION
## Summary
Correctly handle values with spaces for env vars.

## Test Plan
1. CI
2. Manually compare a couple of generated commands based on public configs.

## Additional Notes
—
