### PR TITLE
Apply style to scenario report

### DIFF
--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -65,15 +65,22 @@ class SlurmReportItem:
 
     @classmethod
     def get_metadata(cls, run_dir: Path) -> Optional[SlurmSystemMetadata]:
-        if (run_dir / "metadata").exists():
-            node_files = list(run_dir.glob("metadata/node-*.toml"))
-            if node_files:
-                node_file = node_files[0]
-                with node_file.open() as f:
-                    try:
-                        return SlurmSystemMetadata.model_validate(toml.load(f))
-                    except Exception as e:
-                        logging.debug(f"Error validating metadata for {node_file}: {e}")
+        if not (run_dir / "metadata").exists():
+            logging.debug(f"No metadata folder found in {run_dir}")
+            return None
+
+        node_files = list(run_dir.glob("metadata/node-*.toml"))
+        if not node_files:
+            logging.debug(f"No node files found in {run_dir}/metadata")
+            return None
+
+        node_file = node_files[0]
+        with node_file.open() as f:
+            try:
+                return SlurmSystemMetadata.model_validate(toml.load(f))
+            except Exception as e:
+                logging.debug(f"Error validating metadata for {node_file}: {e}")
+
         return None
 
     @classmethod

--- a/src/cloudai/util/base-report.jinja2
+++ b/src/cloudai/util/base-report.jinja2
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{ name }}</title>
+        <style>
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+                line-height: 1.6;
+                max-width: 1200px;
+                margin: 0;
+                padding: 2rem;
+                color: #333;
+            }
+            h1 {
+                color: #2c3e50;
+                border-bottom: 2px solid #eee;
+                padding-bottom: 0.5rem;
+                margin-bottom: 2rem;
+            }
+            h2 {
+                color: #2c3e50;
+                margin-top: 2rem;
+                margin-bottom: 1rem;
+            }
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 1rem;
+                box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            }
+            th, td {
+                padding: 12px 15px;
+                text-align: left;
+                border-bottom: 1px solid #eee;
+            }
+            th {
+                background-color: #f8f9fa;
+                font-weight: 600;
+            }
+            tr:hover {
+                background-color: #f8f9fa;
+            }
+            a {
+                color: #3498db;
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+        </style>
+        {% block extra_head %}{% endblock %}
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+        {% block content %}{% endblock %}
+    </body>
+</html>

--- a/src/cloudai/util/general-report.jinja2
+++ b/src/cloudai/util/general-report.jinja2
@@ -1,26 +1,22 @@
-<html>
-    <head>
-        <title>{{ name }}</title>
-    </head>
-    <body>
-        <h1>{{ name }}</h1>
-    </body>
-    <table>
-        <tr>
-            <th>Test</th>
-            <th>Description</th>
-            <th>Results</th>
-        </tr>
-        {% for item in report_items %}
-        <tr>
-            <td>{{ item.name }}</td>
-            <td>{{ item.description }}</td>
-            {% if item.logs_path %}
-                <td><a href="{{ item.logs_path }}">logs</a></td>
-            {% else %}
+{% extends "base-report.jinja2" %}
+
+{% block content %}
+<table>
+    <tr>
+        <th>Test</th>
+        <th>Description</th>
+        <th>Results</th>
+    </tr>
+    {% for item in report_items %}
+    <tr>
+        <td>{{ item.name }}</td>
+        <td>{{ item.description }}</td>
+        {% if item.logs_path %}
+            <td><a href="{{ item.logs_path }}">logs</a></td>
+        {% else %}
             <td>no logs</td>
-            {% endif %}
-        </tr>
-        {% endfor %}
-    </table>
-</html>
+        {% endif %}
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}

--- a/src/cloudai/util/general-slurm-report.jinja2
+++ b/src/cloudai/util/general-slurm-report.jinja2
@@ -1,28 +1,24 @@
-<html>
-    <head>
-        <title>{{ name }}</title>
-    </head>
-    <body>
-        <h1>{{ name }}</h1>
-    </body>
-    <table>
-        <tr>
-            <th>Test</th>
-            <th>Description</th>
-            <th>Results</th>
-            <th>Nodes</th>
-        </tr>
-        {% for item in report_items %}
-        <tr>
-            <td>{{ item.name }}</td>
-            <td>{{ item.description }}</td>
-            {% if item.logs_path %}
-                <td><a href="{{ item.logs_path }}">logs</a></td>
-            {% else %}
+{% extends "base-report.jinja2" %}
+
+{% block content %}
+<table>
+    <tr>
+        <th>Test</th>
+        <th>Description</th>
+        <th>Results</th>
+        <th>Nodes</th>
+    </tr>
+    {% for item in report_items %}
+    <tr>
+        <td>{{ item.name }}</td>
+        <td>{{ item.description }}</td>
+        {% if item.logs_path %}
+            <td><a href="{{ item.logs_path }}">logs</a></td>
+        {% else %}
             <td>no logs</td>
-            {% endif %}
-            <td>{{ item.nodes }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-</html>
+        {% endif %}
+        <td>{{ item.nodes }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
Apply style to scenario report. Also extended logging while metadata is collected.

New report looks like this:
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/e19d6e09-bb6c-40e9-b6d5-16852b74ca15" />

## Test Plan
1. CI
2. Manual runs of `generate-report`.

## Additional Notes
—
