### PR TITLE
Allow val_check_interval to be int, float, or list of both

### DIFF
--- a/src/cloudai/workloads/nemo_run/nemo_run.py
+++ b/src/cloudai/workloads/nemo_run/nemo_run.py
@@ -80,7 +80,7 @@ class Trainer(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     max_steps: Union[int, List[int]] = 100
-    val_check_interval: Union[int, List[int]] = 1000
+    val_check_interval: Union[int, float, list[Union[int, float]]] = 1000
     num_nodes: Optional[Union[int, List[int]]] = None
     strategy: TrainerStrategy = Field(default_factory=TrainerStrategy)
     plugins: Optional[Plugin] = None


### PR DESCRIPTION
## Summary
This ensures compatibility with Pytorch lightning and fixes #543. 

## Test Plan
CI

## Additional Notes
—