### PR TITLE
Add single sbatch runner for slurm systems

### DIFF
--- a/src/cloudai/_core/test_scenario_parser.py
+++ b/src/cloudai/_core/test_scenario_parser.py
@@ -16,13 +16,14 @@
 
 import copy
 import logging
-import re
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Type
 
 import toml
 from pydantic import ValidationError
+
+from cloudai.util import format_time_limit, parse_time_limit
 
 from ..models.scenario import TestRunModel, TestScenarioModel
 from ..models.workload import TestDefinition
@@ -43,55 +44,6 @@ def get_reporters(test_info: TestRunModel, tdef: TestDefinition) -> Set[Type[Rep
         reporters.add(NcclTestPredictionReportGenerationStrategy)
 
     return reporters
-
-
-def parse_time_limit(limit: str) -> timedelta:
-    try:
-        if re.match(r"^\d+[smhdw]$", limit, re.IGNORECASE):
-            return parse_abbreviated_time(limit)
-        if "-" in limit:
-            return parse_dashed_time(limit)
-        if len(limit.split(":")) == 3:
-            hours, minutes, seconds = map(int, limit.split(":"))
-            return timedelta(hours=hours, minutes=minutes, seconds=seconds)
-        if len(limit.split(":")) == 2:
-            hours, minutes = map(int, limit.split(":"))
-            return timedelta(hours=hours, minutes=minutes)
-    except ValueError as err:
-        raise ValueError(f"Invalid time limit format: {limit}. Refer to SLURM time format documentation.") from err
-
-    raise ValueError(f"Unsupported time limit format: {limit}. Refer to SLURM time format documentation.")
-
-
-def parse_abbreviated_time(limit: str) -> timedelta:
-    value, unit = int(limit[:-1]), limit[-1].lower()
-    if unit == "s":
-        return timedelta(seconds=value)
-    if unit == "m":
-        return timedelta(minutes=value)
-    if unit == "h":
-        return timedelta(hours=value)
-    if unit == "d":
-        return timedelta(days=value)
-    if unit == "w":
-        return timedelta(weeks=value)
-    raise ValueError(f"Invalid abbreviated time format: {limit}")
-
-
-def parse_dashed_time(limit: str) -> timedelta:
-    days, time_part = limit.split("-", 1)
-    hours, minutes, seconds = map(int, time_part.split(":"))
-    return timedelta(days=int(days), hours=hours, minutes=minutes, seconds=seconds)
-
-
-def format_time_limit(total_time: timedelta) -> str:
-    total_seconds = int(total_time.total_seconds())
-    days, remainder = divmod(total_seconds, 86400)
-    hours, remainder = divmod(remainder, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    if days > 0:
-        return f"{days}-{hours:02}:{minutes:02}:{seconds:02}"
-    return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
 def calculate_total_time_limit(test_hooks: List[TestScenario], time_limit: Optional[str] = None) -> Optional[str]:

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -152,6 +152,12 @@ class CloudAICLI:
                 help="Enable cache without checking.",
                 default=False,
             )
+            p.add_argument(
+                "--single-sbatch",
+                action="store_true",
+                help="Use single sbatch for all test runs (Slurm only).",
+                default=False,
+            )
 
     def add_install_and_uninstall(self):
         for mode in {"install", "uninstall"}:

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -39,6 +39,8 @@ from cloudai import (
     TestParser,
     TestScenario,
 )
+from cloudai.runner.slurm.single_sbatch_runner import SingleSbatchRunner
+from cloudai.systems.slurm.slurm_system import SlurmSystem
 
 from ..parser import HOOK_ROOT
 from ..util import prepare_output_dir
@@ -189,6 +191,13 @@ def handle_dry_run_and_run(args: argparse.Namespace) -> int:
     if args.mode == "dry-run":
         system.monitor_interval = 1
     system.update()
+
+    if args.single_sbatch:
+        if not isinstance(system, SlurmSystem):
+            logging.error("Single sbatch is only supported for Slurm systems.")
+            return 1
+
+        Registry().update_runner("slurm", SingleSbatchRunner)
 
     logging.info(f"System Name: {system.name}")
     logging.info(f"Scheduler: {system.scheduler}")

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -222,6 +222,10 @@ def handle_dry_run_and_run(args: argparse.Namespace) -> int:
     runner = Runner(args.mode, system, test_scenario)
     register_signal_handlers(runner.cancel_on_signal)
 
+    if args.single_sbatch:  # in this mode cases are unrolled using grid search
+        handle_non_dse_job(runner, args)
+        return 0
+
     all_dse = all(tr.is_dse_job for tr in test_scenario.test_runs)
 
     if any(tr.is_dse_job for tr in test_scenario.test_runs):

--- a/src/cloudai/runner/slurm/single_sbatch_runner.py
+++ b/src/cloudai/runner/slurm/single_sbatch_runner.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import copy
+import logging
+from datetime import timedelta
+from pathlib import Path
+from typing import Generator, Optional, cast
+
+import toml
+
+from cloudai import JobIdRetrievalError, System, TestRun, TestScenario
+from cloudai._core.test_scenario_parser import format_time_limit, parse_time_limit
+from cloudai.runner.slurm.slurm_runner import SlurmJob, SlurmRunner
+from cloudai.systems.slurm.slurm_system import SlurmJobMetadata, SlurmSystem
+from cloudai.systems.slurm.strategy.slurm_command_gen_strategy import SlurmCommandGenStrategy
+from cloudai.util import CommandShell
+
+
+class SingleSbatchRunner(SlurmRunner):
+    """Slurm runner that puts all tests from a scenario into a single sbatch job."""
+
+    def __init__(self, mode: str, system: System, test_scenario: TestScenario, output_path: Path) -> None:
+        super().__init__(mode, system, test_scenario, output_path)
+        self.cmd_shell = CommandShell()
+        self.system = cast(SlurmSystem, system)
+        self.job_name = "cloudai-single-sbatch"
+
+    def get_sbatch_directives(self) -> list[str]:
+        max_nodes, node_list = self.extract_sbatch_nodes_spec()
+
+        batch_script_content: list[str] = [
+            f"#SBATCH --nodelist={','.join(node_list)}" if node_list else f"#SBATCH -N {max_nodes}",
+            f"#SBATCH --job-name={self.job_name}",
+            f"#SBATCH --output={self.scenario_root.absolute() / 'common.out'}",
+            f"#SBATCH --error={self.scenario_root.absolute() / 'common.err'}",
+            f"#SBATCH --partition={self.system.default_partition}",
+        ]
+        time_limit = self.build_time_limit()
+        if time_limit:
+            batch_script_content.append(f"#SBATCH --time={time_limit}")
+        if self.system.account:
+            batch_script_content.append(f"#SBATCH --account={self.system.account}")
+        if self.system.distribution:
+            batch_script_content.append(f"#SBATCH --distribution={self.system.distribution}")
+        if self.system.gpus_per_node:
+            batch_script_content.append(f"#SBATCH --gpus-per-node={self.system.gpus_per_node}")
+            batch_script_content.append(f"#SBATCH --gres=gpu:{self.system.gpus_per_node}")
+        if self.system.ntasks_per_node:
+            batch_script_content.append(f"#SBATCH --ntasks-per-node={self.system.ntasks_per_node}")
+
+        for arg in self.system.extra_sbatch_args:
+            batch_script_content.append(f"#SBATCH {arg}")
+
+        return batch_script_content
+
+    def build_time_limit(self) -> Optional[str]:
+        total_trs, trs_with_time_limit = 0, 0
+        total_time_limit: timedelta = timedelta(seconds=0)
+        for tr in self.all_trs:
+            total_trs += 1
+            if tr.time_limit:
+                trs_with_time_limit += 1
+                total_time_limit += parse_time_limit(tr.time_limit)
+
+        if trs_with_time_limit == 0:
+            return None
+
+        if trs_with_time_limit != 0 and trs_with_time_limit != total_trs:
+            raise ValueError("All tests must have a time limit or none of them must have a time limit")
+
+        return format_time_limit(total_time_limit)
+
+    def extract_sbatch_nodes_spec(self) -> tuple[int, list[str]]:
+        max_nodes = 1
+        all_node_lists: list[str] = []
+        for tr in self.all_trs:
+            max_nodes = max(max_nodes, tr.nnodes)
+            all_node_lists.extend(tr.nodes)
+
+        _, node_list = self.system.get_nodes_by_spec(max_nodes, all_node_lists)
+        if node_list:
+            if max_nodes <= len(node_list):
+                max_nodes = len(node_list)
+            else:
+                raise ValueError(
+                    f"Number of nodes in the nodes list ({len(node_list)}) does not cover the max number "
+                    f"of nodes ({max_nodes})"
+                )
+
+        return max_nodes, node_list
+
+    def aux_commands(self) -> list[str]:
+        tr = copy.deepcopy(next(self.all_trs))
+        tr.output_path = self.scenario_root
+        max_nodes, _ = self.extract_sbatch_nodes_spec()
+        tr.num_nodes = max_nodes
+        cmd_gen = cast(SlurmCommandGenStrategy, tr.test.test_template.command_gen_strategy)
+        return [cmd_gen._metadata_cmd(tr), cmd_gen._ranks_mapping_cmd(tr)]
+
+    def get_single_tr_block(self, tr: TestRun) -> str:
+        cmd_gen = cast(SlurmCommandGenStrategy, tr.test.test_template.command_gen_strategy)
+        srun_cmd = cmd_gen.gen_srun_command(tr)
+        nnodes, node_list = self.system.get_nodes_by_spec(tr.nnodes, tr.nodes)
+        node_arg = f"--nodelist={','.join(node_list)}" if node_list else f"-N{nnodes}"
+        extra_args = (
+            f"{node_arg} --output={tr.output_path.absolute()}/stdout.txt --error={tr.output_path.absolute()}/stderr.txt"
+        )
+        srun_cmd = srun_cmd.replace("srun", f"srun {extra_args}")
+
+        return srun_cmd
+
+    def unroll_dse(self, tr: TestRun) -> Generator[TestRun, None, None]:
+        for idx, combination in enumerate(tr.all_combinations):
+            next_tr = tr.apply_params_set(combination)
+            next_tr.step = idx + 1
+            next_tr.output_path = self.get_job_output_path(next_tr)
+
+            if next_tr.test.test_definition.constraint_check(next_tr):
+                yield next_tr
+
+    def gen_sbatch_content(self) -> str:
+        content: list[str] = ["#!/bin/bash", *self.get_sbatch_directives(), ""]
+        content.extend(self.aux_commands())
+        content.append("")
+
+        tr = self.test_scenario.test_runs[0]
+        if tr.pre_test:
+            content.append(self.add_pre_tests(tr.pre_test, tr))
+
+        for tr in self.all_trs:
+            content.append(self.get_single_tr_block(tr))
+            content.append("")
+
+        return "\n".join(content)
+
+    def add_pre_tests(self, pre_tc: TestScenario, base_tr: TestRun) -> str:
+        content = []
+        cmd_gen = cast(SlurmCommandGenStrategy, base_tr.test.test_template.command_gen_strategy)
+        content.append(cmd_gen.gen_pre_test(pre_tc, self.scenario_root))
+        content.append("if [ $PRE_TEST_SUCCESS -ne 1 ]; then")
+        content.append("    exit 1")
+        content.append("fi")
+        content.append("")
+        return "\n".join(content)
+
+    @property
+    def all_trs(self) -> Generator[TestRun, None, None]:
+        for tr in self.test_scenario.test_runs:
+            if tr.is_dse_job:
+                for _tr in self.unroll_dse(tr):
+                    yield _tr
+            else:
+                tr.output_path = self.get_job_output_path(tr)
+                yield tr
+
+    async def run(self):
+        if self.shutting_down:
+            return
+
+        self.scenario_root.mkdir(parents=True, exist_ok=True)
+        tr = self.test_scenario.test_runs[0]
+        job = self._submit_test(tr)
+
+        is_completed = False
+        while not is_completed:
+            if self.shutting_down:
+                break
+            is_completed = True if self.mode == "dry-run" else self.system.is_job_completed(job)
+            await asyncio.sleep(self.system.monitor_interval)
+
+        await self.job_completion_callback(job)
+
+    def _submit_test(self, tr: TestRun) -> SlurmJob:
+        with open(self.scenario_root / "cloudai_sbatch_script.sh", "w") as f:
+            f.write(self.gen_sbatch_content())
+
+        job_id = 0
+        if self.mode == "run":
+            exec_cmd = f"sbatch {self.scenario_root / 'cloudai_sbatch_script.sh'}"
+            stdout, stderr = self.cmd_shell.execute(exec_cmd).communicate()
+            job_id = tr.test.test_template.get_job_id(stdout, stderr)
+            if job_id is None:
+                raise JobIdRetrievalError(
+                    test_name=tr.name,
+                    command=exec_cmd,
+                    stdout=stdout,
+                    stderr=stderr,
+                    message="Failed to retrieve job ID from command output.",
+                )
+        logging.info(f"Submitted slurm job: {job_id}")
+        return SlurmJob(tr, id=job_id)
+
+    def store_job_metadata(self, job: SlurmJob):
+        logging.debug(f"Storing job metadata for job {job.id}")
+        res = None if self.mode == "dry-run" else self.system.get_job_status(job)
+        logging.debug(f"Job status ra: {res}")
+
+        job_name, job_state, time_sec = "unknown", "UNKNOWN", 0
+        if res:
+            job_name, job_state, time_sec = res[0], res[1], int(res[2])
+
+        job_meta = SlurmJobMetadata(
+            job_id=int(job.id),
+            job_name=job_name,
+            job_state=job_state,
+            elapsed_time_sec=time_sec,
+            srun_cmd="n/a for single sbatch run",
+            test_cmd="n/a for single sbatch run",
+        )
+
+        job_res = self.scenario_root / "slurm-job.toml"
+        with job_res.open("w") as job_file:
+            toml.dump(job_meta.model_dump(), job_file)
+        logging.debug(f"Saved job metadata: {job_res}")

--- a/src/cloudai/runner/slurm/single_sbatch_runner.py
+++ b/src/cloudai/runner/slurm/single_sbatch_runner.py
@@ -143,6 +143,7 @@ class SingleSbatchRunner(SlurmRunner):
             content.append(self.add_pre_tests(tr.pre_test, tr))
 
         for tr in self.all_trs:
+            self.on_job_submit(tr)
             content.append(self.get_single_tr_block(tr))
             content.append("")
 

--- a/src/cloudai/runner/slurm/single_sbatch_runner.py
+++ b/src/cloudai/runner/slurm/single_sbatch_runner.py
@@ -24,11 +24,10 @@ from typing import Generator, Optional, cast
 import toml
 
 from cloudai import JobIdRetrievalError, System, TestRun, TestScenario
-from cloudai._core.test_scenario_parser import format_time_limit, parse_time_limit
 from cloudai.runner.slurm.slurm_runner import SlurmJob, SlurmRunner
 from cloudai.systems.slurm.slurm_system import SlurmJobMetadata, SlurmSystem
 from cloudai.systems.slurm.strategy.slurm_command_gen_strategy import SlurmCommandGenStrategy
-from cloudai.util import CommandShell
+from cloudai.util import CommandShell, format_time_limit, parse_time_limit
 
 
 class SingleSbatchRunner(SlurmRunner):

--- a/src/cloudai/util/__init__.py
+++ b/src/cloudai/util/__init__.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Optional
 
 from .command_shell import CommandShell
+from .utils import format_time_limit, parse_time_limit
 
 
 def prepare_output_dir(path: Path) -> Optional[Path]:
@@ -45,5 +46,7 @@ def prepare_output_dir(path: Path) -> Optional[Path]:
 
 __all__ = [
     "CommandShell",
+    "format_time_limit",
+    "parse_time_limit",
     "prepare_output_dir",
 ]

--- a/src/cloudai/util/utils.py
+++ b/src/cloudai/util/utils.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from datetime import timedelta
+
+
+def parse_time_limit(limit: str) -> timedelta:
+    try:
+        if re.match(r"^\d+[smhdw]$", limit, re.IGNORECASE):
+            return parse_abbreviated_time(limit)
+        if "-" in limit:
+            return parse_dashed_time(limit)
+        if len(limit.split(":")) == 3:
+            hours, minutes, seconds = map(int, limit.split(":"))
+            return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        if len(limit.split(":")) == 2:
+            hours, minutes = map(int, limit.split(":"))
+            return timedelta(hours=hours, minutes=minutes)
+    except ValueError as err:
+        raise ValueError(f"Invalid time limit format: {limit}. Refer to SLURM time format documentation.") from err
+
+    raise ValueError(f"Unsupported time limit format: {limit}. Refer to SLURM time format documentation.")
+
+
+def parse_abbreviated_time(limit: str) -> timedelta:
+    value, unit = int(limit[:-1]), limit[-1].lower()
+    if unit == "s":
+        return timedelta(seconds=value)
+    if unit == "m":
+        return timedelta(minutes=value)
+    if unit == "h":
+        return timedelta(hours=value)
+    if unit == "d":
+        return timedelta(days=value)
+    if unit == "w":
+        return timedelta(weeks=value)
+    raise ValueError(f"Invalid abbreviated time format: {limit}")
+
+
+def parse_dashed_time(limit: str) -> timedelta:
+    days, time_part = limit.split("-", 1)
+    hours, minutes, seconds = map(int, time_part.split(":"))
+    return timedelta(days=int(days), hours=hours, minutes=minutes, seconds=seconds)
+
+
+def format_time_limit(total_time: timedelta) -> str:
+    total_seconds = int(total_time.total_seconds())
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if days > 0:
+        return f"{days}-{hours:02}:{minutes:02}:{seconds:02}"
+    return f"{hours:02}:{minutes:02}:{seconds:02}"

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -92,6 +92,7 @@ class TestInDryRun:
             test_scenario=test_scenario_path,
             output_dir=tmp_path,
             enable_cache_without_check=False,
+            single_sbatch=False,
             log_file="debug.log",
         )
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,22 +261,24 @@ class TestCLIDefaultModes:
             tests_dir=Path.cwd(),
         )
 
-    def test_run_dry_run_modes(self, cli: CloudAICLI):
+    @pytest.mark.parametrize("single_sbatch", [True, False])
+    def test_run_dry_run_modes(self, cli: CloudAICLI, single_sbatch: bool):
         assert "dry-run" in cli.handlers
         assert "run" in cli.handlers
 
+        cmd = [
+            "--system-config",
+            f"{Path(__file__)}",
+            "--tests-dir",
+            f"{Path.cwd()}",
+            "--test-scenario",
+            f"{Path(__file__)}",
+        ]
+        if single_sbatch:
+            cmd.append("--single-sbatch")
+
         for mode in {"dry-run", "run"}:
-            args = cli.parser.parse_args(
-                [
-                    mode,
-                    "--system-config",
-                    f"{Path(__file__)}",
-                    "--tests-dir",
-                    f"{Path.cwd()}",
-                    "--test-scenario",
-                    f"{Path(__file__)}",
-                ]
-            )
+            args = cli.parser.parse_args([mode, *cmd])
 
             assert args == argparse.Namespace(
                 log_file="debug.log",
@@ -287,6 +289,7 @@ class TestCLIDefaultModes:
                 test_scenario=Path(__file__),
                 output_dir=None,
                 enable_cache_without_check=False,
+                single_sbatch=single_sbatch,
             )
 
     @pytest.mark.parametrize(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -37,10 +37,13 @@ class MyTestDefinition(TestDefinition):
     pass
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def registry():
     registry = Registry()
+
+    strategies_map = copy.copy(registry.strategies_map)
     scenario_reports = copy.copy(registry.scenario_reports)
+
     registry.scenario_reports.clear()
 
     yield registry
@@ -49,6 +52,9 @@ def registry():
     if MyTestDefinition in registry.reports_map:
         del registry.reports_map[MyTestDefinition]
     registry.update_scenario_report(scenario_reports)
+
+    registry.strategies_map.clear()
+    registry.strategies_map.update(strategies_map)
 
 
 class MyRunner(BaseRunner):

--- a/tests/test_single_sbatch_runner.py
+++ b/tests/test_single_sbatch_runner.py
@@ -1,0 +1,513 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import re
+from typing import cast
+
+import pytest
+import toml
+
+from cloudai import TestScenario
+from cloudai._core.test import Test
+from cloudai._core.test_scenario import TestRun
+from cloudai._core.test_template import TestTemplate
+from cloudai.runner.slurm.single_sbatch_runner import SingleSbatchRunner
+from cloudai.runner.slurm.slurm_job import SlurmJob
+from cloudai.systems.slurm.slurm_system import SlurmJobMetadata, SlurmSystem
+from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition, NcclTestSlurmCommandGenStrategy
+from cloudai.workloads.sleep import SleepCmdArgs, SleepSlurmCommandGenStrategy, SleepTestDefinition
+
+
+class MyNCCL(NCCLTestDefinition):
+    def constraint_check(self, tr: TestRun) -> bool:
+        return "CONSTRAINT" not in tr.test.test_definition.extra_env_vars
+
+
+@pytest.fixture
+def nccl_tr(slurm_system: SlurmSystem) -> TestRun:
+    tr = TestRun(
+        name="nccl_test",
+        test=Test(
+            test_definition=MyNCCL(name="nccl", description="desc", test_template_name="t", cmd_args=NCCLCmdArgs()),
+            test_template=TestTemplate(slurm_system),
+        ),
+        num_nodes=2,
+        nodes=[],
+        output_path=slurm_system.output_path,
+    )
+    tr.test.test_template.command_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system, {})
+    return tr
+
+
+@pytest.fixture
+def sleep_tr(slurm_system: SlurmSystem) -> TestRun:
+    tr = TestRun(
+        name="sleep_test",
+        test=Test(
+            test_definition=SleepTestDefinition(
+                name="sleep", description="desc", test_template_name="t", cmd_args=SleepCmdArgs()
+            ),
+            test_template=TestTemplate(slurm_system),
+        ),
+        num_nodes=1,
+        nodes=[],
+        output_path=slurm_system.output_path,
+    )
+    tr.test.test_template.command_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system, {})
+    tr.output_path.mkdir(parents=True, exist_ok=True)
+    return tr
+
+
+def test_sbatch_default(sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    tc = TestScenario(name="tc", test_runs=[sleep_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+
+    sbatch_lines = runner.get_sbatch_directives()
+    assert sbatch_lines == [
+        f"#SBATCH -N {sleep_tr.num_nodes}",
+        f"#SBATCH --job-name={runner.job_name}",
+        f"#SBATCH --output={runner.scenario_root.absolute() / 'common.out'}",
+        f"#SBATCH --error={runner.scenario_root.absolute() / 'common.err'}",
+        f"#SBATCH --partition={slurm_system.default_partition}",
+    ]
+
+
+def test_sbatch_system_fields(sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    sleep_tr.time_limit = "00:00:10"
+    tc = TestScenario(name="tc", test_runs=[sleep_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+
+    runner.system.account = "test_account"
+    runner.system.distribution = "test_distribution"
+    runner.system.gpus_per_node = 2
+    runner.system.ntasks_per_node = 4
+    runner.system.extra_sbatch_args = ["--test-arg1", "--test-arg2"]
+    sbatch_lines = runner.get_sbatch_directives()
+    assert sbatch_lines == [
+        f"#SBATCH -N {sleep_tr.num_nodes}",
+        f"#SBATCH --job-name={runner.job_name}",
+        f"#SBATCH --output={runner.scenario_root.absolute() / 'common.out'}",
+        f"#SBATCH --error={runner.scenario_root.absolute() / 'common.err'}",
+        f"#SBATCH --partition={slurm_system.default_partition}",
+        f"#SBATCH --time={sleep_tr.time_limit}",
+        f"#SBATCH --account={runner.system.account}",
+        f"#SBATCH --distribution={runner.system.distribution}",
+        f"#SBATCH --gpus-per-node={runner.system.gpus_per_node}",
+        f"#SBATCH --gres=gpu:{runner.system.gpus_per_node}",
+        f"#SBATCH --ntasks-per-node={runner.system.ntasks_per_node}",
+        "#SBATCH --test-arg1",
+        "#SBATCH --test-arg2",
+    ]
+
+
+class TestNodeSpec:
+    def test_max_nodes(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(sleep_tr)
+        another_tr.num_nodes = 3
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        sbatch_lines = runner.get_sbatch_directives()
+        assert sbatch_lines[0] == f"#SBATCH -N {another_tr.num_nodes}"
+
+    def test_nodes_list_covers_max(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(sleep_tr)
+        sleep_tr.nodes = []
+        sleep_tr.num_nodes = 1
+        another_tr.nodes = ["node-[030-035]"]
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        sbatch_lines = runner.get_sbatch_directives()
+        _, node_list = runner.system.get_nodes_by_spec(1, another_tr.nodes)
+        assert sbatch_lines[0] == f"#SBATCH --nodelist={','.join(node_list)}"
+
+    def test_nodes_list_does_not_cover_max(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(sleep_tr)
+        sleep_tr.nodes = []
+        sleep_tr.num_nodes = 1
+        another_tr.nodes = ["node-[030-035]"]
+        nnodes, _ = slurm_system.get_nodes_by_spec(1, another_tr.nodes)
+        sleep_tr.num_nodes = nnodes + 1
+
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            runner.get_sbatch_directives()
+
+        assert str(exc_info.value) == (
+            f"Number of nodes in the nodes list ({nnodes}) does not cover the max number "
+            f"of nodes ({sleep_tr.num_nodes})"
+        )
+
+    def test_mixed_spec(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(sleep_tr)
+        sleep_tr.nodes = []
+        sleep_tr.num_nodes = 1
+        another_tr.nodes = ["node-[030-035]"]
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        srun_cmd = runner.get_single_tr_block(sleep_tr)
+        assert f"-N{sleep_tr.num_nodes}" in srun_cmd
+        assert "--nodelist" not in srun_cmd
+
+        srun_cmd = runner.get_single_tr_block(another_tr)
+        assert f"-N{another_tr.num_nodes}" not in srun_cmd
+        assert "--nodelist" in srun_cmd
+
+
+class TestTimeLimit:
+    def test_simple(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        sleep_tr.time_limit = "00:00:10"
+        tc = TestScenario(name="tc", test_runs=[sleep_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        assert runner.build_time_limit() == sleep_tr.time_limit
+
+    def test_no_limits(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(sleep_tr)
+        another_tr.time_limit = None
+        sleep_tr.time_limit = None
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        assert runner.build_time_limit() is None
+
+    def test_mixed_limits(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(sleep_tr)
+        another_tr.time_limit = None
+        sleep_tr.time_limit = "00:00:10"
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            runner.build_time_limit()
+
+        assert str(exc_info.value) == "All tests must have a time limit or none of them must have a time limit"
+
+    def test_sum_limits(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        sleep_tr.time_limit = "00:00:10"
+        another_tr = copy.deepcopy(sleep_tr)
+        another_tr.time_limit = "1-00:10:20"
+        tc = TestScenario(name="tc", test_runs=[sleep_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        assert runner.build_time_limit() == "1-00:10:30"
+
+
+class TestAuxCommands:
+    def test_bare_metal(self, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        tc = TestScenario(name="tc", test_runs=[sleep_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        aux_cmds = runner.aux_commands()
+        assert len(aux_cmds) == 2
+
+        metadata_cmd = (
+            "srun --export=ALL --mpi=pmix --ntasks=1 --ntasks-per-node=1 "
+            f"--output={runner.scenario_root}/metadata/node-%N.toml "
+            f"--error={runner.scenario_root}/metadata/nodes.err "
+            "bash "
+            f"{runner.system.install_path}/slurm-metadata.sh"
+        )
+        assert aux_cmds[0] == metadata_cmd
+
+        ranks_mapping_cmd = (
+            f"srun --export=ALL --mpi=pmix --output={runner.scenario_root}/mapping-stdout.txt "
+            f"--error={runner.scenario_root}/mapping-stderr.txt bash -c "
+            r'"echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."'
+        )
+        assert aux_cmds[1] == ranks_mapping_cmd
+
+    def test_container(self, nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        tdef = cast(NCCLTestDefinition, nccl_tr.test.test_definition)
+        # tdef._docker_image = DockerImage(url="nvcr.io/nvidia/pytorch:24.02-py3", _installed_path=Path("/nccl_install"))
+        tc = TestScenario(name="tc", test_runs=[nccl_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        aux_cmds = runner.aux_commands()
+        assert len(aux_cmds) == 2
+
+        mounts = (
+            f"--container-mounts={runner.system.output_path.absolute()}:/cloudai_run_results,"
+            f"{runner.system.install_path.absolute()}:/cloudai_install,"
+            f"{runner.system.output_path.absolute()}"
+        )
+        metadata_cmd = (
+            f"srun --export=ALL --mpi=pmix --container-image={tdef.docker_image.installed_path} {mounts} "
+            f"--no-container-mount-home --ntasks=2 --ntasks-per-node=1 "
+            f"--output={runner.scenario_root}/metadata/node-%N.toml "
+            f"--error={runner.scenario_root}/metadata/nodes.err "
+            "bash /cloudai_install/slurm-metadata.sh"
+        )
+        assert aux_cmds[0] == metadata_cmd
+
+        ranks_mapping_cmd = (
+            f"srun --export=ALL --mpi=pmix --container-image={tdef.docker_image.installed_path} {mounts} "
+            f"--no-container-mount-home --output={runner.scenario_root}/mapping-stdout.txt "
+            f"--error={runner.scenario_root}/mapping-stderr.txt bash -c "
+            r'"echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."'
+        )
+        assert aux_cmds[1] == ranks_mapping_cmd
+
+    def test_max_nodes_used_for_metadata(self, nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        another_tr = copy.deepcopy(nccl_tr)
+        another_tr.num_nodes = nccl_tr.nnodes + 1
+        tc = TestScenario(name="tc", test_runs=[nccl_tr, another_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        aux_cmds = runner.aux_commands()
+
+        metadata_cmd = aux_cmds[0]
+        assert f"--ntasks={another_tr.nnodes}" in metadata_cmd
+
+    def test_max_nodes_used_for_metadata_dse(self, nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        nccl_tr.num_nodes = [1, 2]
+        tc = TestScenario(name="tc", test_runs=[nccl_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+        aux_cmds = runner.aux_commands()
+
+        metadata_cmd = aux_cmds[0]
+        assert f"--ntasks={max(nccl_tr.num_nodes)}" in metadata_cmd
+
+
+def test_single_tr_block(sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    tc = TestScenario(name="tc", test_runs=[sleep_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+
+    runner.system.global_env_vars["GLOBAL_VAR"] = "global_value"
+    sleep_tr.test.test_definition.extra_env_vars["LOCAL_VAR"] = "local_value"
+    block = runner.get_single_tr_block(sleep_tr)
+
+    tdef = cast(SleepTestDefinition, sleep_tr.test.test_definition)
+    assert block == (
+        f"srun -N1 "
+        f"--output={sleep_tr.output_path.absolute()}/stdout.txt "
+        f"--error={sleep_tr.output_path.absolute()}/stderr.txt "
+        f'--export=ALL --mpi=pmix bash -c "source {sleep_tr.output_path.absolute()}/env_vars.sh; '
+        f'sleep {tdef.cmd_args.seconds}"'
+    )
+
+
+def test_unroll_dse(nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    nccl_tr.test.test_definition.extra_env_vars["NCCL_VAR"] = ["v1", "v2"]
+    tc = TestScenario(name="tc", test_runs=[nccl_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+
+    dse_runs = list(runner.unroll_dse(nccl_tr))
+
+    assert len(dse_runs) == 2
+    assert dse_runs[0].test.test_definition.extra_env_vars["NCCL_VAR"] == "v1"
+    assert dse_runs[1].test.test_definition.extra_env_vars["NCCL_VAR"] == "v2"
+
+
+def test_unroll_dse_constraint_check(nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    nccl_tr.test.test_definition.extra_env_vars["CONSTRAINT"] = "1"
+    tc = TestScenario(name="tc", test_runs=[nccl_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+
+    # assert nccl_tr.test.test_definition.constraint_check(nccl_tr) is False
+    dse_runs = list(runner.unroll_dse(nccl_tr))
+    # dse_runs = list(runner.unroll_dse(nccl_tr))
+    assert len(dse_runs) == 0
+
+
+class TestSbatch:
+    def test_single_case(self, slurm_system: SlurmSystem, nccl_tr: TestRun) -> None:
+        nccl_tr.test.test_definition.extra_env_vars["NCCL_VAR"] = "nccl_value"
+        tc = TestScenario(name="tc", test_runs=[nccl_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        sbatch = runner.gen_sbatch_content()
+        output_paths = [
+            p.replace(f"{runner.scenario_root.absolute()}", "SCENARIO_ROOT")
+            for p in re.findall(r"--output=(\S+)", sbatch)
+        ]
+        assert len(output_paths) == 4
+        assert output_paths[0] == "SCENARIO_ROOT/common.out"
+        assert output_paths[1] == "SCENARIO_ROOT/metadata/node-%N.toml"
+        assert output_paths[2] == "SCENARIO_ROOT/mapping-stdout.txt"
+        assert output_paths[3] == f"SCENARIO_ROOT/{nccl_tr.name}/0/stdout.txt"
+
+    def test_with_two_cases(self, slurm_system: SlurmSystem, nccl_tr: TestRun, sleep_tr: TestRun) -> None:
+        nccl_tr.test.test_definition.extra_env_vars["NCCL_VAR"] = "nccl_value"
+        sleep_tr.test.test_definition.extra_env_vars["SLEEP_VAR"] = "sleep_value"
+        tc = TestScenario(name="tc", test_runs=[nccl_tr, sleep_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        sbatch = runner.gen_sbatch_content()
+        sbatch = sbatch.replace(str(runner.scenario_root.absolute()), "SCENARIO_ROOT").replace(
+            str(runner.system.install_path.absolute()), "INSTALL_PATH"
+        )
+
+        ref = "\n".join(
+            [
+                "#!/bin/bash",
+                *runner.get_sbatch_directives(),
+                "",
+                *runner.aux_commands(),
+                "",
+                runner.get_single_tr_block(nccl_tr),
+                "",
+                runner.get_single_tr_block(sleep_tr),
+                "",
+            ]
+        )
+        ref = ref.replace(str(runner.scenario_root.absolute()), "SCENARIO_ROOT").replace(
+            str(runner.system.install_path.absolute()), "INSTALL_PATH"
+        )
+
+        assert sbatch == ref
+
+        output_paths = [
+            p.replace(f"{runner.scenario_root.absolute()}", "SCENARIO_ROOT")
+            for p in re.findall(r"--output=(\S+)", sbatch)
+        ]
+        assert len(output_paths) == 5
+        assert output_paths[-2] != output_paths[-1]
+
+    def test_dse(self, nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        nccl_tr.test.test_definition.extra_env_vars["NCCL_VAR"] = ["v1", "v2"]
+        tc = TestScenario(name="tc", test_runs=[nccl_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        sbatch = runner.gen_sbatch_content()
+        sbatch = sbatch.replace(str(runner.scenario_root.absolute()), "SCENARIO_ROOT").replace(
+            str(runner.system.install_path.absolute()), "INSTALL_PATH"
+        )
+
+        dse_runs = list(runner.unroll_dse(nccl_tr))
+        ref = "\n".join(
+            [
+                "#!/bin/bash",
+                *runner.get_sbatch_directives(),
+                "",
+                *runner.aux_commands(),
+                "",
+                runner.get_single_tr_block(dse_runs[0]),
+                "",
+                runner.get_single_tr_block(dse_runs[1]),
+                "",
+            ]
+        )
+        ref = ref.replace(str(runner.scenario_root.absolute()), "SCENARIO_ROOT").replace(
+            str(runner.system.install_path.absolute()), "INSTALL_PATH"
+        )
+
+        assert sbatch == ref
+
+        paths = set([str(tr.output_path.absolute()) for tr in dse_runs])
+        assert len(paths) == len(dse_runs), "Output paths are not unique"
+
+    def test_dse_and_non_dse(self, nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+        dse_nccl = copy.deepcopy(nccl_tr)
+        dse_nccl.test.test_definition.extra_env_vars["NCCL_VAR"] = ["v1", "v2"]
+
+        tc = TestScenario(name="tc", test_runs=[dse_nccl, nccl_tr])
+        runner = SingleSbatchRunner(
+            mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path
+        )
+
+        sbatch = runner.gen_sbatch_content()
+        sbatch = sbatch.replace(str(runner.scenario_root.absolute()), "SCENARIO_ROOT").replace(
+            str(runner.system.install_path.absolute()), "INSTALL_PATH"
+        )
+
+        dse_runs = list(runner.unroll_dse(dse_nccl))
+        ref = "\n".join(
+            [
+                "#!/bin/bash",
+                *runner.get_sbatch_directives(),
+                "",
+                *runner.aux_commands(),
+                "",
+                runner.get_single_tr_block(dse_runs[0]),
+                "",
+                runner.get_single_tr_block(dse_runs[1]),
+                "",
+                runner.get_single_tr_block(nccl_tr),
+                "",
+            ]
+        )
+        ref = ref.replace(str(runner.scenario_root.absolute()), "SCENARIO_ROOT").replace(
+            str(runner.system.install_path.absolute()), "INSTALL_PATH"
+        )
+        assert sbatch == ref
+
+
+def test_store_job_metadata(nccl_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    tc = TestScenario(name="tc", test_runs=[nccl_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+    nccl_tr.output_path.mkdir(parents=True, exist_ok=True)
+    runner.mode = "dry-run"
+
+    runner.store_job_metadata(SlurmJob(nccl_tr, id=1))
+
+    out_file = runner.scenario_root / "slurm-job.toml"
+    assert out_file.exists()
+    sjm = SlurmJobMetadata.model_validate(toml.load(out_file))
+    assert sjm.job_id == 1
+    assert sjm.srun_cmd == "n/a for single sbatch run"
+    assert sjm.test_cmd == "n/a for single sbatch run"
+
+
+def test_pre_test(nccl_tr: TestRun, sleep_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    nccl_tr.pre_test = TestScenario(name="pre_test", test_runs=[sleep_tr])
+    tc = TestScenario(name="tc", test_runs=[nccl_tr])
+    runner = SingleSbatchRunner(mode="run", system=slurm_system, test_scenario=tc, output_path=slurm_system.output_path)
+
+    pre_tests = runner.add_pre_tests(nccl_tr.pre_test, nccl_tr)
+    tdef = cast(SleepTestDefinition, sleep_tr.test.test_definition)
+
+    assert pre_tests == "\n".join(
+        [
+            f"srun --output={sleep_tr.output_path.absolute()}/stdout.txt "
+            f"--error={sleep_tr.output_path.absolute()}/stderr.txt "
+            f"--export=ALL --mpi=pmix bash -c "
+            f'"source {sleep_tr.output_path.absolute()}/env_vars.sh; sleep {tdef.cmd_args.seconds}"',
+            "SUCCESS_0=$()",
+            "PRE_TEST_SUCCESS=$( [ $SUCCESS_0 -eq 1 ] && echo 1 || echo 0 )",
+            "if [ $PRE_TEST_SUCCESS -ne 1 ]; then",
+            "    exit 1",
+            "fi",
+            "",
+        ]
+    )


### PR DESCRIPTION
## Summary
Add single sbatch runner for slurm systems: all cases are put into a single sbatch file instead of per-case sbatch files. Some notes:
1. Max number of nodes is chosen automatically based on cases description.
2. DSE cases are unrolled using grid search strategy, agent spec is ignored.
3. Dependency specifications are ignored, cases run one by one.
4. Each case results are still placed into own folder, `test-run.toml` is created per case.
5. `slurm-job.toml` is created per whole job and doesn't contain real command lines.
6. All reports work the same way.
7. New CLI option `--single-sbatch` enables it on Slurm systems, raises an error on others.

## Test Plan
1. CI (extended)
2. See comments for real runs.

## Additional Notes
—