### PR TITLE
Fix invalid type for image when cache is disabled

### DIFF
--- a/src/cloudai/util/docker_image_cache_manager.py
+++ b/src/cloudai/util/docker_image_cache_manager.py
@@ -157,7 +157,7 @@ class DockerImageCacheManager:
 
         # If not caching locally, return True. Defer checking URL accessibility to srun.
         if not self.system.cache_docker_images_locally:
-            return DockerImageCacheResult(True, Path(docker_image_url), "")
+            return DockerImageCacheResult(True, None, "")
 
         docker_image_path = Path(docker_image_url)
         if docker_image_path.is_file() and docker_image_path.exists():

--- a/tests/test_slurm_installer.py
+++ b/tests/test_slurm_installer.py
@@ -81,6 +81,13 @@ class TestInstallOneDocker:
         assert res.message == f"Cached Docker image already exists at {cached_file}."
         assert d.installed_path == cached_file
 
+    def test_cache_disabled(self, installer: SlurmInstaller):
+        d = DockerImage("fake_url/img")
+        installer.system.cache_docker_images_locally = False
+        res = installer.is_installed_one(d)
+        assert res.success
+        assert d.installed_path == d.url
+
 
 class TestInstallOneGitRepo:
     @pytest.fixture


### PR DESCRIPTION
## Summary
Fix issue when `Path` was returned instead of `None` for the case when caching is not enabled on the system.

## Test Plan
1. CI (extended)
2. Local dry-run that showed the problem

## Additional Notes
—
