### PR TITLE
Silently skip NIXL summary generation if no NIXL tests

### DIFF
--- a/src/cloudai/workloads/nixl_bench/nixl_summary_report.py
+++ b/src/cloudai/workloads/nixl_bench/nixl_summary_report.py
@@ -64,6 +64,9 @@ class NIXLBenchSummaryReport(Reporter):
 
     def generate(self) -> None:
         self.load_tdef_with_results()
+        if not self.tdef_res:
+            logging.debug("No NIXL Bench test runs found, skipping report generation.")
+            return
 
         console = Console(record=True)
         for op_type, metric in self.report_configs:


### PR DESCRIPTION
## Summary
Silently skip NIXL summary generation if no NIXL tests.

## Test Plan
1. CI.
2. Manual runs of `run` and `generate-report`.

## Additional Notes
—