### PR TITLE
Llama31_405b 

### DIFF
--- a/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
+++ b/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
@@ -282,7 +282,7 @@ def llama3_70b_bf16_b200_tp_overlap_config() -> run.Config[TransformerLayerTPOve
             BulkOverlapCfg,
             cga_size=2,
             method="bulk",
-            num_sm=16,
+            num_sm=8,
             set_sm_margin=False,
         ),
         qkv_wgrad=run.Config(
@@ -324,7 +324,7 @@ def llama3_70b_bf16_b200_tp_overlap_config() -> run.Config[TransformerLayerTPOve
         ),
         fc1_wgrad=run.Config(
             BulkOverlapCfg,
-            num_sm=4,
+            num_sm=2,
             cga_size=2,
             set_sm_margin=False,
             method="bulk",
@@ -345,7 +345,7 @@ def llama3_70b_bf16_b200_tp_overlap_config() -> run.Config[TransformerLayerTPOve
         ),
         fc2_fprop=run.Config(
             PipelineOverlapCfg,
-            num_sm=16,
+            num_sm=8,
             cga_size=2,
             num_splits=4,
             set_sm_margin=True,
@@ -769,14 +769,28 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
             limit_test_batches=50,
             limit_val_batches=32,
             log_every_n_steps=10,
+            accumulate_grad_batches=1,
+            plugins=run.Config(
+                nl.MegatronMixedPrecision,
+                precision="bf16-mixed",
+                params_dtype=torch.bfloat16,
+                pipeline_dtype=torch.bfloat16,
+                autocast_enabled=False,
+                grad_reduce_in_fp32=False,
+            ),
             strategy=run.Config(
                 nl.MegatronStrategy,
                 tensor_model_parallel_size=8,
                 pipeline_model_parallel_size=1,
                 context_parallel_size=2,
-                virtual_pipeline_model_parallel_size=None,
-                sequence_parallel=False,
+                virtual_pipeline_model_parallel_size=8,
+                sequence_parallel=True,
+                expert_model_parallel_size=1,
+                expert_tensor_parallel_size=None,
                 pipeline_dtype=torch.bfloat16,
+                gradient_as_bucket_view=True,
+                ckpt_async_save=True,
+                ckpt_parallel_load=True,
                 ddp=run.Config(
                     DistributedDataParallelConfig,
                     check_for_nan_in_grad=True,
@@ -786,18 +800,10 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
                 ),
             ),
             num_sanity_val_steps=0,
+            use_distributed_sampler=False,
             val_check_interval=1000,
             max_epochs=10,
             callbacks=[
-                run.Config(
-                    MegatronCommOverlapCallback,
-                    tp_comm_overlap=True,
-                    overlap_grad_reduce=True,
-                    overlap_param_gather=True,
-                    overlap_param_gather_with_optimizer_step=True,
-                    defer_embedding_wgrad_compute=True,
-                    wgrad_deferral_limit=22,
-                ),
                 timing_callback(),
             ],
         ),
@@ -805,11 +811,22 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
             nl.MegatronOptimizerModule,
             config=run.Config(
                 OptimizerConfig,
-                lr=1e-4,
+                lr=0.0003,
                 bf16=True,
+                use_precision_aware_optimizer=True,
                 params_dtype=torch.bfloat16,
                 use_distributed_optimizer=True,
-                weight_decay=0,
+                weight_decay=0.1,
+                adam_beta1=0.9,
+                adam_beta2=0.95,
+                adam_eps=1e-05,
+                clip_grad=1.0,
+            ),
+            lr_scheduler=run.Config(
+                CosineAnnealingScheduler,
+                warmup_steps=2000,
+                constant_steps=0,
+                min_lr=2.9999999999999997e-05,
             ),
         ),
         resume=run.Config(
@@ -819,7 +836,6 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
             resume_past_end=True,
         ),
     )
-    recipe.model.config.vocab_size = 128256
     recipe.trainer.callbacks.append(
         run.Config(
             FLOPsMeasurementCallback,
@@ -832,19 +848,56 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
     set_enable_cuda_graphs_params(recipe)
     recipe.trainer.strategy.cross_entropy_fusion_impl = "te"
 
+    gpu_type = os.getenv("CLOUDAI_GPU_TYPE")
+    compute_dtype = os.getenv("CLOUDAI_GPU_DTYPE")
+    if gpu_type == "h100" and compute_dtype == "bf16":
+        tp_overlap_cfg = llama3_70b_bf16_h100_tp_overlap_config()
+        tp_comm_overlap = True
+    elif gpu_type == "h100" and compute_dtype == "fp8":
+        tp_overlap_cfg = llama3_70b_fp8_h100_tp_overlap_config()
+        tp_comm_overlap = True
+    elif gpu_type == "b200" and compute_dtype == "bf16":
+        tp_overlap_cfg = llama3_70b_bf16_b200_tp_overlap_config()
+        tp_comm_overlap = True
+    elif gpu_type == "b200" and compute_dtype == "fp8":
+        tp_overlap_cfg = llama3_70b_fp8_b200_tp_overlap_config()
+        tp_comm_overlap = True
+    else:
+        print(
+            "Warning: Not using Default Comm Overlap Config.\n"
+            "Please set the GPU type and compute dtype in the environment variables."
+        )
+        tp_overlap_cfg = None
+        tp_comm_overlap = False
+
+    recipe.trainer.callbacks.append(
+        run.Config(
+            MegatronCommOverlapCallback,
+            tp_comm_overlap=tp_comm_overlap,
+            tp_comm_overlap_cfg=tp_overlap_cfg,
+            overlap_param_gather_with_optimizer_step=True,
+            defer_embedding_wgrad_compute=True,
+            wgrad_deferral_limit=22,
+        )
+    )
+    recipe.model.config.expert_tensor_parallel_size = None
+    recipe.model.config.seq_length = 8192
     enable_fsdp = os.getenv("CLOUDAI_ENABLE_FSDP", "0") == "1"
     disable_tp_commd_overlap = os.getenv("CLOUDAI_DISABLE_TP_COMM_OVERLAP", "0") == "1"
     if enable_fsdp:
+        recipe.trainer.limit_val_batches = 0
         recipe.model.config.init_model_with_meta_device = True
         recipe.trainer.strategy.fsdp = "megatron"
         recipe.trainer.strategy.ddp.data_parallel_sharding_strategy = "optim_grads_params"
         recipe.trainer.strategy.ddp.average_in_collective = False
         recipe.trainer.strategy.ddp.keep_fp8_transpose_cache_when_using_custom_fsdp = False
         recipe.model.config.gradient_accumulation_fusion = False
-        recipe.trainer.callbacks[0].defer_embedding_wgrad_compute = False
+        recipe.trainer.callbacks[2].defer_embedding_wgrad_compute = False
+        recipe.trainer.callbacks[2].wgrad_deferral_limit = 50
+        recipe.trainer.callbacks[2].overlap_param_gather_with_optimizer_step = False
 
         if disable_tp_commd_overlap:
-            recipe.trainer.callbacks[0].tp_comm_overlap = False
+            recipe.trainer.callbacks[2].tp_comm_overlap = False
 
     recompute_layers = int(os.getenv("CLOUDAI_RECOMPUTE_LAYERS", "0"))
     if recompute_layers > 0:
@@ -857,6 +910,11 @@ def cloudai_llama3_405b_recipe() -> run.Partial:
         recipe.model.config.cpu_offloading = True
         recipe.model.config.cpu_offloading_weights = False
         recipe.model.config.cpu_offloading_num_layers = activation_offload_layers
+
+    recipe.trainer.strategy.account_for_embedding_in_pipeline_split = True
+    recipe.trainer.strategy.account_for_loss_in_pipeline_split = True
+    recipe.trainer.callbacks.append(run.Config(GarbageCollectionCallback, gc_interval_train=100, gc_interval_val=100))
+    recipe.model.tokenizer = recipe.data.tokenizer
     return recipe
 
 

--- a/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
+++ b/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
@@ -733,8 +733,6 @@ def cloudai_llama3_70b_recipe() -> run.Partial:
         )
     )
     recipe.trainer.strategy.cross_entropy_fusion_impl = "te"
-    gpu_type = os.getenv("CLOUDAI_GPU_TYPE")
-    compute_dtype = os.getenv("CLOUDAI_GPU_DTYPE")
     set_enable_cuda_graphs_params(recipe)
 
     tp_overlap_cfg, tp_comm_overlap = get_tp_overlap_config()

--- a/src/cloudai/workloads/nemo_run/nemo_run.py
+++ b/src/cloudai/workloads/nemo_run/nemo_run.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from pathlib import Path
 from typing import List, Optional, Union, cast
 
@@ -156,9 +157,28 @@ class NeMoRunTestDefinition(TestDefinition):
         gbs = cast(int, self.cmd_args.data.global_batch_size)
 
         constraint1 = num_gpus % (tp * pp * cp) == 0
+        if not constraint1:
+            logging.error(
+                "Constraint 1 failed: num_gpus %% (tp * pp * cp) != 0. "
+                f"Values: num_gpus={num_gpus}, tp={tp}, pp={pp}, cp={cp}"
+            )
+
         constraint2 = True if vp is None else (num_layers // pp) % vp == 0
+        if not constraint2:
+            logging.error(
+                "Constraint 2 failed: vp is not None and (num_layers // pp) %% vp != 0. "
+                f"Values: num_layers={num_layers}, pp={pp}, vp={vp}"
+            )
+
         constraint3 = dp != 0
+        if not constraint3:
+            logging.error(
+                f"Constraint 3 failed: dp == 0. Values: dp={dp}, num_gpus={num_gpus}, tp={tp}, pp={pp}, cp={cp}"
+            )
+
         constraint4 = gbs % (mbs * dp) == 0 if dp != 0 else False
+        if not constraint4:
+            logging.error(f"Constraint 4 failed: gbs %% (mbs * dp) != 0. Values: gbs={gbs}, mbs={mbs}, dp={dp}")
 
         return constraint1 and constraint2 and constraint3 and constraint4
 

--- a/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Union, cast
 
@@ -52,6 +52,16 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if pipeline_model_parallel_size > 1:
             logging.debug("Setting NCCL_P2P_NET_CHUNKSIZE to 2097152 as pipeline_model_parallel_size is greater than 1")
             env_vars["NCCL_P2P_NET_CHUNKSIZE"] = "2097152"
+
+        enable_fsdp = os.getenv("CLOUDAI_ENABLE_FSDP", "0")
+        if enable_fsdp == "1":
+            logging.info(
+                (
+                    "CLOUDAI_ENABLE_FSDP is set to 1. Currently, NemoRun does not support FSDP "
+                    "with TP communication overlap."
+                )
+            )
+            env_vars["CLOUDAI_DISABLE_TP_COMM_OVERLAP"] = "1"
 
     def _run_script(self, tr: TestRun) -> Path:
         tdef: NeMoRunTestDefinition = cast(NeMoRunTestDefinition, tr.test.test_definition)


### PR DESCRIPTION
The request is to enable Llama3 405b on B200/GB200. The FSDP is now supported in Nemo2.0 however, it doesn't currently work with TP [[1](https://github.com/NVIDIA/NeMo/blob/main/scripts/performance/utils.py#L349)] and certain comm overlap [[2](https://github.com/NVIDIA/NeMo/blob/main/scripts/performance/utils.py#L349)] parameters.

This PR adds new feature sets for Nemo2.0 for Llama3 405b (target):

[Update]: FSDP support

- There is a bug that prevents FSDP to be functional: https://gitlab-master.nvidia.com/dl/JoC/nemo-ci/-/issues/2422
- The fix for the above issue will be available in Nemo container 25.07.rc3 (not available yet). 

Layer Recomputation (Potential to save memory)
Offload specific activation layer to CPU

References:
[1] [TP disabled with FSDP](https://github.com/NVIDIA/NeMo/blob/main/scripts/performance/utils.py#L345)
[2][ TP Comm Overlap disabled with FSDP](https://github.com/NVIDIA/NeMo/blob/main/scripts/performance/utils.py#L349)





## Test Plan
CI/CD
Dry-Run
Real System

```
python cloudaix.py run --system-config conf/common/system/prenyx.toml --tests-dir conf/staging/nemo_perf/test/xxx/ --test-scenario conf/staging/nemo_perf/test_scenario/xxx/dse_nemo_run_llama31_405b.toml
[INFO] System Name: xxxx
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: xxx
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: dse_nemo_run_llama31_405b

Section Name: dse_nemo_run_llama31_405b_1
  Test Name: dse_nemo_run_perf_llama31_405b_bf16_converged
  Description: dse_nemo_run_perf_llama31_405b_bf16
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Running step 1 with action {'trainer.strategy.tensor_model_parallel_size': xxx, 'trainer.strategy.pipeline_model_parallel_size': xxx 'trainer.strategy.context_parallel_size': xx 'trainer.strategy.virtual_pipeline_model_parallel_size': xxx, 'data.micro_batch_size': xxx 'data.global_batch_size': xxx}
[INFO] Starting test: dse_nemo_run_llama31_405b_1
[INFO] Running test: dse_nemo_run_llama31_405b_1
[INFO] Submitted slurm job: 600536
[INFO] Job completed: dse_nemo_run_llama31_405b_1 (iteration 1 of 1)
[INFO] Generated scenario report at results/dse_nemo_run_llama31_405b_2025-06-24_16-55-07/dse_nemo_run_llama31_405b.html
[INFO] Writing best config for dse_nemo_run_llama31_405b_1 to results/dse_nemo_run_llama31_405b_2025-06-24_16-55-07/dse_nemo_run_llama31_405b_1/0/dse_nemo_run_llama31_405b_1.toml
[INFO] All jobs are complete.
```
B200 logs: [here](https://drive.google.com/drive/folders/1q39wiL7Thh58qnnNpDj3N-Qr1jpPf2BG)

## Additional Notes
Thanks Malay for adding the Llama3 405b configuration. This [PR](https://github.com/Mellanox/cloudaix/pull/258) from Malay needs to be aligned with this feature support in CLoudAI.

Note: This is duplicate of https://github.com/NVIDIA/cloudai/pull/528. [528](https://github.com/NVIDIA/cloudai/pull/528) will be closed since this [PR 559](https://github.com/NVIDIA/cloudai/pull/559) introduced massive structural change unnecessary effort in fixing merge conflicts.