### PR TITLE
Correctly load and save tdef as part of TestRunDetails

### DIFF
--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -57,7 +57,7 @@ def create_test_directories(slurm_system: SlurmSystem, test_run: TestRun) -> Non
 @pytest.fixture
 def benchmark_tr(slurm_system: SlurmSystem) -> TestRun:
     test_definition = NCCLTestDefinition(
-        name="nccl", description="NCCL test", test_template_name="nccl", cmd_args=NCCLCmdArgs()
+        name="nccl", description="NCCL test", test_template_name="NcclTest", cmd_args=NCCLCmdArgs()
     )
     test_template = TestTemplate(system=slurm_system)
     test = Test(test_definition=test_definition, test_template=test_template)
@@ -71,7 +71,7 @@ def dse_tr(slurm_system: SlurmSystem) -> TestRun:
     test_definition = NCCLTestDefinition(
         name="nccl",
         description="NCCL test",
-        test_template_name="nccl",
+        test_template_name="NcclTest",
         cmd_args=NCCLCmdArgs(),
         extra_env_vars={"VAR1": ["value1", "value2"]},
         agent_steps=12,


### PR DESCRIPTION
## Summary
Correctly load and save test definition objects as part of `TestRunDetails`.

## Test Plan
1. CI (extended).
2. See comments for real runs.

## Additional Notes
—
