### PR TITLE
Do not use --copies for venv creation

### DIFF
--- a/src/cloudai/systems/slurm/slurm_installer.py
+++ b/src/cloudai/systems/slurm/slurm_installer.py
@@ -263,7 +263,7 @@ class SlurmInstaller(BaseInstaller):
             logging.debug(msg)
             return InstallStatusResult(True, msg)
 
-        cmd = ["python", "-m", "venv", "--copies", str(venv_path)]
+        cmd = ["python", "-m", "venv", str(venv_path)]
         logging.debug(f"Creating venv using cmd: {' '.join(cmd)}")
         result = subprocess.run(cmd, capture_output=True, text=True)
         logging.debug(f"venv creation STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")

--- a/tests/test_slurm_installer.py
+++ b/tests/test_slurm_installer.py
@@ -188,9 +188,7 @@ class TestInstallOnePythonExecutable:
             mock_run.return_value = CompletedProcess(args=[], returncode=0)
             res = installer._create_venv(py)
         assert res.success
-        mock_run.assert_called_once_with(
-            ["python", "-m", "venv", "--copies", str(venv_path)], capture_output=True, text=True
-        )
+        mock_run.assert_called_once_with(["python", "-m", "venv", str(venv_path)], capture_output=True, text=True)
 
     @pytest.mark.parametrize("failure_on_venv_creation,reqs_install_failure", [(True, False), (False, True)])
     def test_error_creating_venv(


### PR DESCRIPTION
## Summary
In some environments using `--copies` leads to the error. It can happen for `uv`-created venvs. Fixes [internal bug](https://redmine.mellanox.com/issues/4474900).

## Test Plan
1. CI
2. Manual runs of installation.

## Additional Notes
—