### PR TITLE
Added support for additional args in cmd_args in chakra replay workload

### DIFF
--- a/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
@@ -38,11 +38,18 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
         self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
     ) -> List[str]:
         tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, tr.test.test_definition)
+
+        additional_cmd_args_dict = tdef.cmd_args.model_dump()
+
+        for known_cmd_arg in {"docker_image_url", "mpi", "trace_type", "trace_path", "num_replays"}:
+            additional_cmd_args_dict.pop(known_cmd_arg)
+
         srun_command_parts = [
             "comm_replay",
             f"--trace-type {tdef.cmd_args.trace_type}",
             f"--trace-path {tdef.cmd_args.trace_path}",
             f"--num-replays {tdef.cmd_args.num_replays}",
+            *[f"{k} {v}" for k, v in additional_cmd_args_dict.items()],
             tr.test.extra_cmd_args,
         ]
         return srun_command_parts

--- a/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
@@ -57,6 +57,18 @@ class TestChakraReplaySlurmCommandGenStrategy:
                     "",
                 ],
             ),
+            (
+                {"trace_type": "comms_trace", "trace_path": "/workspace/traces/", "num_replays": 5, "--max-steps": "100"},
+                "",
+                [
+                    "comm_replay",
+                    "--trace-type comms_trace",
+                    "--trace-path /workspace/traces/",
+                    "--num-replays 5",
+                    "--max-steps 100",
+                    "",
+                ],
+            ),
         ],
     )
     def test_generate_test_command(


### PR DESCRIPTION
## Summary
Before this change chakra replay workload would ignore any args provided in cmd_args, except the ones defined in the schema.
Although it's possible to provide those args in `extra_cmd_args`, it's impossible to override them in test scenario.

## Test Plan
Added another test case that checks such arg propagates to the output.

