### PR TITLE
Refactor supports_gpu_directives to focus on GresTypes

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -183,6 +183,7 @@ class SlurmSystem(BaseModel, System):
                 self.supports_gpu_directives_cache = True
                 return True
 
+        self.supports_gpu_directives_cache = False
         return False
 
     @field_serializer("install_path", "output_path")

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -178,17 +178,12 @@ class SlurmSystem(BaseModel, System):
             self.supports_gpu_directives_cache = True
             return True
 
-        has_gres_gpu = False
-        has_gpu_gres_type = False
-
         for line in stdout.splitlines():
-            if "AccountingStorageTRES" in line and "gres/gpu" in line:
-                has_gres_gpu = True
-            if "GresTypes" in line and "gpu" in line and "(null)" not in line:
-                has_gpu_gres_type = True
+            if "GresTypes" in line and "gpu" in line:
+                self.supports_gpu_directives_cache = True
+                return True
 
-        self.supports_gpu_directives_cache = has_gres_gpu and has_gpu_gres_type
-        return self.supports_gpu_directives_cache
+        return False
 
     @field_serializer("install_path", "output_path")
     def _path_serializer(self, v: Path) -> str:

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -567,3 +567,31 @@ def test_supports_gpu_directives(
 ):
     mock_fetch_command_output.return_value = (scontrol_output, "")
     assert slurm_system.supports_gpu_directives == expected_support
+
+
+@pytest.mark.parametrize(
+    "initial_output, subsequent_output, expected_support",
+    [
+        # Initial output supports GPU, subsequent output does not
+        ("GresTypes = gpu", "GresTypes = cpu", True),
+        # Initial output does not support GPU, subsequent output does
+        ("GresTypes = cpu", "GresTypes = gpu", False),
+    ],
+)
+@patch("cloudai.systems.slurm.slurm_system.SlurmSystem.fetch_command_output")
+def test_supports_gpu_directives_cache(
+    mock_fetch_command_output,
+    initial_output: str,
+    subsequent_output: str,
+    expected_support: bool,
+    slurm_system: SlurmSystem,
+):
+    mock_fetch_command_output.return_value = (initial_output, "")
+
+    assert slurm_system.supports_gpu_directives is expected_support
+    assert mock_fetch_command_output.call_count == 1
+
+    mock_fetch_command_output.return_value = (subsequent_output, "")
+
+    assert slurm_system.supports_gpu_directives is expected_support
+    assert mock_fetch_command_output.call_count == 1

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -535,33 +535,29 @@ class TestSlurmCommandGenStrategyCache:
 @pytest.mark.parametrize(
     "scontrol_output,expected_support",
     [
-        # Case 1: gres/gpu in AccountingStorageTRES and gpu in GresTypes - should be supported
+        # Case 1: GresTypes includes gpu - should be supported
         (
             """Configuration data as of 2023-06-14T16:28:09
-AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages,gres/gpu,gres/gpumem,gres/gpuutil
 GresTypes               = gpu""",
             True,
         ),
-        # Case 2: gres/gpu in AccountingStorageTRES but GresTypes is (null) - should NOT be supported
+        # Case 2: GresTypes is (null) - should NOT be supported
         (
             """Configuration data as of 2023-06-14T16:28:09
-AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages,gres/gpu,gres/gpumem,gres/gpuutil
 GresTypes               = (null)""",
             False,
         ),
-        # Case 3: No gres/gpu in AccountingStorageTRES - should NOT be supported
+        # Case 3: GresTypes does not include gpu - should NOT be supported
         (
             """Configuration data as of 2023-06-14T16:28:09
-AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages
-GresTypes               = gpu""",
+GresTypes               = cpu""",
             False,
         ),
-        # Case 4: No gres/gpu in AccountingStorageTRES and GresTypes is (null) - should NOT be supported
+        # Case 4: GresTypes includes multiple types including gpu - should be supported
         (
             """Configuration data as of 2023-06-14T16:28:09
-AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages
-GresTypes               = (null)""",
-            False,
+GresTypes               = cpu,gpu,fpga""",
+            True,
         ),
     ],
 )

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -570,16 +570,11 @@ def test_supports_gpu_directives(
 
 
 @pytest.mark.parametrize(
-    "test_value, expected_support",
-    [
-        (True, True),
-        (False, False),
-    ],
+    "cache_value",
+    [True, False],
 )
 @patch("cloudai.systems.slurm.slurm_system.SlurmSystem.fetch_command_output")
-def test_supports_gpu_directives_cache(
-    mock_fetch_command_output, test_value: bool, expected_support: bool, slurm_system: SlurmSystem
-):
-    slurm_system.supports_gpu_directives_cache = test_value
-    assert slurm_system.supports_gpu_directives is expected_support
+def test_supports_gpu_directives_cache(mock_fetch_command_output, cache_value: bool, slurm_system: SlurmSystem):
+    slurm_system.supports_gpu_directives_cache = cache_value
+    assert slurm_system.supports_gpu_directives is cache_value
     mock_fetch_command_output.assert_not_called()

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -570,28 +570,16 @@ def test_supports_gpu_directives(
 
 
 @pytest.mark.parametrize(
-    "initial_output, subsequent_output, expected_support",
+    "test_value, expected_support",
     [
-        # Initial output supports GPU, subsequent output does not
-        ("GresTypes = gpu", "GresTypes = cpu", True),
-        # Initial output does not support GPU, subsequent output does
-        ("GresTypes = cpu", "GresTypes = gpu", False),
+        (True, True),
+        (False, False),
     ],
 )
 @patch("cloudai.systems.slurm.slurm_system.SlurmSystem.fetch_command_output")
 def test_supports_gpu_directives_cache(
-    mock_fetch_command_output,
-    initial_output: str,
-    subsequent_output: str,
-    expected_support: bool,
-    slurm_system: SlurmSystem,
+    mock_fetch_command_output, test_value: bool, expected_support: bool, slurm_system: SlurmSystem
 ):
-    mock_fetch_command_output.return_value = (initial_output, "")
-
+    slurm_system.supports_gpu_directives_cache = test_value
     assert slurm_system.supports_gpu_directives is expected_support
-    assert mock_fetch_command_output.call_count == 1
-
-    mock_fetch_command_output.return_value = (subsequent_output, "")
-
-    assert slurm_system.supports_gpu_directives is expected_support
-    assert mock_fetch_command_output.call_count == 1
+    mock_fetch_command_output.assert_not_called()


### PR DESCRIPTION
## Summary
Refactor supports_gpu_directives to focus on GresTypes

1. Related Chat: https://nvidia.slack.com/archives/C06LC3PRHDZ/p1749064907087079
2. Related PR: https://github.com/NVIDIA/cloudai/pull/541

## Test Plan
1. CI passes
2. Ran on servers

EOS
```
python cloudaix.py run --system-config conf//common/system/eos.toml --tests-dir conf/devops/verification/test/ --test-scenario conf/devops/verification/test_scenario/nemo_run_pretrain_fp8_nightly.toml
```

CW
```
python cloudaix.py run --system-config conf//common/system/cw.toml --tests-dir conf/devops/verification/test/ --test-scenario conf/devops/verification/test_scenario/nemo_run_pretrain_fp8_nightly.toml
```

IL-1
```
python cloudaix.py run --system-config conf//common/system/israel_1.toml --tests-dir conf/devops/verification/test/ --test-scenario conf/devops/verification/test_scenario/nemo_run_pretrain_fp8_nightly.toml
```

+ Zsolt confirmed: https://nvidia.slack.com/archives/C06LC3PRHDZ/p1749071608956029?thread_ts=1749064907.087079&cid=C06LC3PRHDZ

pretyche
```
python ./cloudaix.py run --system-config conf/devops/verification/syste
m/pre-tyche.toml --tests-dir conf/devops/verification/test/ --test-scenario conf/devops/verification/test_scenario/nemo_run_pretrain_fp8_nightly.toml 
```