### PR TITLE
Update MegatronRun model dump logic

### DIFF
--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -28,8 +28,8 @@ from ...models.workload import CmdArgs, TestDefinition
 class MegatronRunCmdArgs(CmdArgs):
     """MegatronRun test command arguments."""
 
-    docker_image_url: str = Field(exclude=True)
-    run_script: Path = Field(exclude=True)
+    docker_image_url: str = Field()
+    run_script: Path = Field()
 
     global_batch_size: Optional[int] = 16
     hidden_size: Optional[int] = 4096
@@ -65,7 +65,7 @@ class MegatronRunCmdArgs(CmdArgs):
 
     @property
     def cmd_args(self) -> dict[str, Union[str, list[str]]]:
-        args = self.model_dump(exclude_none=True)
+        args = self.model_dump(exclude_none=True, exclude={"docker_image_url", "run_script"})
         args = {f"--{k.replace('_', '-')}": v for k, v in args.items()}
         return args
 

--- a/tests/test_test_definitions.py
+++ b/tests/test_test_definitions.py
@@ -291,11 +291,6 @@ class TestMegatronRun:
         assert megatron_run.cmd_args_dict["--tokenizer-model"] == Path("/path/to/tokenizer")
         assert megatron_run.cmd_args.tokenizer_model == Path("/path/to/tokenizer")
 
-    def test_auxiliary_fields_not_in_model_dump(self, megatron_run: MegatronRunTestDefinition):
-        d = megatron_run.cmd_args.model_dump()
-        assert "docker_image_url" not in d
-        assert "run_script" not in d
-
     @pytest.mark.parametrize("field", ["load", "save"])
     def test_load_is_set_but_not_mounted(self, field: str):
         with pytest.raises(ValueError) as exc_info:

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -47,6 +47,7 @@ from cloudai.workloads.jax_toolbox import (
     NemotronTestDefinition,
 )
 from cloudai.workloads.megatron_run import CheckpointTimingReportGenerationStrategy, MegatronRunTestDefinition
+from cloudai.workloads.megatron_run.megatron_run import MegatronRunCmdArgs
 from cloudai.workloads.nccl_test import (
     NCCLCmdArgs,
     NCCLTestDefinition,
@@ -412,6 +413,7 @@ class TestSpec:
         )
         _, tdef = test_scenario_parser._prepare_tdef(model.tests[0])
         assert tdef.cmd_args_dict["unknown"] == 42
+        assert isinstance(tdef.cmd_args, NCCLCmdArgs)
 
 
 class TestReporters:

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -47,7 +47,6 @@ from cloudai.workloads.jax_toolbox import (
     NemotronTestDefinition,
 )
 from cloudai.workloads.megatron_run import CheckpointTimingReportGenerationStrategy, MegatronRunTestDefinition
-from cloudai.workloads.megatron_run.megatron_run import MegatronRunCmdArgs
 from cloudai.workloads.nccl_test import (
     NCCLCmdArgs,
     NCCLTestDefinition,


### PR DESCRIPTION
## Summary
`model_dump()` should include all fields, otherwise construction test with TestScenarion won't be possible.

**NOTE**: this should be a temp solution, going forward we need to find away to remove this limitation.

## Test Plan
1. CI
2. Internal slack [channel](https://nvidia.slack.com/archives/C06LC3PRHDZ/p1746910981915689).

## Additional Notes
—
