### PR TITLE
Control if home folder should be mounted into container for slurm

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -140,6 +140,7 @@ class SlurmSystem(BaseModel, System):
     extra_srun_args: Optional[str] = None
     extra_sbatch_args: list[str] = []
     supports_gpu_directives_cache: Optional[bool] = Field(default=None, exclude=True)
+    container_mount_home: bool = False
 
     data_repository: Optional[DataRepositoryConfig] = None
 

--- a/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/strategy/slurm_command_gen_strategy.py
@@ -264,6 +264,9 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             if mounts:
                 srun_command_parts.append(f"--container-mounts={','.join(mounts)}")
 
+            if not self.system.container_mount_home:
+                srun_command_parts.append("--no-container-mount-home")
+
         if self.system.extra_srun_args:
             srun_command_parts.append(self.system.extra_srun_args)
 

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -39,7 +39,7 @@ class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_srun_prefix(self, tr: TestRun, use_pretest_extras: bool = False) -> list[str]:
         cmd = super().gen_srun_prefix(tr)
         tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, tr.test.test_definition)
-        return [*cmd, *tdef.extra_srun_args, "--no-container-mount-home"]
+        return [*cmd, *tdef.extra_srun_args]
 
     def generate_test_command(
         self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun

--- a/tests/ref_data/nixl_bench.sbatch
+++ b/tests/ref_data/nixl_bench.sbatch
@@ -12,6 +12,6 @@ srun --export=ALL --mpi=pmix --output=__OUTPUT_DIR__/output/mapping-stdout.txt -
 
 srun --export=ALL --mpi=pmix --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash __INSTALL_DIR__/slurm-metadata.sh
 
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:1 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install --overlap --ntasks-per-node=1 --ntasks=1 --nodelist=$SLURM_JOB_MASTER_NODE -N1 bash -c "/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$(hostname -I | awk '{print $1}'):2379" &
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:1 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --ntasks-per-node=1 --ntasks=1 --nodelist=$SLURM_JOB_MASTER_NODE -N1 bash -c "/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$(hostname -I | awk '{print $1}'):2379" &
 sleep 5
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install --overlap --ntasks-per-node=1 --ntasks=2 -N2 bash -c "./nixlbench --etcd-endpoints http://$SLURM_JOB_MASTER_NODE:2379"
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --ntasks-per-node=1 --ntasks=2 -N2 bash -c "./nixlbench --etcd-endpoints http://$SLURM_JOB_MASTER_NODE:2379"

--- a/tests/ref_data/slurm_container.sbatch
+++ b/tests/ref_data/slurm_container.sbatch
@@ -8,8 +8,8 @@
 
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
-srun --export=ALL --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --no-container-mount-home --output=__OUTPUT_DIR__/output/mapping-stdout.txt --error=__OUTPUT_DIR__/output/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."
+srun --export=ALL --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --output=__OUTPUT_DIR__/output/mapping-stdout.txt --error=__OUTPUT_DIR__/output/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."
 
-srun --export=ALL --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --no-container-mount-home --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
+srun --export=ALL --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
-srun --export=ALL --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --no-container-mount-home bash -c "source __OUTPUT_DIR__/output/env_vars.sh; pwd ; ls"
+srun --export=ALL --mpi=pmix --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; pwd ; ls"

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -352,6 +352,16 @@ def test_gen_srun_prefix_with_pretest_extras(
     assert ("--pre-arg2" in srun_prefix_with_extras) is use_pretest_extras
 
 
+@pytest.mark.parametrize("container_mount_home", [True, False])
+def test_gen_srun_prefix_with_container_mount_home(
+    container_mount_home: bool, strategy_fixture: SlurmCommandGenStrategy, testrun_fixture: TestRun
+):
+    strategy_fixture.system.container_mount_home = container_mount_home
+    strategy_fixture.image_path = Mock(return_value="path")
+    srun_prefix = strategy_fixture.gen_srun_prefix(testrun_fixture)
+    assert ("--no-container-mount-home" in srun_prefix) is not container_mount_home
+
+
 def test_append_distribution_and_hostfile_with_nodes(
     strategy_fixture: SlurmCommandGenStrategy, testrun_fixture: TestRun
 ) -> None:

--- a/tests/slurm_command_gen_strategy/test_slurm_container_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_slurm_container_slurm_command_gen_strategy.py
@@ -90,8 +90,8 @@ def test_with_extra_srun_args(slurm_system: SlurmSystem, test_run: TestRun) -> N
         f"--container-mounts={test_run.output_path.absolute()}:/cloudai_run_results,"
         f"{slurm_system.install_path.absolute()}:/cloudai_install,"
         f"{test_run.output_path.absolute()} "
-        f"{' '.join(extra_args)} "
-        f"--no-container-mount-home"
+        f"--no-container-mount-home "
+        f"{' '.join(extra_args)}"
     )
 
     assert cmd == f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; cmd"'

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -399,6 +399,7 @@ def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -
 
 def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, str]):
     slurm_system.output_path.mkdir(parents=True, exist_ok=True)
+    slurm_system.container_mount_home = True
 
     tr = test_req[0]
 


### PR DESCRIPTION
## Summary
Add an option for Slurm system to control if home folder should be mounted (default is yes for slurm). CloudAI's default is `false`, so `--no-container-mount-home` is added by default.

_Note_: I've set `slurm_system.container_mount_home = True` for acceptance tests to avoid multiple changes in ref files. A unit test for this behavior was added.

## Test Plan
1. CI (extended).
2. See comments for real runs.

## Additional Notes
—
