### PR TITLE
Make sure install status is populated to all duplicates

### DIFF
--- a/src/cloudai/_core/install_status_result.py
+++ b/src/cloudai/_core/install_status_result.py
@@ -16,6 +16,8 @@
 
 from typing import Dict, Optional
 
+from .installables import Installable
+
 
 class InstallStatusResult:
     """
@@ -27,7 +29,9 @@ class InstallStatusResult:
         details (Optional[Dict[str, str]]): A dictionary containing details about the result for each test template.
     """
 
-    def __init__(self, success: bool, message: str = "", details: Optional[Dict[str, str]] = None):
+    def __init__(
+        self, success: bool, message: str = "", details: Optional[Dict[Installable, "InstallStatusResult"]] = None
+    ):
         """
         Initialize the InstallStatusResult.
 

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -14,15 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
 from concurrent.futures import Future
 from pathlib import Path
-from typing import Generator
+from typing import Generator, cast
 from unittest.mock import Mock, patch
 
 import pytest
 
 from cloudai import BaseInstaller, InstallStatusResult
-from cloudai._core.installables import DockerImage, GitRepo, Installable
+from cloudai._core.installables import DockerImage, File, GitRepo, Installable
+from cloudai.installer.slurm_installer import SlurmInstaller
 from cloudai.systems import SlurmSystem
 from cloudai.util import prepare_output_dir
 
@@ -108,13 +110,25 @@ class TestBaseInstaller:
         )
 
     def test_uninstalls_only_uniq(self, mock_executor: Mock, installer: MyInstaller, docker_image: DockerImage):
-        mock_executor.return_value.__enter__.return_value.submit.return_value = create_real_future(0)
+        mock_executor.return_value.__enter__.return_value.submit.return_value = create_real_future(
+            installer.uninstall_one(docker_image)
+        )
 
         installer.uninstall([docker_image, docker_image])
 
         assert mock_executor.return_value.__enter__.return_value.submit.call_count == 1 + len(
             installer.system.system_installables()
         )
+
+    def test_all_items_with_duplicates(self, _, installer: MyInstaller, docker_image: DockerImage):
+        all_items = installer.all_items([docker_image, docker_image], with_duplicates=True)
+        assert len(all_items) == 3
+        assert all_items[:2] == [docker_image, docker_image]
+
+    def test_all_items_without_duplicates(self, _, installer: MyInstaller, docker_image: DockerImage):
+        all_items = installer.all_items([docker_image, docker_image])
+        assert len(all_items) == 2
+        assert docker_image in all_items
 
 
 @pytest.mark.parametrize(
@@ -179,6 +193,7 @@ def test_system_installables_are_used(slurm_system: SlurmSystem):
     installer.uninstall_one = Mock(return_value=InstallStatusResult(True))
     installer.is_installed_one = Mock(return_value=InstallStatusResult(True))
     installer.mark_as_installed_one = Mock(return_value=InstallStatusResult(True))
+    installer._populate_sucessful_install = Mock()
 
     installer.install([])
     assert installer.install_one.call_count == len(slurm_system.system_installables())
@@ -191,3 +206,35 @@ def test_system_installables_are_used(slurm_system: SlurmSystem):
 
     installer.mark_as_installed([])
     assert installer.mark_as_installed_one.call_count == len(slurm_system.system_installables())
+
+
+class TestSuccessIsPopulated:
+    @pytest.fixture
+    def installer(self, slurm_system: SlurmSystem):
+        slurm_system.install_path.mkdir(parents=True, exist_ok=True)
+        installer = SlurmInstaller(slurm_system)
+        installer._check_prerequisites = Mock(return_value=InstallStatusResult(True))
+        # make sure system installables are installed
+        for ins in installer.system.system_installables():
+            item = cast(File, ins)
+            shutil.copyfile(item.src, installer.system.install_path / item.src.name, follow_symlinks=False)
+
+        return installer
+
+    def test_both_installed(self, installer: SlurmInstaller):
+        f1, f2 = File(src=Path(__file__)), File(src=Path(__file__))
+        res = installer.install([f1, f2])
+        assert res.success
+        assert f1._installed_path is not None, "First file is not installed"
+        assert f2._installed_path is not None, "Second file is not installed"
+        assert f1._installed_path == f2._installed_path, "Files are installed to different paths"
+
+    def test_both_is_installed(self, installer: SlurmInstaller):
+        f = installer.system.install_path / "file"
+        f.touch()
+        f1, f2 = File(src=f), File(src=f)
+        res = installer.is_installed([f1, f2])
+        assert res.success, res.message
+        assert f1._installed_path is not None, "First file is not installed"
+        assert f2._installed_path is not None, "Second file is not installed"
+        assert f1._installed_path == f2._installed_path, "Files are installed to different paths"


### PR DESCRIPTION
## Summary
When two cases have the same installable, only one is actually installed to save time and avoid race conditions. But that left another one not marked as installed.
Fixes internal [bug](https://redmine.mellanox.com/issues/4461274).

## Test Plan
1. CI (extended)
2. Manual install/uninstall on a slurm system.

## Additional Notes
—