### PR TITLE
Add GPU directive support check to SlurmSystem and use it in command gen

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -165,6 +165,20 @@ class SlurmSystem(BaseModel, System):
 
         return groups
 
+    @property
+    def supports_gpu_directives(self) -> bool:
+        try:
+            stdout, stderr = self.fetch_command_output("scontrol show config")
+            if stderr:
+                logging.warning(f"Error checking GPU support: {stderr}")
+                return True
+
+            return any("AccountingStorageTRES" in line and "gres/gpu" in line for line in stdout.splitlines())
+
+        except Exception as e:
+            logging.warning(f"Failed to check Slurm GPU directive support: {e}")
+            return True
+
     @field_serializer("install_path", "output_path")
     def _path_serializer(self, v: Path) -> str:
         return str(v)

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -173,7 +173,16 @@ class SlurmSystem(BaseModel, System):
                 logging.warning(f"Error checking GPU support: {stderr}")
                 return True
 
-            return any("AccountingStorageTRES" in line and "gres/gpu" in line for line in stdout.splitlines())
+            has_gres_gpu = False
+            has_gpu_gres_type = False
+
+            for line in stdout.splitlines():
+                if "AccountingStorageTRES" in line and "gres/gpu" in line:
+                    has_gres_gpu = True
+                if "GresTypes" in line and "gpu" in line and "(null)" not in line:
+                    has_gpu_gres_type = True
+
+            return has_gres_gpu and has_gpu_gres_type
 
         except Exception as e:
             logging.warning(f"Failed to check Slurm GPU directive support: {e}")

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -378,9 +378,10 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         hostfile = self._append_nodes_related_directives(batch_script_content, tr)
 
-        if self.system.gpus_per_node:
+        if self.system.gpus_per_node and self.system.supports_gpu_directives:
             batch_script_content.append(f"#SBATCH --gpus-per-node={self.system.gpus_per_node}")
             batch_script_content.append(f"#SBATCH --gres=gpu:{self.system.gpus_per_node}")
+
         if self.system.ntasks_per_node:
             batch_script_content.append(f"#SBATCH --ntasks-per-node={self.system.ntasks_per_node}")
         if tr.time_limit:

--- a/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
@@ -134,6 +134,11 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         cmd_args_dict["trainer"]["num_nodes"] = num_nodes
 
+        if self.system.gpus_per_node:
+            cmd_args_dict["trainer"]["devices"] = self.system.gpus_per_node
+        else:
+            logging.warning("SlurmSystem.gpus_per_node is not set. Skipping trainer.devices injection.")
+
         self.append_flattened_dict("", cmd_args_dict, command)
 
         if tr.test.extra_cmd_args:

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -535,12 +535,28 @@ class TestSlurmCommandGenStrategyCache:
 @pytest.mark.parametrize(
     "scontrol_output,expected_support",
     [
+        # Case 1: gres/gpu in AccountingStorageTRES and gpu in GresTypes - should be supported
         (
             """Configuration data as of 2023-06-14T16:28:09
 AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages,gres/gpu,gres/gpumem,gres/gpuutil
 GresTypes               = gpu""",
             True,
         ),
+        # Case 2: gres/gpu in AccountingStorageTRES but GresTypes is (null) - should NOT be supported
+        (
+            """Configuration data as of 2023-06-14T16:28:09
+AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages,gres/gpu,gres/gpumem,gres/gpuutil
+GresTypes               = (null)""",
+            False,
+        ),
+        # Case 3: No gres/gpu in AccountingStorageTRES - should NOT be supported
+        (
+            """Configuration data as of 2023-06-14T16:28:09
+AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages
+GresTypes               = gpu""",
+            False,
+        ),
+        # Case 4: No gres/gpu in AccountingStorageTRES and GresTypes is (null) - should NOT be supported
         (
             """Configuration data as of 2023-06-14T16:28:09
 AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -530,3 +530,28 @@ class TestSlurmCommandGenStrategyCache:
         res = strategy.get_cached_nodes_spec(test_run)
         assert mock_get_nodes.call_count == 2
         assert res == (2, ["node03", "node04"])
+
+
+@pytest.mark.parametrize(
+    "scontrol_output,expected_support",
+    [
+        (
+            """Configuration data as of 2023-06-14T16:28:09
+AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages,gres/gpu,gres/gpumem,gres/gpuutil
+GresTypes               = gpu""",
+            True,
+        ),
+        (
+            """Configuration data as of 2023-06-14T16:28:09
+AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages
+GresTypes               = (null)""",
+            False,
+        ),
+    ],
+)
+@patch("cloudai.systems.slurm.slurm_system.SlurmSystem.fetch_command_output")
+def test_supports_gpu_directives(
+    mock_fetch_command_output, scontrol_output: str, expected_support: bool, slurm_system: SlurmSystem
+):
+    mock_fetch_command_output.return_value = (scontrol_output, "")
+    assert slurm_system.supports_gpu_directives == expected_support


### PR DESCRIPTION
## Summary
1. Add GPU directive support check to SlurmSystem and use it in command gen
2. Inject trainer.devices using SlurmSystem.gpus_per_node

https://redmine.mellanox.com/issues/4449955
https://github.com/Mellanox/cloudaix/pull/267

## Test Plan
1. CI passes
2. Ran on internal servers.