### PR TITLE
Fix how test-in-scenario is merge with test-in-toml

### DIFF
--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -75,8 +75,8 @@ class TestRunModel(BaseModel):
             "agent_steps": self.agent_steps,
             "agent_metric": self.agent_metric,
             "extra_container_mounts": self.extra_container_mounts,
-            "cmd_args": self.cmd_args.model_dump() if self.cmd_args else None,
             "extra_env_vars": self.extra_env_vars if self.extra_env_vars else None,
+            "cmd_args": self.cmd_args.model_dump() if self.cmd_args else None,
             "git_repos": [repo.model_dump() for repo in self.git_repos] if self.git_repos else None,
             "nsys": self.nsys.model_dump() if self.nsys else None,
         }

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -46,7 +46,11 @@ from cloudai.workloads.jax_toolbox import (
     JaxToolboxReportGenerationStrategy,
     NemotronTestDefinition,
 )
-from cloudai.workloads.megatron_run import CheckpointTimingReportGenerationStrategy, MegatronRunTestDefinition
+from cloudai.workloads.megatron_run import (
+    CheckpointTimingReportGenerationStrategy,
+    MegatronRunCmdArgs,
+    MegatronRunTestDefinition,
+)
 from cloudai.workloads.nccl_test import (
     NCCLCmdArgs,
     NCCLTestDefinition,
@@ -280,7 +284,7 @@ def test_total_time_limit_with_empty_hooks():
     assert result == "01:00:00"
 
 
-class TestSpec:
+class TestInScenario:
     @pytest.mark.parametrize("missing_arg", ["test_template_name", "name", "description"])
     def test_without_base(self, missing_arg: str):
         spec = {
@@ -413,6 +417,34 @@ class TestSpec:
         _, tdef = test_scenario_parser._prepare_tdef(model.tests[0])
         assert tdef.cmd_args_dict["unknown"] == 42
         assert isinstance(tdef.cmd_args, NCCLCmdArgs)
+
+    def test_data_is_merge_correctly(self, test_scenario_parser: TestScenarioParser, slurm_system: SlurmSystem):
+        test_scenario_parser.test_mapping = {
+            "megatron": Test(
+                test_definition=MegatronRunTestDefinition(
+                    name="megatron",
+                    description="desc",
+                    test_template_name="MegatronRun",
+                    cmd_args=MegatronRunCmdArgs(docker_image_url="docker://megatron", run_script=Path("run.sh")),
+                ),
+                test_template=TestTemplate(system=slurm_system),
+            )
+        }
+        model = TestScenarioModel.model_validate(
+            toml.loads(
+                """
+            name = "test"
+
+            [[Tests]]
+            id = "1"
+            test_name = "megatron"
+            cmd_args = { any = 42 }
+            """
+            )
+        )
+        _, tdef = test_scenario_parser._prepare_tdef(model.tests[0])
+        assert isinstance(tdef.cmd_args, MegatronRunCmdArgs)
+        assert tdef.cmd_args.run_script == Path("run.sh")
 
 
 class TestReporters:


### PR DESCRIPTION
## Summary
Original implementation would fully replace some fields like `cmd_args` with in-scenario value instead of merging values including nested structure. It wasn't visible for Test Definitions when almost all fields have default values.

## Test Plan
1. CI (extended)
2. Manually run CloudAIx-based test where this issue was discovered.

## Additional Notes
—