### PR TITLE
Fix for handling srun with multiline commands

### DIFF
--- a/src/cloudai/systems/slurm/slurm_metadata.py
+++ b/src/cloudai/systems/slurm/slurm_metadata.py
@@ -44,10 +44,18 @@ class SlurmStepMetadata(_SlurmStepMetadataBase):
     submit_line: str
 
     @classmethod
-    def from_sacct_single_line(cls, line: str, delimiter: str) -> SlurmStepMetadata:
+    def from_sacct_output(cls, output: str, delimiter: str) -> list[SlurmStepMetadata]:
+        jobs: list[SlurmStepMetadata] = []
+        for line in output.splitlines():
+            if job := cls._from_sacct_single_line(line, delimiter):
+                jobs.append(job)
+        return jobs
+
+    @classmethod
+    def _from_sacct_single_line(cls, line: str, delimiter: str) -> SlurmStepMetadata | None:
         data = line.split(delimiter)
         if len(data) < 8:
-            raise ValueError(f"Invalid line: {line}")
+            return None
 
         job_id, step_id = data[0].split(".") if "." in data[0] else (data[0], "")
 

--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -321,7 +321,7 @@ class SlurmSystem(BaseModel, System):
                 logging.error(error_message)
                 raise RuntimeError(error_message)
 
-            return [SlurmStepMetadata.from_sacct_single_line(line, "|") for line in stdout.splitlines()]
+            return SlurmStepMetadata.from_sacct_output(stdout, delimiter="|")
 
         return []
 

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -599,9 +599,17 @@ sacct_output = """2623913,job,COMPLETED,0:0,2025-05-09T01:34:52,2025-05-09T01:59
 2623913.2,all_reduce_perf_mpi,COMPLETED,0:0,2025-05-09T01:36:16,2025-05-09T01:37:02,46,srun -N2 ...,
 2623913.3,all_reduce_perf_mpi,COMPLETED,0:0,2025-05-09T01:37:02,2025-05-09T01:37:59,57,srun -N2 ...,
 """
+sacct_output2 = """2968718|job:run|COMPLETED|0:0|2025-06-16T07:40:16|2025-06-16T07:49:08|532|sbatch run_submission.sh|
+2968718.batch|batch|COMPLETED|0:0|2025-06-16T07:40:16|2025-06-16T07:49:08|532||
+2968718.extern|extern|COMPLETED|0:0|2025-06-16T07:40:16|2025-06-16T07:49:08|532||
+2968718.0|bash|COMPLETED|0:0|2025-06-16T07:40:54|2025-06-16T07:49:11|497|srun long cmd
+with
+  multiple
+  lines |
+"""
 
 
-@pytest.mark.parametrize("sacct_line", sacct_output.splitlines())
-def test_slurm_job_metadata_from_sacct_output(sacct_line: str):
-    job_metadata = SlurmStepMetadata.from_sacct_single_line(sacct_line, delimiter=",")
-    assert job_metadata is not None
+@pytest.mark.parametrize("sacct_output,delimiter,expected_nsteps", [(sacct_output, ",", 7), (sacct_output2, "|", 4)])
+def test_slurm_job_metadata_from_sacct_output(sacct_output: str, delimiter: str, expected_nsteps: int):
+    job_metadata = SlurmStepMetadata.from_sacct_output(sacct_output, delimiter=delimiter)
+    assert len(job_metadata) == expected_nsteps


### PR DESCRIPTION
## Summary
Fix parsing `sacct` information when `srun` has a multiline command.
Fixes [internal bug](https://redmine.mellanox.com/issues/4501538).

## Test Plan
1. CI (extended).
2. See comments for real runs.

## Additional Notes
—