### PR TITLE
Remove venv folder if requirements installation failed

### DIFF
--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -177,7 +177,7 @@ class SlurmInstaller(BaseInstaller):
         if repo_path.exists():
             item.installed_path = repo_path
             msg = f"Git repository already exists at {repo_path}."
-            logging.warning(msg)
+            logging.debug(msg)
             return InstallStatusResult(True, msg)
 
         res = self._clone_repository(item.url, repo_path)
@@ -196,14 +196,20 @@ class SlurmInstaller(BaseInstaller):
         if not res.success:
             return res
 
-        venv_path = self.system.install_path / item.venv_name
-        res = self._create_venv(venv_path)
+        res = self._create_venv(item)
         if not res.success:
             return res
 
-        assert item.git_repo.installed_path, "Git repository must be installed before creating virtual environment."
+        return InstallStatusResult(True)
+
+    def _install_dependencies(self, item: PythonExecutable) -> InstallStatusResult:
+        venv_path = self.system.install_path / item.venv_name
+
+        if not item.git_repo.installed_path:
+            return InstallStatusResult(False, "Git repository must be installed before creating virtual environment.")
 
         project_dir = item.git_repo.installed_path
+
         if item.project_subpath:
             project_dir = project_dir / item.project_subpath
 
@@ -222,11 +228,7 @@ class SlurmInstaller(BaseInstaller):
         else:
             return InstallStatusResult(False, "No pyproject.toml or requirements.txt found for installation.")
 
-        if not res.success:
-            return res
-
-        item.venv_path = venv_path
-        return InstallStatusResult(True)
+        return res
 
     def _clone_repository(self, git_url: str, path: Path) -> InstallStatusResult:
         logging.debug(f"Cloning repository {git_url} into {path}")
@@ -251,21 +253,33 @@ class SlurmInstaller(BaseInstaller):
             return InstallStatusResult(False, f"Failed to checkout commit: {result.stderr}")
         return InstallStatusResult(True)
 
-    def _create_venv(self, venv_dir: Path) -> InstallStatusResult:
-        logging.debug(f"Creating virtual environment in {venv_dir}")
-        if venv_dir.exists():
-            msg = f"Virtual environment already exists at {venv_dir}."
-            logging.warning(msg)
+    def _create_venv(self, item: PythonExecutable) -> InstallStatusResult:
+        venv_path = self.system.install_path / item.venv_name
+        logging.debug(f"Creating virtual environment in {venv_path}")
+        if venv_path.exists():
+            msg = f"Virtual environment already exists at {venv_path}."
+            logging.debug(msg)
             return InstallStatusResult(True, msg)
 
-        cmd = ["python", "-m", "venv", str(venv_dir)]
+        cmd = ["python", "-m", "venv", str(venv_path)]
         logging.debug(f"Creating venv using cmd: {' '.join(cmd)}")
-        result = subprocess.run(["python", "-m", "venv", str(venv_dir)], capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True)
         logging.debug(f"venv creation STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
         if result.returncode != 0:
-            if venv_dir.exists():
-                rmtree(venv_dir)
-            return InstallStatusResult(False, f"Failed to create venv:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
+            if venv_path.exists():
+                rmtree(venv_path)
+            return InstallStatusResult(
+                False, f"Failed to create venv:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            )
+
+        res = self._install_dependencies(item)
+        if not res.success:
+            if venv_path.exists():
+                rmtree(venv_path)
+            return res
+
+        item.venv_path = self.system.install_path / item.venv_name
+
         return InstallStatusResult(True)
 
     def _install_pyproject(self, venv_dir: Path, project_dir: Path) -> InstallStatusResult:

--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -287,15 +287,19 @@ class SlurmInstaller(BaseInstaller):
             logging.warning(msg)
             return InstallStatusResult(True, msg)
 
+        cmd = ["python", "-m", "venv", str(venv_dir)]
+        logging.debug(f"Creating venv using cmd: {' '.join(cmd)}")
         result = subprocess.run(["python", "-m", "venv", str(venv_dir)], capture_output=True, text=True)
+        logging.debug(f"venv creation STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
         if result.returncode != 0:
             if venv_dir.exists():
                 rmtree(venv_dir)
-            return InstallStatusResult(False, f"Failed to create venv: {result.stderr}")
+            return InstallStatusResult(False, f"Failed to create venv:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
         return InstallStatusResult(True)
 
     def _install_pyproject(self, venv_dir: Path, project_dir: Path) -> InstallStatusResult:
         install_cmd = [str(venv_dir / "bin" / "python"), "-m", "pip", "install", str(project_dir)]
+        logging.debug(f"Installing dependencies using: {' '.join(install_cmd)}")
         result = subprocess.run(install_cmd, capture_output=True, text=True)
 
         if result.returncode != 0:
@@ -308,6 +312,7 @@ class SlurmInstaller(BaseInstaller):
             return InstallStatusResult(False, f"Requirements file is invalid or does not exist: {requirements_txt}")
 
         install_cmd = [str(venv_dir / "bin" / "python"), "-m", "pip", "install", "-r", str(requirements_txt)]
+        logging.debug(f"Installing dependencies using: {' '.join(install_cmd)}")
         result = subprocess.run(install_cmd, capture_output=True, text=True)
 
         if result.returncode != 0:

--- a/tests/test_slurm_installer.py
+++ b/tests/test_slurm_installer.py
@@ -175,26 +175,36 @@ class TestInstallOnePythonExecutable:
     def test_venv_created(self, installer: SlurmInstaller, git: GitRepo):
         py = PythonExecutable(git)
         venv_path = installer.system.install_path / py.venv_name
+        installer._install_dependencies = Mock(return_value=InstallStatusResult(True))
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = CompletedProcess(args=[], returncode=0)
-            res = installer._create_venv(venv_path)
+            res = installer._create_venv(py)
         assert res.success
         mock_run.assert_called_once_with(["python", "-m", "venv", str(venv_path)], capture_output=True, text=True)
 
-    @pytest.mark.parametrize("venv_folder_created", [True, False])
-    def test_error_creating_venv(self, installer: SlurmInstaller, git: GitRepo, venv_folder_created: bool):
+    @pytest.mark.parametrize("failure_on_venv_creation,reqs_install_failure", [(True, False), (False, True)])
+    def test_error_creating_venv(
+        self, installer: SlurmInstaller, git: GitRepo, failure_on_venv_creation: bool, reqs_install_failure: bool
+    ):
         py = PythonExecutable(git)
         venv_path = installer.system.install_path / py.venv_name
 
+        if reqs_install_failure:
+            installer._install_dependencies = Mock(return_value=InstallStatusResult(False, "err"))
+
         def mock_run(*args, **kwargs):
-            if venv_folder_created:  # simulate case when installation started, but didn't finish successfully
-                venv_path.mkdir()
-            return CompletedProcess(args=args, returncode=1, stderr="err")
+            venv_path.mkdir()
+            if failure_on_venv_creation and "venv" in args[0]:
+                return CompletedProcess(args=args, returncode=1, stderr="err")
+            return CompletedProcess(args=args, returncode=0)
 
         with patch("subprocess.run", side_effect=mock_run):
-            res = installer._create_venv(venv_path)
+            res = installer._create_venv(py)
         assert not res.success
-        assert res.message == "Failed to create venv: err"
+        if failure_on_venv_creation:
+            assert res.message == "Failed to create venv:\nSTDOUT:\nNone\nSTDERR:\nerr"
+        else:
+            assert res.message == "err"
         assert not venv_path.exists(), "venv folder wasn't removed after unsuccessful installation"
 
     def test_venv_already_exists(self, installer: SlurmInstaller, git: GitRepo):
@@ -203,7 +213,7 @@ class TestInstallOnePythonExecutable:
         venv_path.mkdir()
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = CompletedProcess(args=[], returncode=1, stderr="err")
-            res = installer._create_venv(venv_path)
+            res = installer._create_venv(py)
         assert mock_run.call_count == 0
         assert res.success
         assert res.message == f"Virtual environment already exists at {venv_path}."
@@ -211,10 +221,7 @@ class TestInstallOnePythonExecutable:
     def test_requirements_no_file(self, installer: SlurmInstaller, git: GitRepo):
         py = PythonExecutable(git)
         venv_path = installer.system.install_path / py.venv_name
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess(args=[], returncode=0)
-            res = installer._create_venv(venv_path)
-        assert res.success
+        venv_path.mkdir()
         res = installer._install_requirements(venv_path, installer.system.install_path / "requirements.txt")
         assert not res.success
         assert (
@@ -254,13 +261,10 @@ class TestInstallOnePythonExecutable:
         pyproject_file = repo_dir / "pyproject.toml"
         pyproject_file.write_text("[tool.poetry]\nname = 'dummy_project'")
 
-        installer._install_one_git_repo = Mock(return_value=InstallStatusResult(True))
-        installer._clone_repository = Mock(return_value=InstallStatusResult(True))
-        installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        installer._create_venv = Mock(return_value=InstallStatusResult(True))
-        installer._install_pyproject = Mock(return_value=InstallStatusResult(True))
-        installer._install_requirements = Mock(return_value=InstallStatusResult(True))
-        res = installer._install_python_executable(py)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0)
+            res = installer._install_python_executable(py)
+
         assert res.success
         assert py.git_repo.installed_path == installer.system.install_path / py.git_repo.repo_name
         assert py.venv_path == installer.system.install_path / py.venv_name
@@ -322,19 +326,16 @@ class TestInstallOnePythonExecutable:
 
         py = PythonExecutable(git, project_subpath=Path("subdir"), dependencies_from_pyproject=True)
 
-        installer._install_one_git_repo = Mock(return_value=InstallStatusResult(True))
-        installer._create_venv = Mock(return_value=InstallStatusResult(True))
-        installer._install_requirements = Mock(return_value=InstallStatusResult(True))
         installer._install_pyproject = Mock(return_value=InstallStatusResult(True))
+        installer._install_requirements = Mock(return_value=InstallStatusResult(True))
 
         py.git_repo.installed_path = repo_dir
 
-        res = installer._install_python_executable(py)
+        res = installer._install_dependencies(py)
 
         assert res.success
         installer._install_pyproject.assert_called_once_with(installer.system.install_path / py.venv_name, subdir)
         installer._install_requirements.assert_not_called()
-        assert py.venv_path == installer.system.install_path / py.venv_name
 
     def test_install_python_executable_prefers_requirements_txt(
         self, installer: SlurmInstaller, git: GitRepo, setup_repo
@@ -343,21 +344,15 @@ class TestInstallOnePythonExecutable:
 
         py = PythonExecutable(git, project_subpath=Path("subdir"), dependencies_from_pyproject=False)
 
-        installer._install_one_git_repo = Mock(return_value=InstallStatusResult(True))
-        installer._create_venv = Mock(return_value=InstallStatusResult(True))
         installer._install_requirements = Mock(return_value=InstallStatusResult(True))
         installer._install_pyproject = Mock(return_value=InstallStatusResult(True))
 
         py.git_repo.installed_path = repo_dir
 
-        res = installer._install_python_executable(py)
+        res = installer._install_dependencies(py)
 
         assert res.success
-        installer._install_requirements.assert_called_once_with(
-            installer.system.install_path / py.venv_name, requirements_file
-        )
         installer._install_pyproject.assert_not_called()
-        assert py.venv_path == installer.system.install_path / py.venv_name
 
 
 class TestGitRepo:


### PR DESCRIPTION
## Summary
Found out that dependencies installation error still leaves venv folder for PythonExecutable. That leads to situation when re-installation doesn't run because dir exists. Alse encountered some issues and existing CloudAI logging didn't help with root-cause, so I've expanded logging. 

## Test Plan
1. CI
2. Run installation manually, check folders.

## Additional Notes
—
