### PR TITLE
Fix path to jinja template

### DIFF
--- a/src/cloudai/reporter.py
+++ b/src/cloudai/reporter.py
@@ -117,6 +117,10 @@ class StatusReporter(Reporter):
     """Generates HTML status reports with system-specific templates."""
 
     @property
+    def template_file_path(self) -> Path:
+        return Path(__file__).parent / "util"
+
+    @property
     def template_file(self) -> str:
         if isinstance(self.system, SlurmSystem):
             return "general-slurm-report.jinja2"
@@ -131,9 +135,9 @@ class StatusReporter(Reporter):
         self.report_best_dse_config()
 
     def generate_scenario_report(self) -> None:
-        template = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(Path(__file__).parent.parent / "util")
-        ).get_template(self.template_file)
+        template = jinja2.Environment(loader=jinja2.FileSystemLoader(self.template_file_path)).get_template(
+            self.template_file
+        )
 
         report_items = (
             SlurmReportItem.from_test_runs(self.trs, self.results_root)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -22,10 +22,12 @@ import pytest
 import toml
 
 from cloudai import Test, TestRun, TestScenario
+from cloudai._core.system import System
 from cloudai.core import CommandGenStrategy, TestTemplate
 from cloudai.models.scenario import TestRunDetails
 from cloudai.reporter import PerTestReporter, StatusReporter, TarballReporter
 from cloudai.systems.slurm.slurm_system import SlurmSystem
+from cloudai.systems.standalone.standalone_system import StandaloneSystem
 from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition
 
 
@@ -136,3 +138,15 @@ def test_best_dse_config(dse_tr: TestRun, slurm_system: SlurmSystem) -> None:
     nccl = NCCLTestDefinition.model_validate(toml.load(best_config_path))
     assert isinstance(nccl.cmd_args, NCCLCmdArgs)
     assert nccl.agent_steps == 12
+
+
+@pytest.mark.parametrize(
+    "system",
+    [
+        SlurmSystem(name="slurm", install_path=Path.cwd(), output_path=Path.cwd(), partitions=[], default_partition=""),
+        StandaloneSystem(name="standalone", install_path=Path.cwd(), output_path=Path.cwd()),
+    ],
+)
+def test_template_file_path(system: System) -> None:
+    reporter = StatusReporter(system, TestScenario(name="test_scenario", test_runs=[]), system.output_path)
+    assert (reporter.template_file_path / reporter.template_file).exists()


### PR DESCRIPTION
## Summary
Fix path to jinja template. Because of this scenario report is not generated.

## Test Plan
1. CI (extended).
2. Manually run `generate-report` on the results with the above failure. Scenario report was generated.

## Additional Notes
Seems that in my env this file was still in old location and I didn't see the warning for real runs. The issues comes from #559.