### PR TITLE
Generate reports for DSE jobs

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -115,6 +115,8 @@ def prepare_installation(
 def handle_dse_job(runner: Runner, args: argparse.Namespace):
     registry = Registry()
 
+    original_test_runs = copy.deepcopy(runner.runner.test_scenario.test_runs)
+
     for tr in runner.runner.test_scenario.test_runs:
         test_run = copy.deepcopy(tr)
         env = CloudAIGymEnv(test_run=test_run, runner=runner)
@@ -139,6 +141,12 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace):
             feedback = {"trial_index": step, "value": reward}
             agent.update_policy(feedback)
             logging.info(f"Step {step}: Observation: {observation}, Reward: {reward}")
+
+    if args.mode == "run":
+        runner.runner.test_scenario.test_runs = original_test_runs
+        generate_reports(runner.runner.system, runner.runner.test_scenario, runner.runner.scenario_root)
+
+    logging.info("All jobs are complete.")
 
 
 def generate_reports(system: System, test_scenario: TestScenario, result_dir: Path) -> None:


### PR DESCRIPTION
## Summary
Reports are currently not generated for DSE jobs. This PR addresses the issue. We will revisit the gym design and architecture at a later time. This is intended as a temporary fix.

## Test Plan
1. CI passes
2. Ran on CW
```
$ python cloudaix.py --log-level DEBUG run --system-config conf//common/system/cw.toml --tests-dir conf/./devops/verification/test/ --test-scenario ./conf/./devops/verification/test_scenario/dse_nccl_test.toml
```

```
$ ls
cloudai_nccl_test_bokeh_report.html  cloudai_sbatch_script.sh  mapping-stderr.txt  metadata    stdout.txt
cloudai_nccl_test_csv_report.csv     env_vars.sh               mapping-stdout.txt  stderr.txt  test-run.toml
```