### PR TITLE
Use copies for venv creation + fix tests

### DIFF
--- a/src/cloudai/installer/slurm_installer.py
+++ b/src/cloudai/installer/slurm_installer.py
@@ -261,7 +261,7 @@ class SlurmInstaller(BaseInstaller):
             logging.debug(msg)
             return InstallStatusResult(True, msg)
 
-        cmd = ["python", "-m", "venv", str(venv_path)]
+        cmd = ["python", "-m", "venv", "--copies", str(venv_path)]
         logging.debug(f"Creating venv using cmd: {' '.join(cmd)}")
         result = subprocess.run(cmd, capture_output=True, text=True)
         logging.debug(f"venv creation STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")

--- a/tests/ref_data/nixl_bench.sbatch
+++ b/tests/ref_data/nixl_bench.sbatch
@@ -12,6 +12,6 @@ srun --export=ALL --mpi=pmix --output=__OUTPUT_DIR__/output/mapping-stdout.txt -
 
 srun --export=ALL --mpi=pmix --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash __INSTALL_DIR__/slurm-metadata.sh
 
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:1 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install --overlap --ntasks-per-node=1 --ntasks=1 --nodelist=$SLURM_JOB_MASTER_NODE -N1 bash -c "/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$(hostname -I | awk '{print $1}'):2379" &
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:1 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --ntasks-per-node=1 --ntasks=1 --nodelist=$SLURM_JOB_MASTER_NODE -N1 bash -c "/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$(hostname -I | awk '{print $1}'):2379" &
 sleep 5
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install --overlap --ntasks-per-node=1 --ntasks=2 -N2 bash -c "./nixlbench --etcd-endpoints http://$SLURM_JOB_MASTER_NODE:2379"
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --ntasks-per-node=1 --ntasks=2 -N2 bash -c "./nixlbench --etcd-endpoints http://$SLURM_JOB_MASTER_NODE:2379"

--- a/tests/test_slurm_installer.py
+++ b/tests/test_slurm_installer.py
@@ -180,7 +180,9 @@ class TestInstallOnePythonExecutable:
             mock_run.return_value = CompletedProcess(args=[], returncode=0)
             res = installer._create_venv(py)
         assert res.success
-        mock_run.assert_called_once_with(["python", "-m", "venv", str(venv_path)], capture_output=True, text=True)
+        mock_run.assert_called_once_with(
+            ["python", "-m", "venv", "--copies", str(venv_path)], capture_output=True, text=True
+        )
 
     @pytest.mark.parametrize("failure_on_venv_creation,reqs_install_failure", [(True, False), (False, True)])
     def test_error_creating_venv(


### PR DESCRIPTION
## Summary
1. Use `--copies` when creating a venv to allow mounting it into a container.
2. Fix tests caused by unordered PRs merge.

## Test Plan
1. CI
2. Manual runs of installation for venvs.

## Additional Notes
—