### PR TITLE
Add BashCmd workload

### DIFF
--- a/src/cloudai/workloads/bash_cmd/__init__.py
+++ b/src/cloudai/workloads/bash_cmd/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .bash_cmd import BashCmdArgs, BashCmdCommandGenStrategy, BashCmdTestDefinition
+
+__all__ = [
+    "BashCmdArgs",
+    "BashCmdCommandGenStrategy",
+    "BashCmdTestDefinition",
+]

--- a/src/cloudai/workloads/bash_cmd/bash_cmd.py
+++ b/src/cloudai/workloads/bash_cmd/bash_cmd.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+from cloudai.core import CmdArgs, Installable, TestDefinition, TestRun
+from cloudai.systems.slurm import SlurmCommandGenStrategy
+
+
+class BashCmdArgs(CmdArgs):
+    """Arguments for a Bash command."""
+
+    cmd: str
+
+
+class BashCmdTestDefinition(TestDefinition):
+    """Test definition for a Bash command."""
+
+    cmd_args: BashCmdArgs
+
+    @property
+    def installables(self) -> list[Installable]:
+        return [*self.git_repos]
+
+
+class BashCmdCommandGenStrategy(SlurmCommandGenStrategy):
+    """Command generation strategy for generic Slurm container tests."""
+
+    def _container_mounts(self, tr: TestRun) -> list[str]:
+        return []
+
+    def gen_nsys_command(self, tr: TestRun) -> list[str]:
+        """NSYS command is generated as part of the test command and disabled here."""
+        return []
+
+    def gen_srun_prefix(self, tr: TestRun, use_pretest_extras: bool = False) -> list[str]:  # noqa: Vulture
+        return []
+
+    def generate_test_command(
+        self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]], tr: TestRun
+    ) -> list[str]:
+        tdef: BashCmdTestDefinition = cast(BashCmdTestDefinition, tr.test.test_definition)
+        srun_command_parts: list[str] = [*super().gen_nsys_command(tr), tdef.cmd_args.cmd]
+        return [" ".join(srun_command_parts)]
+
+    def gen_srun_success_check(self, tr: TestRun) -> str:
+        return "[ $? -eq 0 ] && echo 1 || echo 0"

--- a/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock
+
+import pytest
+
+from cloudai.core import Test, TestRun, TestTemplate
+from cloudai.systems.slurm import SlurmSystem
+from cloudai.workloads.bash_cmd import BashCmdArgs, BashCmdCommandGenStrategy, BashCmdTestDefinition
+
+
+@pytest.fixture
+def bash_tr(slurm_system: SlurmSystem) -> TestRun:
+    tr = TestRun(
+        name="bash",
+        test=Test(
+            test_definition=BashCmdTestDefinition(
+                name="bash",
+                description="desc",
+                test_template_name="t",
+                cmd_args=BashCmdArgs(cmd="echo 'Hello, world!'"),
+            ),
+            test_template=TestTemplate(slurm_system),
+        ),
+        num_nodes=1,
+        nodes=[],
+        output_path=slurm_system.output_path,
+    )
+    return tr
+
+
+@pytest.fixture
+def bash_cmd_gen(slurm_system: SlurmSystem) -> BashCmdCommandGenStrategy:
+    return BashCmdCommandGenStrategy(slurm_system, {})
+
+
+def test_gen_srun_success_check(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
+    res = bash_cmd_gen.gen_srun_success_check(bash_tr)
+    assert res == "[ $? -eq 0 ] && echo 1 || echo 0"
+
+
+def test_generate_test_command(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
+    res = bash_cmd_gen.generate_test_command({}, {}, bash_tr)
+    assert res == ["echo 'Hello, world!'"]
+
+
+def test_gen_srun_prefix(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
+    res = bash_cmd_gen.gen_srun_prefix(bash_tr)
+    assert res == []
+
+
+def test_gen_nsys_command(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
+    res = bash_cmd_gen.gen_nsys_command(bash_tr)
+    assert res == []
+
+
+def test_gen_container_mounts(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
+    res = bash_cmd_gen._container_mounts(bash_tr)
+    assert res == []
+
+
+def test_installables(bash_tr: TestRun):
+    res = bash_tr.test.test_definition.installables
+    assert res == []
+
+    bash_tr.test.test_definition.git_repos = [Mock()]
+    res = bash_tr.test.test_definition.installables
+    assert len(res) == 1


### PR DESCRIPTION
## Summary
Add `BashCmd` workload. It is a simple bash command without `srun` prefixes.

## Test Plan
1. CI
2. Manually tested as part of https://github.com/Mellanox/cloudaix/pull/192.

## Additional Notes
—