### PR TITLE
Migrate to modern datetime interface

### DIFF
--- a/src/cloudai/workloads/nccl_test/runai_json_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/runai_json_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, cast
 
 from cloudai import JsonGenStrategy, TestRun
@@ -31,7 +31,7 @@ class NcclTestRunAIJsonGenStrategy(JsonGenStrategy):
         project_id = runai_system.project_id
         cluster_id = runai_system.cluster_id
 
-        postfix = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        postfix = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
         name = f"nccl-test-{postfix}"
 
         training_payload = {


### PR DESCRIPTION
## Summary
This small PR resolves the annoying `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```
