### PR TITLE
Store test details and best config for DSE

### DIFF
--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -102,6 +102,8 @@ class BaseRunner(ABC):
             tr (TestRun): The test to be started.
         """
         logging.info(f"Starting test: {tr.name}")
+        tr.output_path = self.get_job_output_path(tr)
+        await self.job_submit_callback(tr)
         try:
             job = self._submit_test(tr)
             self.jobs.append(job)
@@ -109,6 +111,10 @@ class BaseRunner(ABC):
         except JobSubmissionError as e:
             logging.error(e)
             exit(1)
+
+    async def job_submit_callback(self, tr: TestRun) -> None:
+        cmd_gen = tr.test.test_template.command_gen_strategy
+        cmd_gen.store_test_run(tr)
 
     async def delayed_submit_test(self, tr: TestRun, delay: int = 5):
         """

--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -23,6 +23,8 @@ from .test_template_strategy import TestTemplateStrategy
 class CommandGenStrategy(TestTemplateStrategy, ABC):
     """Abstract base class defining the interface for command generation strategies across different systems."""
 
+    TEST_RUN_DUMP_FILE_NAME: str = "test-run.toml"
+
     @abstractmethod
     def gen_exec_command(self, tr: TestRun) -> str:
         """
@@ -33,5 +35,17 @@ class CommandGenStrategy(TestTemplateStrategy, ABC):
 
         Returns:
             str: The generated execution command.
+        """
+        pass
+
+    @abstractmethod
+    def store_test_run(self, tr: TestRun) -> None:
+        """
+        Store the test run information in output folder.
+
+        Only at command generation time, CloudAI has all the information to store the test run.
+
+        Args:
+            tr (TestRun): The test run object to be stored.
         """
         pass

--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -161,6 +161,9 @@ class StatusReporter(Reporter):
             return "general-slurm-report.jinja2"
         return "general-report.jinja2"
 
+    def best_dse_config_file_name(self, tr: TestRun) -> str:
+        return "{tr.name}.toml"
+
     def generate(self) -> None:
         self.load_test_runs()
         self.generate_scenario_report()
@@ -200,9 +203,10 @@ class StatusReporter(Reporter):
             with best_step_details.open() as f:
                 trd = TestRunDetails.model_validate(toml.load(f))
 
-            with (tr_root / "best-config.toml").open("w") as f:
+            best_config_path = tr_root / self.best_dse_config_file_name(tr)
+            logging.info(f"Writing best config for {tr.name} to {best_config_path}")
+            with best_config_path.open("w") as f:
                 toml.dump(trd.test_definition.model_dump(), f)
-                logging.info(f"Wrote best config for {tr.name} to {self.results_root / tr.name / 'best-config.toml'}")
 
 
 class TarballReporter(Reporter):

--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -164,6 +164,7 @@ class StatusReporter(Reporter):
     def generate(self) -> None:
         self.load_test_runs()
         self.generate_scenario_report()
+        self.report_best_dse_config()
 
     def generate_scenario_report(self) -> None:
         template = jinja2.Environment(
@@ -199,8 +200,9 @@ class StatusReporter(Reporter):
             with best_step_details.open() as f:
                 trd = TestRunDetails.model_validate(toml.load(f))
 
-            with (self.results_root / tr.name / "best-config.toml").open("w") as f:
+            with (tr_root / "best-config.toml").open("w") as f:
                 toml.dump(trd.test_definition.model_dump(), f)
+                logging.info(f"Wrote best config for {tr.name} to {self.results_root / tr.name / 'best-config.toml'}")
 
 
 class TarballReporter(Reporter):

--- a/src/cloudai/_core/reporter.py
+++ b/src/cloudai/_core/reporter.py
@@ -23,10 +23,13 @@ from pathlib import Path
 from typing import Optional
 
 import jinja2
+import pandas as pd
 import toml
 
+from ..models.scenario import TestRunDetails
 from ..systems.slurm.metadata import SlurmSystemMetadata
 from ..systems.slurm.slurm_system import SlurmSystem
+from .command_gen_strategy import CommandGenStrategy
 from .system import System
 from .test_scenario import TestRun, TestScenario
 
@@ -178,6 +181,26 @@ class StatusReporter(Reporter):
             f.write(report)
 
         logging.info(f"Generated scenario report at {report_path}")
+
+    def report_best_dse_config(self):
+        for tr in self.test_scenario.test_runs:
+            if not tr.test.test_definition.is_dse_job:
+                continue
+
+            tr_root = self.results_root / tr.name / f"{tr.current_iteration}"
+            trajectory_file = tr_root / "trajectory.csv"
+            if not trajectory_file.exists():
+                logging.warning(f"No trajectory file found for {tr.name} at {trajectory_file}")
+                continue
+
+            df = pd.read_csv(trajectory_file)
+            best_step = df.loc[df["reward"].idxmax()]["step"]
+            best_step_details = tr_root / f"{best_step}" / CommandGenStrategy.TEST_RUN_DUMP_FILE_NAME
+            with best_step_details.open() as f:
+                trd = TestRunDetails.model_validate(toml.load(f))
+
+            with (self.results_root / tr.name / "best-config.toml").open("w") as f:
+                toml.dump(trd.test_definition.model_dump(), f)
 
 
 class TarballReporter(Reporter):

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -54,11 +54,24 @@ class TestTemplate:
             system (System): System configuration for the test template.
         """
         self.system = system
-        self.command_gen_strategy: Optional[CommandGenStrategy] = None
+        self._command_gen_strategy: Optional[CommandGenStrategy] = None
         self.json_gen_strategy: Optional[JsonGenStrategy] = None
         self.job_id_retrieval_strategy: Optional[JobIdRetrievalStrategy] = None
         self.job_status_retrieval_strategy: Optional[JobStatusRetrievalStrategy] = None
         self.grading_strategy: Optional[GradingStrategy] = None
+
+    @property
+    def command_gen_strategy(self) -> CommandGenStrategy:
+        if self._command_gen_strategy is None:
+            raise ValueError(
+                "command_gen_strategy is missing. Ensure the strategy is registered in the Registry "
+                "by calling the appropriate registration function for the system type."
+            )
+        return self._command_gen_strategy
+
+    @command_gen_strategy.setter
+    def command_gen_strategy(self, value: CommandGenStrategy) -> None:
+        self._command_gen_strategy = value
 
     def gen_exec_command(self, tr: TestRun) -> str:
         """
@@ -70,11 +83,6 @@ class TestTemplate:
         Returns:
             str: The generated execution command.
         """
-        if self.command_gen_strategy is None:
-            raise ValueError(
-                "command_gen_strategy is missing. Ensure the strategy is registered in the Registry "
-                "by calling the appropriate registration function for the system type."
-            )
         return self.command_gen_strategy.gen_exec_command(tr)
 
     def gen_json(self, tr: TestRun) -> Dict[Any, Any]:

--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 from .._core.installables import GitRepo
 from .._core.registry import Registry
 from .._core.test_scenario import TestRun
-from .workload import CmdArgs, NsysConfiguration, TestDefinition
+from .workload import CmdArgs, NsysConfiguration
 
 
 class TestRunDependencyModel(BaseModel):
@@ -164,6 +164,9 @@ class TestRunDetails(BaseModel):
 
     Used for storing a single test run with all fields set during command generation.
     """
+
+    __test__ = False
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     nnodes: int

--- a/src/cloudai/runner/slurm/slurm_runner.py
+++ b/src/cloudai/runner/slurm/slurm_runner.py
@@ -42,7 +42,6 @@ class SlurmRunner(BaseRunner):
 
     def _submit_test(self, tr: TestRun) -> SlurmJob:
         logging.info(f"Running test: {tr.name}")
-        tr.output_path = self.get_job_output_path(tr)
         exec_cmd = tr.test.test_template.gen_exec_command(tr)
         logging.debug(f"Executing command for test {tr.name}: {exec_cmd}")
         job_id = 0

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -53,10 +53,9 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         ...
 
     def store_test_run(self, tr: TestRun) -> None:
-        env_vars = {k: f"{v}" for k, v in (self.system.global_env_vars | tr.test.extra_env_vars).items()}
         test_cmd, srun_cmd = " ".join(self.generate_test_command({}, {}, tr)), self.gen_srun_command(tr)
         with (tr.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w") as f:
-            trd = TestRunDetails.from_test_run(tr, test_cmd=test_cmd, full_cmd=srun_cmd, env_vars=env_vars)
+            trd = TestRunDetails.from_test_run(tr, test_cmd=test_cmd, full_cmd=srun_cmd)
             toml.dump(trd.model_dump(), f)
 
     @final

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -56,7 +56,10 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         ...
 
     def store_test_run(self, tr: TestRun) -> None:
-        test_cmd, srun_cmd = " ".join(self.generate_test_command({}, {}, tr)), self.gen_srun_command(tr)
+        test_cmd, srun_cmd = (
+            " ".join(self.generate_test_command(env_vars={}, cmd_args={}, tr=tr)),
+            self.gen_srun_command(tr),
+        )
         with (tr.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w") as f:
             trd = TestRunDetails.from_test_run(tr, test_cmd=test_cmd, full_cmd=srun_cmd)
             toml.dump(trd.model_dump(), f)

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -21,9 +21,11 @@ from typing import Callable, Dict, Optional, Tuple, Type
 from unittest.mock import Mock, patch
 
 import pytest
+import toml
 
 from cloudai import CommandGenStrategy, Test, TestDefinition, TestRun, TestScenario, TestTemplate
 from cloudai.cli import handle_dry_run_and_run, setup_logging
+from cloudai.models.scenario import TestRunDetails
 from cloudai.systems import SlurmSystem
 from cloudai.systems.slurm.strategy import SlurmCommandGenStrategy
 from cloudai.workloads.jax_toolbox import (
@@ -68,56 +70,77 @@ SLURM_TEST_SCENARIOS = [
 ]
 
 
-@pytest.mark.parametrize("scenario", SLURM_TEST_SCENARIOS, ids=lambda x: str(x))
-def test_slurm(tmp_path: Path, scenario: Dict):
-    test_scenario_path = scenario["path"]
-    expected_dirs_number = scenario.get("expected_dirs_number")
-    log_file = scenario.get("log_file", ".")
-    log_file_path = tmp_path / log_file
+class TestInDryRun:
+    @pytest.fixture(scope="class", params=SLURM_TEST_SCENARIOS)
+    def do_dry_run(self, tmp_path_factory: pytest.TempPathFactory, request: pytest.FixtureRequest) -> tuple[Path, dict]:
+        tmp_path = tmp_path_factory.mktemp("dry_run")
+        scenario = request.param
 
-    setup_logging(log_file_path, "DEBUG")
-    args = argparse.Namespace(
-        mode="dry-run",
-        system_config=Path("conf/common/system/example_slurm_cluster.toml"),
-        test_templates_dir=Path("conf/common/test_template"),
-        tests_dir=Path("conf/common/test"),
-        hook_dir=Path("conf/common/hook"),
-        test_scenario=test_scenario_path,
-        output_dir=tmp_path,
-        enable_cache_without_check=False,
-        log_file="debug.log",
-    )
-    with (
-        patch("asyncio.sleep", return_value=None),
-        patch("cloudai.systems.slurm.SlurmSystem.is_job_completed", return_value=True),
-        patch("cloudai.systems.slurm.SlurmSystem.is_job_running", return_value=True),
-        patch("cloudai.util.command_shell.CommandShell.execute") as mock_execute,
-    ):
-        mock_process = Mock()
-        mock_process.poll.return_value = 0
-        mock_process.returncode = 0
-        mock_process.communicate.return_value = ("", "")
-        mock_execute.return_value = mock_process
+        test_scenario_path = scenario["path"]
+        log_file = scenario.get("log_file", ".")
+        log_file_path = tmp_path / log_file
 
-        handle_dry_run_and_run(args)
+        setup_logging(log_file_path, "DEBUG")
+        args = argparse.Namespace(
+            mode="dry-run",
+            system_config=Path("conf/common/system/example_slurm_cluster.toml"),
+            test_templates_dir=Path("conf/common/test_template"),
+            tests_dir=Path("conf/common/test"),
+            hook_dir=Path("conf/common/hook"),
+            test_scenario=test_scenario_path,
+            output_dir=tmp_path,
+            enable_cache_without_check=False,
+            log_file="debug.log",
+        )
+        with (
+            patch("asyncio.sleep", return_value=None),
+            patch("cloudai.systems.slurm.SlurmSystem.is_job_completed", return_value=True),
+            patch("cloudai.systems.slurm.SlurmSystem.is_job_running", return_value=True),
+            patch("cloudai.util.command_shell.CommandShell.execute") as mock_execute,
+        ):
+            mock_process = Mock()
+            mock_process.poll.return_value = 0
+            mock_process.returncode = 0
+            mock_process.communicate.return_value = ("", "")
+            mock_execute.return_value = mock_process
 
-    # Find the directory that was created for the test results
-    results_output_dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+            handle_dry_run_and_run(args)
 
-    # Assuming there's only one result directory created
-    assert len(results_output_dirs) == 1, "No result directory found or multiple directories found."
-    results_output = results_output_dirs[0]
+        return (tmp_path, scenario)
 
-    test_dirs = list(results_output.iterdir())
+    def test_the_only_results_dir_created(self, do_dry_run: tuple[Path, dict]) -> None:
+        tmp_path = do_dry_run[0]
+        results_output_dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+        assert len(results_output_dirs) == 1, "No result directory found or multiple directories found."
 
-    if expected_dirs_number is not None:
-        assert len(test_dirs) == expected_dirs_number, "Dirs number in output is not as expected"
+    def test_number_of_cases(self, do_dry_run: tuple[Path, dict]) -> None:
+        tmp_path, scenario = do_dry_run
+        results_output_dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+        results_output = results_output_dirs[0]
 
-    for td in test_dirs:
-        assert td.is_dir(), "Invalid test directory"
-        assert "Tests." in td.name, "Invalid test directory name"
+        test_dirs = list(results_output.iterdir())
 
-    assert log_file_path.exists(), f"Log file {log_file_path} was not created"
+        if scenario["expected_dirs_number"] is not None:
+            assert len(test_dirs) == scenario["expected_dirs_number"], "Dirs number in output is not as expected"
+
+        for td in test_dirs:
+            assert td.is_dir(), "Invalid test directory"
+            assert "Tests." in td.name, "Invalid test directory name"
+
+    def test_log_file(self, do_dry_run: tuple[Path, dict]) -> None:
+        tmp_path, scenario = do_dry_run
+        log_file_path = tmp_path / scenario["log_file"]
+        assert log_file_path.exists(), f"Log file {log_file_path} was not created"
+
+    def test_details_is_dumped_and_valid(self, do_dry_run: tuple[Path, dict]) -> None:
+        tmp_path, scenario = do_dry_run
+
+        num_cases = scenario["expected_dirs_number"]
+        details_tomls = list(tmp_path.glob(f"**/{CommandGenStrategy.TEST_RUN_DUMP_FILE_NAME}"))
+        assert len(details_tomls) == num_cases, "Details files number is not as expected"
+
+        for details_toml in details_tomls:
+            TestRunDetails.model_validate(toml.load(details_toml))
 
 
 @pytest.fixture

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -132,3 +132,6 @@ def test_best_dse_config(dse_tr: TestRun, slurm_system: SlurmSystem) -> None:
     reporter.report_best_dse_config()
     best_config_path = reporter.results_root / dse_tr.name / f"{dse_tr.current_iteration}" / "best-config.toml"
     assert best_config_path.exists()
+    nccl = NCCLTestDefinition.model_validate(toml.load(best_config_path))
+    assert isinstance(nccl.cmd_args, NCCLCmdArgs)
+    assert nccl.agent_steps == 12

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -130,7 +130,9 @@ def test_best_dse_config(dse_tr: TestRun, slurm_system: SlurmSystem) -> None:
         slurm_system, TestScenario(name="test_scenario", test_runs=[dse_tr]), slurm_system.output_path
     )
     reporter.report_best_dse_config()
-    best_config_path = reporter.results_root / dse_tr.name / f"{dse_tr.current_iteration}" / "best-config.toml"
+    best_config_path = (
+        reporter.results_root / dse_tr.name / f"{dse_tr.current_iteration}" / reporter.best_dse_config_file_name(dse_tr)
+    )
     assert best_config_path.exists()
     nccl = NCCLTestDefinition.model_validate(toml.load(best_config_path))
     assert isinstance(nccl.cmd_args, NCCLCmdArgs)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -130,5 +130,5 @@ def test_best_dse_config(dse_tr: TestRun, slurm_system: SlurmSystem) -> None:
         slurm_system, TestScenario(name="test_scenario", test_runs=[dse_tr]), slurm_system.output_path
     )
     reporter.report_best_dse_config()
-    best_config_path = reporter.results_root / dse_tr.name / "best-config.toml"
+    best_config_path = reporter.results_root / dse_tr.name / f"{dse_tr.current_iteration}" / "best-config.toml"
     assert best_config_path.exists()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -14,27 +14,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import csv
 import tarfile
 from pathlib import Path
 
 import pytest
+import toml
 
 from cloudai import Test, TestRun, TestScenario
-from cloudai._core.reporter import PerTestReporter, TarballReporter
+from cloudai._core.command_gen_strategy import CommandGenStrategy
+from cloudai._core.reporter import PerTestReporter, StatusReporter, TarballReporter
 from cloudai._core.test_template import TestTemplate
+from cloudai.models.scenario import TestRunDetails
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition
 
 
 def create_test_directories(slurm_system: SlurmSystem, test_run: TestRun) -> None:
     test_dir = slurm_system.output_path / test_run.name
-
     for iteration in range(test_run.iterations):
         folder = test_dir / str(iteration)
         folder.mkdir(exist_ok=True, parents=True)
         if test_run.test.test_definition.is_dse_job:
-            for step in range(test_run.test.test_definition.agent_steps):
-                (folder / str(step)).mkdir(exist_ok=True, parents=True)
+            with open(folder / "trajectory.csv", "w") as _f_csv:
+                csw_writer = csv.writer(_f_csv)
+                csw_writer.writerow(["step", "action", "reward", "observation"])
+
+                for step in range(test_run.test.test_definition.agent_steps):
+                    step_folder = folder / str(step)
+                    step_folder.mkdir(exist_ok=True, parents=True)
+                    trd = TestRunDetails.from_test_run(test_run, "", "")
+                    csw_writer.writerow([step, {}, step * 2.1, [step]])
+                    with open(step_folder / CommandGenStrategy.TEST_RUN_DUMP_FILE_NAME, "w") as _f_trd:
+                        toml.dump(trd.model_dump(), _f_trd)
 
 
 @pytest.fixture
@@ -111,3 +123,12 @@ def test_create_tarball_preserves_full_name(tmp_path: Path, slurm_system: SlurmS
 
     with tarfile.open(tarball_path, "r:gz") as tar:
         assert f"{results_dir.name}/dummy.txt" in tar.getnames()
+
+
+def test_best_dse_config(dse_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    reporter = StatusReporter(
+        slurm_system, TestScenario(name="test_scenario", test_runs=[dse_tr]), slurm_system.output_path
+    )
+    reporter.report_best_dse_config()
+    best_config_path = reporter.results_root / dse_tr.name / "best-config.toml"
+    assert best_config_path.exists()


### PR DESCRIPTION
## Summary
Store test details per each case for further reporting. Today it will only be used for single sbatch feature (CloudAIx, separate branch), but we might want to add it into our default reports in future.

## Test Plan
1. CI (extended)
2. NCCL run:
```bash
$ cloudai run --system-config ../eos.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/nccl_tests_inline.toml 
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nccl-tests
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: nccl-tests

Section Name: nccl.all_reduce
  Test Name: nccl-all_reduce
  Description: all_reduce
  No dependencies
Section Name: nccl.all_gather
  Test Name: nccl-all_gather
  Description: all_gather
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: nccl.all_reduce
[INFO] Running test: nccl.all_reduce
[INFO] Submitted slurm job: 2650570
[INFO] Starting test: nccl.all_gather
[INFO] Running test: nccl.all_gather
[INFO] Submitted slurm job: 2650571
[INFO] Job completed: nccl.all_reduce (iteration 1 of 1)
[INFO] Job completed: nccl.all_gather (iteration 1 of 1)
[INFO] All test scenario results stored at: results/nccl-tests_2025-05-14_05-41-39
[INFO] Generated scenario report at results/nccl-tests_2025-05-14_05-41-39/nccl-tests.html
[INFO] All jobs are complete.
```
Results:
```bash
$ tree results/nccl-tests_2025-05-14_05-41-39/
results/nccl-tests_2025-05-14_05-41-39/
├── nccl-tests.html
├── nccl.all_gather
│   └── 0
│       ├── cloudai_nccl_test_bokeh_report.html
│       ├── cloudai_nccl_test_csv_report.csv
│       ├── cloudai_sbatch_script.sh
│       ├── mapping-stderr.txt
│       ├── mapping-stdout.txt
│       ├── metadata
│       │   ├── node-eos0568.toml
│       │   ├── node-eos0569.toml
│       │   └── nodes.err
│       ├── slurm-job.toml
│       ├── stderr.txt
│       ├── stdout.txt
│       └── test-run.toml
└── nccl.all_reduce
    └── 0
        ├── cloudai_nccl_test_bokeh_report.html
        ├── cloudai_nccl_test_csv_report.csv
        ├── cloudai_sbatch_script.sh
        ├── mapping-stderr.txt
        ├── mapping-stdout.txt
        ├── metadata
        │   ├── node-eos0259.toml
        │   ├── node-eos0272.toml
        │   └── nodes.err
        ├── slurm-job.toml
        ├── stderr.txt
        ├── stdout.txt
        └── test-run.toml
```

3. Nemo DSE run
```bash
$ cloudai run --system-config ../eos.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario/dse_nemo_ru
n_llama3_8b.toml                                                                                                                                                                                         
[INFO] System Name: EOS                                                                                                                                                                                  
[INFO] Scheduler: slurm                                                                                                                                                                                  
[INFO] Test Scenario Name: nemo_run_llama3_8b                                                                                                                                                            
[INFO] Checking if test templates are installed.                                                                                                                                                         
[INFO] Test Scenario: nemo_run_llama3_8b                                                                                                                                                                 
                                                                                                                                                                                                         
Section Name: dse_nemo_run_llama3_8b_1                                                                                                                                                                   
  Test Name: dse_nemo_run_llama3_8b_fp8                                                                                                                                                                  
  Description: dse_nemo_run_llama3_8b                                                                                                                                                                    
  No dependencies                                                                                                                                                                                        
[INFO] Initializing Runner [RUN] mode                                                                                                                                                                    
[INFO] Creating SlurmRunner                                                                         
[INFO] Running step 1 with action {'docker_image_url': 'nvcr.io/nvidia/nemo:25.04.rc2', 'task': 'pretrain', 'recipe_name': 'cloudai_llama3_8b_recipe', 'num_layers': 32, 'trainer.max_steps': 100, 'train
er.val_check_interval': 100, 'trainer.num_nodes': 1, 'trainer.strategy.tensor_model_parallel_size': 4, 'trainer.strategy.pipeline_model_parallel_size': 1, 'trainer.strategy.context_parallel_size': 2, '
trainer.strategy.virtual_pipeline_model_parallel_size': None, 'trainer.plugins.fp8': 'hybrid', 'trainer.plugins.fp8_margin': 0, 'trainer.plugins.fp8_amax_history_len': 1024, 'trainer.plugins.fp8_amax_c
ompute_algo': 'max', 'trainer.plugins.fp8_wgrad': None, 'trainer.plugins.fp8_params': True, 'trainer.plugins.grad_reduce_in_fp32': True, 'trainer.callbacks': None, 'log.ckpt': None, 'log.tensorboard': 
None, 'data.seq_length': 8192, 'data.micro_batch_size': 1, 'data.global_batch_size': 128, 'data.num_train_samples': 1000, 'extra_env_vars.ENABLE_VBOOST': '1', 'extra_env_vars.ENABLE_NUMA_CONTROL': '1',
 'extra_env_vars.NCCL_P2P_NET_CHUNKSIZE': '2097152', 'extra_env_vars.TORCHX_MAX_RETRIES': '0', 'extra_env_vars.TRANSFORMERS_OFFLINE': '0', 'extra_env_vars.NCCL_NVLS_ENABLE': '0', 'extra_env_vars.NVTE_D
P_AMAX_REDUCE_INTERVAL': '0', 'extra_env_vars.NVTE_ASYNC_AMAX_REDUCTION': '1', 'extra_env_vars.NVTE_FUSED_ATTN': '1', 'extra_env_vars.NVTE_FLASH_ATTN': '1', 'extra_env_vars.NEMO_LOG_MEMORY_USAGE': '1',
 'extra_env_vars.CUDA_DEVICE_MAX_CONNECTIONS': '1', 'extra_env_vars.NVTE_FWD_LAYERNORM_SM_MARGIN': '16', 'extra_env_vars.NVTE_BWD_LAYERNORM_SM_MARGIN': '16'}
[INFO] Starting test: dse_nemo_run_llama3_8b_1                                                                                                                                                           
[INFO] Running test: dse_nemo_run_llama3_8b_1                                                       
[INFO] Submitted slurm job: 2650129                                                                                                                                                                      
[ERROR] Job 2650129 for test dse_nemo_run_llama3_8b_1 failed: Missing success indicators in results/nemo_run_llama3_8b_2025-05-14_05-04-24/dse_nemo_run_llama3_8b_1/0/1/stderr.txt: 'max_steps=', 'reache
d'. These keywords are expected to be present in stderr.txt when the NeMo training job completes successfully. Please review the full stderr output. Ensure that the NeMo training ran to completion and 
the logger output wasn't suppressed. If the issue persists, contact the system administrator.                                                                                                            
[INFO] Terminating all jobs...                                                                                                                                                                           
[INFO] Terminating job 2650129 for test dse_nemo_run_llama3_8b_1                                    
[INFO] All jobs have been killed.                                                                                                                                                                        
[INFO] Step 1: Observation: [24.18813559322034], Reward: 0.04134258286034615
```
DSE runs don't generate reports by default, need to trigger it manually:
```bash
$ cloudai generate-report --system-config ../eos.toml --tests-dir conf/common/test --test-scenario conf/common/test_scenario
/dse_nemo_run_llama3_8b.toml --result-dir  results/nemo_run_llama3_8b_2025-05-14_05-04-24/                                                                                                               
[INFO] Generating report based on system and test scenario                                                                                                                                               
[INFO] Generated scenario report at results/nemo_run_llama3_8b_2025-05-14_05-04-24/nemo_run_llama3_8b.html                                                         
[INFO] Wrote best config for dse_nemo_run_llama3_8b_1 to results/nemo_run_llama3_8b_2025-05-14_05-04-24/dse_nemo_run_llama3_8b_1/best-config.toml                                                        
[INFO] Created tarball at results/nemo_run_llama3_8b_2025-05-14_05-04-24.tgz                                                                                                                             
[INFO] Report generation completed.
```
Results:
```bash
$ tree results/nemo_run_llama3_8b_2025-05-14_05-04-24                                                                       
results/nemo_run_llama3_8b_2025-05-14_05-04-24                                                                                                                                                           
├── dse_nemo_run_llama3_8b_1                                                                                                                                                                             
│   └── 0                                                                                                                                                                                                
│       ├── 1                                                                                                                                                                                            
│       │   ├── cloudai_nemorun_bokeh_report.html                                                                                                                                                        
│       │   ├── cloudai_sbatch_script.sh                                                                                                                                                                 
│       │   ├── mapping-stderr.txt                                                                  
│       │   ├── mapping-stdout.txt                                                                                                                                                                       
│       │   ├── metadata                                                                            
│       │   │   ├── node-eos0546.toml                                                                                                                                                                    
│       │   │   └── nodes.err                                                                       
│       │   ├── report.txt                                                                                                                                                                               
│       │   ├── report_data.json                                                                                                                                                                         
│       │   ├── slurm-job.toml                                                                                                                                                                           
│       │   ├── stderr.txt                                                                                                                                                                               
│       │   ├── stdout.txt                                                                                                                                                                               
│       │   ├── test-run.toml                                                                                                                                                                            
│       │   ├── vboost.err                                                                                                                                                                               
│       │   └── vboost.out                                                                                                                                                                               
│       ├── best-config.toml                                                                                                                                                                             
│       └── trajectory.csv          
└── nemo_run_llama3_8b.html
```

## Additional Notes
—
