### PR TITLE
Remove default_cmd_args field from TestTemplateStrategy

### DIFF
--- a/src/cloudai/_core/test_template_strategy.py
+++ b/src/cloudai/_core/test_template_strategy.py
@@ -34,45 +34,14 @@ class TestTemplateStrategy:
 
     __test__ = False
 
-    def __init__(self, system: System, cmd_args: Dict[str, Union[str, List[str]]]) -> None:
+    def __init__(self, system: System) -> None:
         """
         Initialize a TestTemplateStrategy instance with system configuration, env variables, and command-line arguments.
 
         Args:
             system (System): The system configuration for the test.
-            cmd_args (Dict[str, Union[str, List[str]]]): Default command-line arguments with possible ranges.
         """
         self.system = system
-        self.cmd_args = cmd_args
-        self.default_cmd_args = self._construct_default_cmd_args()
-
-    def _construct_default_cmd_args(self) -> Dict[str, Union[str, List[str]]]:
-        """
-        Construct the default arguments for the test template recursively, flattening ranges.
-
-        Returns:
-            Dict[str, Union[str, List[str]]]: A dictionary containing the combined default arguments
-            with ranges flattened.
-        """
-
-        def construct_args(
-            cmd_args: Dict[str, Union[str, List[str]]], parent_key: str = ""
-        ) -> Dict[str, Union[str, List[str]]]:
-            args: Dict[str, Union[str, List[str]]] = {}
-            for key, value in cmd_args.items():
-                full_key = f"{parent_key}.{key}" if parent_key else key
-
-                if isinstance(value, dict):
-                    nested_args = construct_args(
-                        {k: v for k, v in value.items() if k not in ["type", "default", "values"]},
-                        full_key,
-                    )
-                    args.update(nested_args)
-                else:
-                    args[full_key] = value
-            return args
-
-        return construct_args(self.cmd_args)
 
     @classmethod
     def _flatten_dict(cls, d: Dict[str, Any], parent_key: str = "", sep: str = ".") -> Dict[str, Any]:
@@ -114,27 +83,3 @@ class TestTemplateStrategy:
         final_env_vars = default_env_vars.copy()
         final_env_vars.update(provided_env_vars)
         return final_env_vars
-
-    def _override_cmd_args(
-        self,
-        default_cmd_args: Dict[str, Union[str, List[str]]],
-        provided_cmd_args: Dict[str, Union[str, List[str]]],
-    ) -> Dict[str, Union[str, List[str]]]:
-        """
-        Override the default command-line arguments with provided values.
-
-        Args:
-            default_cmd_args (Dict[str, str]): The default command-line arguments.
-            provided_cmd_args (Dict[str, Union[str, List[str]]]): The provided command-line arguments
-            to override defaults.
-
-        Returns:
-            Dict[str, str]: A dictionary of command-line arguments with overrides applied and ranges flattened.
-        """
-        final_cmd_args = default_cmd_args.copy()
-        flattened_args = self._flatten_dict(provided_cmd_args)
-
-        for key, value in flattened_args.items():
-            final_cmd_args[key] = value
-
-        return final_cmd_args

--- a/src/cloudai/systems/lsf/lsf_command_gen_strategy.py
+++ b/src/cloudai/systems/lsf/lsf_command_gen_strategy.py
@@ -31,17 +31,15 @@ class LSFCommandGenStrategy(CommandGenStrategy):
             properties and methods.
     """
 
-    def __init__(self, system: LSFSystem, cmd_args: Dict[str, Any]) -> None:
+    def __init__(self, system: LSFSystem) -> None:
         """
         Initialize a new LSFCommandGenStrategy instance.
 
         Args:
             system (LSFSystem): The system schema object.
-            cmd_args (Dict[str, Any]): Command-line arguments.
         """
-        super().__init__(system, cmd_args)
+        super().__init__(system)
         self.system = system
-        self.docker_image_url = self.cmd_args.get("docker_image_url", "")
 
     def gen_exec_command(self, tr: TestRun) -> str:
         """
@@ -54,7 +52,7 @@ class LSFCommandGenStrategy(CommandGenStrategy):
             str: The generated LSF command.
         """
         env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
-        cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
+        cmd_args = self._flatten_dict(tr.test.cmd_args)
         lsf_args = self._parse_lsf_args(tr.test.test_template.__class__.__name__, env_vars, cmd_args, tr)
 
         bsub_command = self._gen_bsub_command(lsf_args, env_vars, cmd_args, tr)

--- a/src/cloudai/test_parser.py
+++ b/src/cloudai/test_parser.py
@@ -118,7 +118,6 @@ class TestParser:
         strategy_interface: Type[Union[TestTemplateStrategy, GradingStrategy]],
         system_type: Type[System],
         test_definition_type: Type[TestDefinition],
-        cmd_args: Dict[str, Any],
     ) -> Optional[Union[TestTemplateStrategy, GradingStrategy]]:
         """
         Fetch a strategy from the registry based on system and template.
@@ -128,7 +127,6 @@ class TestParser:
                 The strategy interface to fetch.
             system_type (Type[System]): The system type.
             test_template_type (Type[TestTemplate]): The test template type.
-            cmd_args (Dict[str, Any]): Command-line arguments.
 
         Returns:
             An instance of the requested strategy, or None.
@@ -138,7 +136,7 @@ class TestParser:
         strategy_type = registry.strategies_map.get(key)
         if strategy_type:
             if issubclass(strategy_type, TestTemplateStrategy):
-                return strategy_type(self.system, cmd_args)
+                return strategy_type(self.system)
             else:
                 return strategy_type()
 
@@ -160,19 +158,17 @@ class TestParser:
         Returns:
             Type[TestTemplate]: A subclass of TestTemplate corresponding to the given name.
         """
-        cmd_args = tdef.cmd_args_dict
-
         obj = TestTemplate(system=self.system)
         obj.command_gen_strategy = cast(
             CommandGenStrategy,
-            self._fetch_strategy(CommandGenStrategy, type(obj.system), type(tdef), cmd_args),
+            self._fetch_strategy(CommandGenStrategy, type(obj.system), type(tdef)),
         )
         obj.json_gen_strategy = cast(
             JsonGenStrategy,
-            self._fetch_strategy(JsonGenStrategy, type(obj.system), type(tdef), cmd_args),
+            self._fetch_strategy(JsonGenStrategy, type(obj.system), type(tdef)),
         )
         obj.grading_strategy = cast(
-            GradingStrategy, self._fetch_strategy(GradingStrategy, type(obj.system), type(tdef), cmd_args)
+            GradingStrategy, self._fetch_strategy(GradingStrategy, type(obj.system), type(tdef))
         )
         return obj
 

--- a/src/cloudai/workloads/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/jax_toolbox/slurm_command_gen_strategy.py
@@ -28,8 +28,8 @@ from .nemotron import NemotronTestDefinition
 class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for JaxToolbox tests on Slurm systems."""
 
-    def __init__(self, system: SlurmSystem, cmd_args: Dict[str, Any]) -> None:
-        super().__init__(system, cmd_args)
+    def __init__(self, system: SlurmSystem) -> None:
+        super().__init__(system)
         self.test_name = ""
 
     def image_path(self, tr: TestRun) -> Optional[str]:
@@ -231,12 +231,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return script_lines
 
-    def _generate_python_command(
-        self,
-        stage: str,
-        cmd_args: Dict[str, Any],
-        extra_cmd_args: str,
-    ) -> str:
+    def _generate_python_command(self, stage: str, cmd_args: Dict[str, Any], extra_cmd_args: str) -> str:
         """
         Construct the PAXML Python command for execution in the Slurm environment.
 

--- a/src/cloudai/workloads/nccl_test/kubernetes_json_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/kubernetes_json_gen_strategy.py
@@ -24,7 +24,7 @@ class NcclTestKubernetesJsonGenStrategy(JsonGenStrategy):
 
     def gen_json(self, tr: TestRun) -> Dict[Any, Any]:
         final_env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
-        final_cmd_args = self._override_cmd_args(self.default_cmd_args, tr.test.cmd_args)
+        final_cmd_args = self._flatten_dict(tr.test.cmd_args)
         final_num_nodes = self._determine_num_nodes(tr.nnodes, tr.nodes)
         sanitized_job_name = self.sanitize_k8s_job_name("nccl-test")
         job_spec = self._create_job_spec(

--- a/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
@@ -127,7 +127,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         """
         self.final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
 
-        overriden_cmd_args = self._override_cmd_args(self.default_cmd_args, cmd_args)
+        overriden_cmd_args = self._flatten_dict(cmd_args)
         overriden_cmd_args.pop("launcher_script", None)
         self.final_cmd_args = {k: self._handle_special_keys(k, v) for k, v in sorted(overriden_cmd_args.items())}
 

--- a/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, cast
+from typing import cast
 
 from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy, SlurmSystem
@@ -25,8 +25,8 @@ from .nixl_bench import NIXLBenchTestDefinition
 class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NIXL Bench tests."""
 
-    def __init__(self, system: SlurmSystem, cmd_args: dict[str, Any]) -> None:
-        super().__init__(system, cmd_args)
+    def __init__(self, system: SlurmSystem) -> None:
+        super().__init__(system)
 
         self._current_image_url: str | None = None
 

--- a/src/cloudai/workloads/triton_inference/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/triton_inference/slurm_command_gen_strategy.py
@@ -26,8 +26,8 @@ from .triton_inference import TritonInferenceTestDefinition
 class TritonInferenceSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for TritonInference server and client."""
 
-    def __init__(self, system: SlurmSystem, cmd_args: Dict[str, Any]) -> None:
-        super().__init__(system, cmd_args)
+    def __init__(self, system: SlurmSystem) -> None:
+        super().__init__(system)
         self._current_container_image: str | None = None
 
     def _container_mounts(self, tr: TestRun) -> list[str]:

--- a/tests/json_gen_strategy/test_nccl_runai_json_gen_strategy.py
+++ b/tests/json_gen_strategy/test_nccl_runai_json_gen_strategy.py
@@ -26,7 +26,7 @@ from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition, NcclTes
 class TestNcclTestRunAIJsonGenStrategy:
     @pytest.fixture
     def json_gen_strategy(self, runai_system: RunAISystem) -> NcclTestRunAIJsonGenStrategy:
-        return NcclTestRunAIJsonGenStrategy(runai_system, {})
+        return NcclTestRunAIJsonGenStrategy(runai_system)
 
     def test_gen_json(self, json_gen_strategy: NcclTestRunAIJsonGenStrategy) -> None:
         cmd_args = NCCLCmdArgs.model_validate({"subtest_name": "all_reduce_perf", "docker_image_url": "fake_image_url"})

--- a/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
@@ -45,7 +45,7 @@ def bash_tr(slurm_system: SlurmSystem) -> TestRun:
 
 @pytest.fixture
 def bash_cmd_gen(slurm_system: SlurmSystem) -> BashCmdCommandGenStrategy:
-    return BashCmdCommandGenStrategy(slurm_system, {})
+    return BashCmdCommandGenStrategy(slurm_system)
 
 
 def test_gen_srun_success_check(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):

--- a/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
@@ -27,7 +27,7 @@ from tests.conftest import create_autospec_dataclass
 class TestChakraReplaySlurmCommandGenStrategy:
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> ChakraReplaySlurmCommandGenStrategy:
-        return ChakraReplaySlurmCommandGenStrategy(slurm_system, {})
+        return ChakraReplaySlurmCommandGenStrategy(slurm_system)
 
     @pytest.mark.parametrize(
         "cmd_args, extra_cmd_args, expected_result",

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -32,8 +32,7 @@ class MySlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
 @pytest.fixture
 def strategy_fixture(slurm_system: SlurmSystem) -> SlurmCommandGenStrategy:
-    cmd_args: Dict[str, Union[str, List[str]]] = {"test_arg": "test_value"}
-    strategy = MySlurmCommandGenStrategy(slurm_system, cmd_args)
+    strategy = MySlurmCommandGenStrategy(slurm_system)
     return strategy
 
 
@@ -141,7 +140,7 @@ def make_test_run(slurm_system: SlurmSystem, name: str, output_dir: Path) -> Tes
         extra_env_vars={"TEST_VAR": "VALUE"},
     )
     test_template = TestTemplate(slurm_system)
-    test_template.command_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system, test_def.cmd_args_dict)
+    test_template.command_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system)
     test = Test(test_definition=test_def, test_template=test_template)
     return TestRun(name=name, test=test, num_nodes=1, nodes=["node1"], output_path=output_dir / name)
 
@@ -344,7 +343,7 @@ def test_gen_srun_prefix_with_pretest_extras(
         def pre_test_srun_extra_args(self, tr: TestRun) -> List[str]:
             return ["--pre-arg1", "--pre-arg2"]
 
-    with patch.object(strategy_fixture, "_get_cmd_gen_strategy", return_value=PreTestCmdGenStrategy(slurm_system, {})):
+    with patch.object(strategy_fixture, "_get_cmd_gen_strategy", return_value=PreTestCmdGenStrategy(slurm_system)):
         srun_prefix_with_extras = strategy_fixture.gen_srun_prefix(tr, use_pretest_extras=use_pretest_extras)
 
     assert ("--pre-arg1" in srun_prefix_with_extras) is use_pretest_extras

--- a/tests/slurm_command_gen_strategy/test_jax_toolbox_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_jax_toolbox_slurm_command_gen_strategy.py
@@ -34,7 +34,7 @@ from cloudai.workloads.jax_toolbox import (
 class TestJaxToolboxSlurmCommandGenStrategy:
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> JaxToolboxSlurmCommandGenStrategy:
-        return JaxToolboxSlurmCommandGenStrategy(slurm_system, {})
+        return JaxToolboxSlurmCommandGenStrategy(slurm_system)
 
     @pytest.fixture
     def gpt_test(self) -> GPTTestDefinition:
@@ -159,22 +159,16 @@ class TestJaxToolboxSlurmCommandGenStrategy:
     ):
         grok_test.cmd_args.enable_pgle = enable_pgle
         cargs = {"output_path": str(tmp_path), **grok_test.cmd_args_dict}
-        cmd_gen = JaxToolboxSlurmCommandGenStrategy(slurm_system, cargs)
+        cmd_gen = JaxToolboxSlurmCommandGenStrategy(slurm_system)
         cmd_gen.test_name = "Grok"
         cmd_gen._script_content = MagicMock(return_value="")
         cmd_gen._create_run_script({}, cargs, "")
         assert cmd_gen._script_content.call_count == expected_ncalls
 
     def test_generate_python_command(
-        self,
-        slurm_system: SlurmSystem,
-        cmd_gen_strategy: JaxToolboxSlurmCommandGenStrategy,
-        gpt_test: GPTTestDefinition,
-        tmp_path: Path,
+        self, cmd_gen_strategy: JaxToolboxSlurmCommandGenStrategy, gpt_test: GPTTestDefinition
     ) -> None:
-        cmd_gen_strategy = JaxToolboxSlurmCommandGenStrategy(slurm_system, gpt_test.cmd_args_dict)
-        cargs = {"output_path": "/path/to/output", **gpt_test.cmd_args_dict}
-        cargs = cmd_gen_strategy._override_cmd_args(cmd_gen_strategy.default_cmd_args, cargs)
+        cargs = cmd_gen_strategy._flatten_dict({"output_path": "/path/to/output", **gpt_test.cmd_args_dict})
 
         cmd_gen_strategy.test_name = "GPT"
 

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -27,7 +27,7 @@ from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition, NcclTes
 class TestNcclTestSlurmCommandGenStrategy:
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> NcclTestSlurmCommandGenStrategy:
-        return NcclTestSlurmCommandGenStrategy(slurm_system, {})
+        return NcclTestSlurmCommandGenStrategy(slurm_system)
 
     @pytest.mark.parametrize(
         "job_name_prefix, env_vars, cmd_args, num_nodes, nodes, expected_result",

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
@@ -59,7 +59,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
 
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> NeMoLauncherSlurmCommandGenStrategy:
-        return NeMoLauncherSlurmCommandGenStrategy(slurm_system, {})
+        return NeMoLauncherSlurmCommandGenStrategy(slurm_system)
 
     @pytest.mark.parametrize(
         "expected_content, nodes",

--- a/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
@@ -59,7 +59,7 @@ class TestNeMoRunSlurmCommandGenStrategy:
 
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> NeMoRunSlurmCommandGenStrategy:
-        return NeMoRunSlurmCommandGenStrategy(slurm_system, {})
+        return NeMoRunSlurmCommandGenStrategy(slurm_system)
 
     def test_generate_test_command(self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy, test_run: TestRun) -> None:
         cmd_args = NeMoRunCmdArgs(

--- a/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
@@ -49,7 +49,7 @@ def nixl_bench_tr(slurm_system: SlurmSystem):
 
 class TestNIXLBenchCommand:
     def test_default(self, nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
-        strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, {})
+        strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system)
         cmd = strategy.gen_nixlbench_command(nixl_bench_tr)
         assert cmd == ["./nixlbench", "--etcd-endpoints http://127.0.0.1:2379"]
 
@@ -63,7 +63,7 @@ class TestNIXLBenchCommand:
                 **in_args,
             }
         )
-        strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, {})
+        strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system)
         nixl_bench_tr.test.test_definition.cmd_args = cmd_args
 
         cmd = " ".join(strategy.gen_nixlbench_command(nixl_bench_tr))
@@ -73,7 +73,7 @@ class TestNIXLBenchCommand:
 
 
 def test_gen_etcd_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
-    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, {})
+    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system)
     cmd = " ".join(strategy.gen_etcd_srun_command(nixl_bench_tr))
     assert (
         "/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 "
@@ -92,7 +92,7 @@ def test_gen_etcd_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 
 @pytest.mark.parametrize("nnodes", (1, 2))
 def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem, nnodes: int):
-    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, {})
+    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system)
     nixl_bench_tr.num_nodes = nnodes
     cmd = " ".join(strategy.gen_nixl_srun_command(nixl_bench_tr))
 
@@ -109,6 +109,6 @@ def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 
 
 def test_gen_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
-    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, {})
+    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system)
     cmd = strategy._gen_srun_command({}, {}, nixl_bench_tr)
     assert "sleep 5" in cmd

--- a/tests/slurm_command_gen_strategy/test_sleep_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_sleep_slurm_command_gen_strategy.py
@@ -30,7 +30,7 @@ class TestSleepSlurmCommandGenStrategy:
 
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> SleepSlurmCommandGenStrategy:
-        return SleepSlurmCommandGenStrategy(slurm_system, {})
+        return SleepSlurmCommandGenStrategy(slurm_system)
 
     @pytest.mark.parametrize(
         "cmd_args_data, expected_command",

--- a/tests/slurm_command_gen_strategy/test_slurm_container_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_slurm_container_slurm_command_gen_strategy.py
@@ -43,7 +43,7 @@ def test_run(slurm_system: SlurmSystem) -> TestRun:
 
 
 def test_default(slurm_system: SlurmSystem, test_run: TestRun) -> None:
-    cgs = SlurmContainerCommandGenStrategy(slurm_system, {})
+    cgs = SlurmContainerCommandGenStrategy(slurm_system)
     cmd = cgs.gen_srun_command(test_run)
     srun_part = (
         f"srun --export=ALL --mpi={slurm_system.mpi} "
@@ -58,7 +58,7 @@ def test_default(slurm_system: SlurmSystem, test_run: TestRun) -> None:
 
 
 def test_with_nsys(slurm_system: SlurmSystem, test_run: TestRun) -> None:
-    cgs = SlurmContainerCommandGenStrategy(slurm_system, {})
+    cgs = SlurmContainerCommandGenStrategy(slurm_system)
     nsys = NsysConfiguration()
     test_run.test.test_definition.nsys = nsys
     cmd = cgs.gen_srun_command(test_run)
@@ -80,7 +80,7 @@ def test_with_extra_srun_args(slurm_system: SlurmSystem, test_run: TestRun) -> N
     tdef = cast(SlurmContainerTestDefinition, test_run.test.test_definition)
     tdef.extra_srun_args = extra_args
 
-    cgs = SlurmContainerCommandGenStrategy(slurm_system, {})
+    cgs = SlurmContainerCommandGenStrategy(slurm_system)
     cmd = cgs.gen_srun_command(test_run)
 
     srun_part = (

--- a/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
@@ -32,7 +32,7 @@ from cloudai.workloads.triton_inference import (
 
 @pytest.fixture
 def strategy(slurm_system: SlurmSystem) -> TritonInferenceSlurmCommandGenStrategy:
-    return TritonInferenceSlurmCommandGenStrategy(slurm_system, {})
+    return TritonInferenceSlurmCommandGenStrategy(slurm_system)
 
 
 @pytest.fixture

--- a/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
@@ -27,7 +27,7 @@ from cloudai.workloads.ucc_test import UCCCmdArgs, UCCTestDefinition, UCCTestSlu
 class TestUCCTestSlurmCommandGenStrategy:
     @pytest.fixture
     def cmd_gen_strategy(self, slurm_system: SlurmSystem) -> UCCTestSlurmCommandGenStrategy:
-        return UCCTestSlurmCommandGenStrategy(slurm_system, {})
+        return UCCTestSlurmCommandGenStrategy(slurm_system)
 
     @pytest.mark.parametrize(
         "cmd_args_data, extra_cmd_args, expected_command",

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -161,9 +161,7 @@ def create_test_run(
         name=name,
         test=Test(test_definition=test_definition, test_template=TestTemplate(slurm_system)),
     )
-    tr.test.test_template.command_gen_strategy = command_gen_strategy(
-        slurm_system, tr.test.test_definition.cmd_args_dict
-    )
+    tr.test.test_template.command_gen_strategy = command_gen_strategy(slurm_system)
     if isinstance(tr.test.test_template.command_gen_strategy, SlurmCommandGenStrategy):
         tr.test.test_template.command_gen_strategy.job_name = Mock(return_value="job_name")
     return tr

--- a/tests/test_get_job_id.py
+++ b/tests/test_get_job_id.py
@@ -59,7 +59,7 @@ def test_scenario(slurm_system: SlurmSystem) -> TestScenario:
         ],
     )
     test_scenario.test_runs[0].output_path.mkdir(parents=True, exist_ok=True)
-    test_scenario.test_runs[0].test.test_template.command_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system, {})
+    test_scenario.test_runs[0].test.test_template.command_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system)
     return test_scenario
 
 

--- a/tests/test_single_sbatch_runner.py
+++ b/tests/test_single_sbatch_runner.py
@@ -45,7 +45,7 @@ def nccl_tr(slurm_system: SlurmSystem) -> TestRun:
         nodes=[],
         output_path=slurm_system.output_path / "nccl_test",
     )
-    tr.test.test_template.command_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system, {})
+    tr.test.test_template.command_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system)
     return tr
 
 
@@ -63,7 +63,7 @@ def sleep_tr(slurm_system: SlurmSystem) -> TestRun:
         nodes=[],
         output_path=slurm_system.output_path / "sleep_test",
     )
-    tr.test.test_template.command_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system, {})
+    tr.test.test_template.command_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system)
     tr.output_path.mkdir(parents=True, exist_ok=True)
     return tr
 

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -404,7 +404,7 @@ class TestSlurmCommandGenStrategyCache:
     def test_strategy_caching(self, mock_get_nodes: Mock, slurm_system: SlurmSystem, test_run: TestRun):
         mock_get_nodes.return_value = (2, ["node01", "node02"])
 
-        strategy = ConcreteSlurmStrategy(slurm_system, {})
+        strategy = ConcreteSlurmStrategy(slurm_system)
 
         # First call to get nodes
         res = strategy.get_cached_nodes_spec(test_run)
@@ -432,7 +432,7 @@ class TestSlurmCommandGenStrategyCache:
         mock_get_nodes.side_effect = [(2, ["node01", "node02"]), (2, ["node03", "node04"])]
 
         # Simulate two different test cases
-        strategy1, strategy2 = ConcreteSlurmStrategy(slurm_system, {}), ConcreteSlurmStrategy(slurm_system, {})
+        strategy1, strategy2 = ConcreteSlurmStrategy(slurm_system), ConcreteSlurmStrategy(slurm_system)
 
         res = strategy1.get_cached_nodes_spec(test_run)
         assert mock_get_nodes.call_count == 1
@@ -448,7 +448,7 @@ class TestSlurmCommandGenStrategyCache:
     def test_per_iteration_isolation(self, mock_get_nodes: Mock, slurm_system: SlurmSystem, test_run: TestRun):
         mock_get_nodes.side_effect = [(2, ["node01", "node02"]), (2, ["node03", "node04"])]
 
-        strategy = ConcreteSlurmStrategy(slurm_system, {})
+        strategy = ConcreteSlurmStrategy(slurm_system)
 
         res = strategy.get_cached_nodes_spec(test_run)
         assert mock_get_nodes.call_count == 1
@@ -463,7 +463,7 @@ class TestSlurmCommandGenStrategyCache:
     def test_per_step_isolation(self, mock_get_nodes: Mock, slurm_system: SlurmSystem, test_run: TestRun):
         mock_get_nodes.side_effect = [(2, ["node01", "node02"]), (2, ["node03", "node04"])]
 
-        strategy = ConcreteSlurmStrategy(slurm_system, {})
+        strategy = ConcreteSlurmStrategy(slurm_system)
 
         res = strategy.get_cached_nodes_spec(test_run)
         assert mock_get_nodes.call_count == 1


### PR DESCRIPTION
## Summary
1. It wasn't used for long time, same args come via TestRun object.
2. Constructor simplified to accept only system, args are not needed.
3. Additionally, removed _override_cmd_args as it was used in combination with default_cmd_args only.

## Test Plan
1. CI.
2. See comments for real runs.

## Additional Notes
—