### PR TITLE
Guard on_job_submit with null check for _command_gen_strategy access

### DIFF
--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -113,8 +113,9 @@ class BaseRunner(ABC):
             exit(1)
 
     def on_job_submit(self, tr: TestRun) -> None:
-        cmd_gen = tr.test.test_template.command_gen_strategy
-        cmd_gen.store_test_run(tr)
+        if tr.test.test_template._command_gen_strategy is not None:
+            cmd_gen = tr.test.test_template.command_gen_strategy
+            cmd_gen.store_test_run(tr)
 
     async def delayed_submit_test(self, tr: TestRun, delay: int = 5):
         """

--- a/src/cloudai/_core/test_template.py
+++ b/src/cloudai/_core/test_template.py
@@ -55,7 +55,7 @@ class TestTemplate:
         """
         self.system = system
         self._command_gen_strategy: Optional[CommandGenStrategy] = None
-        self.json_gen_strategy: Optional[JsonGenStrategy] = None
+        self._json_gen_strategy: Optional[JsonGenStrategy] = None
         self.job_id_retrieval_strategy: Optional[JobIdRetrievalStrategy] = None
         self.job_status_retrieval_strategy: Optional[JobStatusRetrievalStrategy] = None
         self.grading_strategy: Optional[GradingStrategy] = None
@@ -72,6 +72,19 @@ class TestTemplate:
     @command_gen_strategy.setter
     def command_gen_strategy(self, value: CommandGenStrategy) -> None:
         self._command_gen_strategy = value
+
+    @property
+    def json_gen_strategy(self) -> JsonGenStrategy:
+        if self._json_gen_strategy is None:
+            raise ValueError(
+                "json_gen_strategy is missing. Ensure the strategy is registered in the Registry "
+                "by calling the appropriate registration function for the system type."
+            )
+        return self._json_gen_strategy
+
+    @json_gen_strategy.setter
+    def json_gen_strategy(self, value: JsonGenStrategy) -> None:
+        self._json_gen_strategy = value
 
     def gen_exec_command(self, tr: TestRun) -> str:
         """


### PR DESCRIPTION
## Summary
Guard on_job_submit with null check for _command_gen_strategy access

Prerequisite for https://github.com/NVIDIA/cloudai/pull/579

## Test Plan
1. CI passes
2. Ran on a K8s server by rebasing https://github.com/NVIDIA/cloudai/pull/579 to this one.