### PR TITLE
Verify if input path exist on argparse level

### DIFF
--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -26,6 +26,13 @@ from .handlers import (
 )
 
 
+def existing_path(filepath: str) -> Path:
+    fpath = Path(filepath)
+    if not fpath.is_file():
+        raise argparse.ArgumentTypeError(f"Path '{fpath}' does not exist.")
+    return fpath
+
+
 class CloudAICLI:
     """Command-line argument parser for CloudAI and derivatives."""
 
@@ -68,18 +75,27 @@ class CloudAICLI:
         self.handlers[name] = handler
         if system_config is not None:
             p.add_argument(
-                "--system-config", help="Path to the system configuration file.", required=system_config, type=Path
+                "--system-config",
+                help="Path to the system configuration file.",
+                required=system_config,
+                type=existing_path,
             )
         if tests_dir is not None:
             p.add_argument(
-                "--tests-dir", help="Path to the test configuration directory.", required=tests_dir, type=Path
+                "--tests-dir", help="Path to the test configuration directory.", required=tests_dir, type=existing_path
             )
         if test_scenario is not None:
-            p.add_argument("--test-scenario", help="Path to the test scenario file.", required=test_scenario, type=Path)
+            p.add_argument(
+                "--test-scenario", help="Path to the test scenario file.", required=test_scenario, type=existing_path
+            )
         if output_dir is not None:
-            p.add_argument("--output-dir", help="Path to the output directory.", required=output_dir, type=Path)
+            p.add_argument(
+                "--output-dir", help="Path to the output directory.", required=output_dir, type=existing_path
+            )
         if result_dir is not None:
-            p.add_argument("--result-dir", help="Path to the result directory.", required=result_dir, type=Path)
+            p.add_argument(
+                "--result-dir", help="Path to the result directory.", required=result_dir, type=existing_path
+            )
 
         return p
 

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -28,7 +28,7 @@ from .handlers import (
 
 def existing_path(filepath: str) -> Path:
     fpath = Path(filepath)
-    if not fpath.is_file():
+    if not fpath.exists():
         raise argparse.ArgumentTypeError(f"Path '{fpath}' does not exist.")
     return fpath
 

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -89,11 +89,11 @@ class CloudAICLI:
                 "--test-scenario", help="Path to the test scenario file.", required=test_scenario, type=existing_path
             )
         if output_dir is not None:
-            p.add_argument(
-                "--output-dir", help="Path to the output directory.", required=output_dir, type=existing_path
-            )
+            p.add_argument("--output-dir", help="Path to the output directory.", required=output_dir, type=Path)
         if result_dir is not None:
-            p.add_argument("--result-dir", help="Path to the result directory.", required=result_dir, type=Path)
+            p.add_argument(
+                "--result-dir", help="Path to the result directory.", required=result_dir, type=existing_path
+            )
 
         return p
 

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -93,9 +93,7 @@ class CloudAICLI:
                 "--output-dir", help="Path to the output directory.", required=output_dir, type=existing_path
             )
         if result_dir is not None:
-            p.add_argument(
-                "--result-dir", help="Path to the result directory.", required=result_dir, type=existing_path
-            )
+            p.add_argument("--result-dir", help="Path to the result directory.", required=result_dir, type=Path)
 
         return p
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,23 +139,23 @@ def test_add_command_all_required():
         [
             "test",
             "--system-config",
-            "system_config",
+            f"{Path(__file__)}",
             "--tests-dir",
-            "tests_dir",
+            f"{Path.cwd()}",
             "--test-scenario",
-            "test_scenario",
+            f"{Path(__file__)}",
             "--output-dir",
-            "output_dir",
+            f"{Path.cwd()}",
         ]
     )
     assert args == argparse.Namespace(
         log_file="debug.log",
         log_level="INFO",
         mode="test",
-        system_config=Path("system_config"),
-        tests_dir=Path("tests_dir"),
-        test_scenario=Path("test_scenario"),
-        output_dir=Path("output_dir"),
+        system_config=Path(__file__),
+        tests_dir=Path.cwd(),
+        test_scenario=Path(__file__),
+        output_dir=Path.cwd(),
     )
 
 
@@ -194,9 +194,9 @@ class TestCLIDefaultModes:
                 [
                     mode,
                     "--system-config",
-                    "system_config",
+                    f"{Path(__file__)}",
                     "--tests-dir",
-                    "tests_dir",
+                    f"{Path.cwd()}",
                 ]
             )
 
@@ -204,8 +204,8 @@ class TestCLIDefaultModes:
                 log_file="debug.log",
                 log_level="INFO",
                 mode=mode,
-                system_config=Path("system_config"),
-                tests_dir=Path("tests_dir"),
+                system_config=Path(__file__),
+                tests_dir=Path.cwd(),
                 test_scenario=None,
                 output_dir=None,
             )
@@ -214,12 +214,12 @@ class TestCLIDefaultModes:
         assert "verify-configs" in cli.handlers
         assert cli.handlers["verify-configs"] is handle_verify_all_configs
 
-        args = cli.parser.parse_args(["verify-configs", "--tests-dir", "tests_dir", "configs_dir"])
+        args = cli.parser.parse_args(["verify-configs", "--tests-dir", f"{Path.cwd()}", "configs_dir"])
         assert args == argparse.Namespace(
             log_file="debug.log",
             log_level="INFO",
             mode="verify-configs",
-            tests_dir=Path("tests_dir"),
+            tests_dir=Path.cwd(),
             strict=False,
             **{"configs_dir": Path("configs_dir")},
         )
@@ -242,23 +242,23 @@ class TestCLIDefaultModes:
             [
                 "generate-report",
                 "--system-config",
-                "system_config",
+                f"{Path(__file__)}",
                 "--tests-dir",
-                "tests_dir",
+                f"{Path.cwd()}",
                 "--test-scenario",
-                "test_scenario",
+                f"{Path(__file__)}",
                 "--result-dir",
-                "result_dir",
+                f"{Path.cwd()}",
             ]
         )
         assert args == argparse.Namespace(
             log_file="debug.log",
             log_level="INFO",
             mode="generate-report",
-            test_scenario=Path("test_scenario"),
-            result_dir=Path("result_dir"),
-            system_config=Path("system_config"),
-            tests_dir=Path("tests_dir"),
+            test_scenario=Path(__file__),
+            result_dir=Path.cwd(),
+            system_config=Path(__file__),
+            tests_dir=Path.cwd(),
         )
 
     def test_run_dry_run_modes(self, cli: CloudAICLI):
@@ -270,11 +270,11 @@ class TestCLIDefaultModes:
                 [
                     mode,
                     "--system-config",
-                    "system_config",
+                    f"{Path(__file__)}",
                     "--tests-dir",
-                    "tests_dir",
+                    f"{Path.cwd()}",
                     "--test-scenario",
-                    "test_scenario",
+                    f"{Path(__file__)}",
                 ]
             )
 
@@ -282,9 +282,9 @@ class TestCLIDefaultModes:
                 log_file="debug.log",
                 log_level="INFO",
                 mode=mode,
-                system_config=Path("system_config"),
-                tests_dir=Path("tests_dir"),
-                test_scenario=Path("test_scenario"),
+                system_config=Path(__file__),
+                tests_dir=Path.cwd(),
+                test_scenario=Path(__file__),
                 output_dir=None,
                 enable_cache_without_check=False,
             )
@@ -306,9 +306,9 @@ class TestCLIDefaultModes:
         self, mode_and_missing_options: tuple[str, list[str]], cli: CloudAICLI, capsys: pytest.CaptureFixture[str]
     ):
         opts = {
-            "--system-config": "system_config",
-            "--tests-dir": "tests_dir",
-            "--test-scenario": "test_scenario",
+            "--system-config": f"{Path(__file__)}",
+            "--tests-dir": f"{Path.cwd()}",
+            "--test-scenario": f"{Path(__file__)}",
             "--output-dir": "output_dir",
         }
         mode, missing_options = mode_and_missing_options

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,7 +145,7 @@ def test_add_command_all_required():
             "--test-scenario",
             f"{Path(__file__)}",
             "--output-dir",
-            f"{Path.cwd()}",
+            "output_dir",
         ]
     )
     assert args == argparse.Namespace(
@@ -155,7 +155,7 @@ def test_add_command_all_required():
         system_config=Path(__file__),
         tests_dir=Path.cwd(),
         test_scenario=Path(__file__),
-        output_dir=Path.cwd(),
+        output_dir=Path("output_dir"),
     )
 
 


### PR DESCRIPTION
## Summary
Verify if input path exist on argparse level. It improves the feedback speed and makes error more readable.

Now:
```bash
$ cloudai dry-run --system-config conf/common/system/example_slurm_cluster.tomll --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nemo_launcher.tomll
usage: cloudai dry-run [-h] --system-config SYSTEM_CONFIG --tests-dir TESTS_DIR --test-scenario TEST_SCENARIO [--output-dir OUTPUT_DIR] [--enable-cache-without-check]
cloudai dry-run: error: argument --system-config: Path 'conf/common/system/example_slurm_cluster.tomll' does not exist.
```

Before:
```bash
$ cloudai dry-run --system-config conf/common/system/example_slurm_cluster.tomll --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nemo_launcher.tomll
Traceback (most recent call last):
  File "/Users/andreyma/workspace/nvidia/cloudai/.venv/bin/cloudai", line 8, in <module>
    sys.exit(main())
  File "/Users/andreyma/workspace/nvidia/cloudai/src/cloudai/__main__.py", line 24, in main
    rc = cloudai_cli.run()
  File "/Users/andreyma/workspace/nvidia/cloudai/src/cloudai/cli/cli.py", line 162, in run
    return self.handlers[args.mode](args)
  File "/Users/andreyma/workspace/nvidia/cloudai/src/cloudai/cli/handlers.py", line 156, in handle_dry_run_and_run
    system, tests, test_scenario = parser.parse(args.tests_dir, args.test_scenario)
  File "/Users/andreyma/workspace/nvidia/cloudai/src/cloudai/parser.py", line 75, in parse
    system = self.parse_system(self.system_config_path)
  File "/Users/andreyma/workspace/nvidia/cloudai/src/cloudai/parser.py", line 154, in parse_system
    with Path(system_config_path).open() as f:
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/pathlib.py", line 1117, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
FileNotFoundError: [Errno 2] No such file or directory: 'conf/common/system/example_slurm_cluster.tomll'
```

## Test Plan
1. CI
2. Manual dry-run for non-existing files: system, tests dir, scenario.

## Additional Notes
—
