### PR TITLE
Require docker image for NCCL tests to be explicitly set in config

### DIFF
--- a/conf/common/test/dse_nccl_all_gather.toml
+++ b/conf/common/test/dse_nccl_all_gather.toml
@@ -19,6 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "all_gather_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "128"

--- a/conf/common/test/nccl_test.toml
+++ b/conf/common/test/nccl_test.toml
@@ -19,6 +19,7 @@ description = "NCCL base test configuration"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 ngpus = 1
 minbytes = "128"
 maxbytes = "4G"

--- a/conf/common/test/nccl_test_all_gather.toml
+++ b/conf/common/test/nccl_test_all_gather.toml
@@ -19,6 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "all_gather_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "128"

--- a/conf/common/test_scenario/nccl_test.toml
+++ b/conf/common/test_scenario/nccl_test.toml
@@ -68,6 +68,7 @@ description = "scatter_perf"
 test_template_name = "NcclTest"
 
   [Tests.cmd_args]
+  docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
   subtest_name = "scatter_perf_mpi"
   ngpus = 1
   minbytes = "128"

--- a/conf/hook/test/nccl_test_all_gather.toml
+++ b/conf/hook/test/nccl_test_all_gather.toml
@@ -19,6 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "all_gather_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "128"

--- a/conf/release/nemo_acceptance/test/nccl_test_all_reduce_loopback.toml
+++ b/conf/release/nemo_acceptance/test/nccl_test_all_reduce_loopback.toml
@@ -23,6 +23,7 @@ NCCL_P2P_DISABLE = "1"
 NCCL_SHM_DISABLE = "1"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "all_reduce_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "8M"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather.toml
@@ -19,6 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "all_gather_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather_worst.toml
@@ -19,6 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "all_gather_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce.toml
@@ -19,6 +19,7 @@ description = "all_reduce"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "all_reduce_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce_worst.toml
@@ -19,6 +19,7 @@ description = "all_reduce_worst_alloc_test"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "all_reduce_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall.toml
@@ -19,6 +19,7 @@ description = "alltoall"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "alltoall_perf_mpi"
 minbytes = "1k"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst.toml
@@ -19,6 +19,7 @@ description = "alltoall_tested_job"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "alltoall_perf_mpi"
 minbytes = "1k"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst_failover.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst_failover.toml
@@ -19,6 +19,7 @@ description = "alltoall_tested_job"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "alltoall_perf_mpi"
 minbytes = "128M"
 maxbytes = "128M"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_bisection.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_bisection.toml
@@ -19,6 +19,7 @@ description = "nccl_test_bisection"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "bisection_perf_mpi"
 ngpus = "1"
 minbytes = "128"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_broadcast.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_broadcast.toml
@@ -19,4 +19,5 @@ description = "broadcast"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "broadcast_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_gather.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_gather.toml
@@ -19,4 +19,5 @@ description = "gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "gather_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_hypercube.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_hypercube.toml
@@ -19,4 +19,5 @@ description = "hypercube"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "hypercube_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce.toml
@@ -19,4 +19,5 @@ description = "reduce"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "reduce_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter.toml
@@ -19,6 +19,7 @@ description = "reduce_scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "reduce_scatter_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter_worst.toml
@@ -19,6 +19,7 @@ description = "reduce_scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "reduce_scatter_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_scatter.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_scatter.toml
@@ -19,4 +19,5 @@ description = "scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
+"docker_image_url" = "nvcr.io/nvidia/pytorch:24.02-py3"
 "subtest_name" = "scatter_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv.toml
@@ -19,6 +19,7 @@ description = "sendrecv"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "sendrecv_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv_worst.toml
@@ -19,6 +19,7 @@ description = "sendrecv"
 test_template_name = "NcclTest"
 
 [cmd_args]
+docker_image_url = "nvcr.io/nvidia/pytorch:24.02-py3"
 subtest_name = "sendrecv_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/src/cloudai/workloads/nccl_test/nccl.py
+++ b/src/cloudai/workloads/nccl_test/nccl.py
@@ -23,7 +23,7 @@ from cloudai.models.workload import CmdArgs, TestDefinition
 class NCCLCmdArgs(CmdArgs):
     """NCCL test command arguments."""
 
-    docker_image_url: str = "nvcr.io/nvidia/pytorch:24.02-py3"
+    docker_image_url: str
     subtest_name: Union[
         Literal[
             "all_reduce_perf_mpi",

--- a/tests/report_generation_strategy/test_nccl_performance_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_nccl_performance_report_generation_strategy.py
@@ -32,7 +32,7 @@ def nccl_tr(tmp_path: Path) -> TestRun:
             name="nccl",
             description="desc",
             test_template_name="t",
-            cmd_args=NCCLCmdArgs(),
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         ),
         test_template=Mock(),
     )

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -42,7 +42,7 @@ def testrun_fixture(tmp_path: Path, slurm_system: SlurmSystem) -> TestRun:
         name="test_job",
         description="Test description",
         test_template_name="d",
-        cmd_args=NCCLCmdArgs(),
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         extra_env_vars={"TEST_VAR": "VALUE"},
     )
 
@@ -136,7 +136,7 @@ def make_test_run(slurm_system: SlurmSystem, name: str, output_dir: Path) -> Tes
         name=name,
         description=name,
         test_template_name="nccl",
-        cmd_args=NCCLCmdArgs(),
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         extra_env_vars={"TEST_VAR": "VALUE"},
     )
     test_template = TestTemplate(slurm_system)
@@ -276,7 +276,7 @@ def test_default_container_mounts_with_extra_mounts(strategy_fixture: SlurmComma
         name="name",
         description="desc",
         test_template_name="tt",
-        cmd_args=NCCLCmdArgs(),
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         extra_container_mounts=["/host:/container"],
     )
     t = Test(test_definition=nccl, test_template=Mock())
@@ -296,7 +296,7 @@ def test_default_container_mounts_with_git_repos(strategy_fixture: SlurmCommandG
         name="name",
         description="desc",
         test_template_name="tt",
-        cmd_args=NCCLCmdArgs(),
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         git_repos=[repo1, repo2],
     )
     t = Test(test_definition=nccl, test_template=Mock())

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -65,7 +65,11 @@ class TestNcclTestSlurmCommandGenStrategy:
         expected_result: Dict[str, Any],
     ) -> None:
         nccl = NCCLTestDefinition(
-            name="name", description="desc", test_template_name="tt", cmd_args=NCCLCmdArgs(), extra_env_vars=env_vars
+            name="name",
+            description="desc",
+            test_template_name="NcclTest",
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+            extra_env_vars=env_vars,
         )
         t = Test(test_definition=nccl, test_template=Mock())
         tr = TestRun(name="t1", test=t, nodes=nodes, num_nodes=num_nodes)
@@ -83,7 +87,7 @@ class TestNcclTestSlurmCommandGenStrategy:
         self, cmd_gen_strategy: NcclTestSlurmCommandGenStrategy, args: dict[str, Union[str, list[str]]]
     ) -> None:
         cmd_args: NCCLCmdArgs = NCCLCmdArgs.model_validate({**{"docker_image_url": "fake_image_url"}, **args})
-        nccl = NCCLTestDefinition(name="name", description="desc", test_template_name="tt", cmd_args=cmd_args)
+        nccl = NCCLTestDefinition(name="name", description="desc", test_template_name="NcclTest", cmd_args=cmd_args)
         t = Test(test_definition=nccl, test_template=Mock())
         tr = TestRun(name="t1", test=t, nodes=[], num_nodes=1)
 

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -301,7 +301,12 @@ def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -
             partial_tr,
             slurm_system,
             "nccl",
-            NCCLTestDefinition(name="nccl", description="nccl", test_template_name="nccl", cmd_args=NCCLCmdArgs()),
+            NCCLTestDefinition(
+                name="nccl",
+                description="nccl",
+                test_template_name="nccl",
+                cmd_args=NCCLCmdArgs(docker_image_url="nvcr.io/nvidia/pytorch:24.02-py3"),
+            ),
             NcclTestSlurmCommandGenStrategy,
         ),
         "sleep": lambda: create_test_run(

--- a/tests/test_job_type_handler.py
+++ b/tests/test_job_type_handler.py
@@ -23,7 +23,12 @@ from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition
 
 @pytest.fixture
 def tr(slurm_system: SlurmSystem) -> TestRun:
-    tdef = NCCLTestDefinition(name="nccl", description="NCCL Test", test_template_name="nccl", cmd_args=NCCLCmdArgs())
+    tdef = NCCLTestDefinition(
+        name="nccl",
+        description="NCCL Test",
+        test_template_name="NcclTest",
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+    )
     return TestRun(
         name="test_run",
         test=Test(test_definition=tdef, test_template=TestTemplate(system=slurm_system)),

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -57,7 +57,10 @@ def create_test_directories(slurm_system: SlurmSystem, test_run: TestRun) -> Non
 @pytest.fixture
 def benchmark_tr(slurm_system: SlurmSystem) -> TestRun:
     test_definition = NCCLTestDefinition(
-        name="nccl", description="NCCL test", test_template_name="NcclTest", cmd_args=NCCLCmdArgs()
+        name="nccl",
+        description="NCCL test",
+        test_template_name="NcclTest",
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
     )
     test_template = TestTemplate(system=slurm_system)
     test = Test(test_definition=test_definition, test_template=test_template)
@@ -72,7 +75,7 @@ def dse_tr(slurm_system: SlurmSystem) -> TestRun:
         name="nccl",
         description="NCCL test",
         test_template_name="NcclTest",
-        cmd_args=NCCLCmdArgs(),
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         extra_env_vars={"VAR1": ["value1", "value2"]},
         agent_steps=12,
     )

--- a/tests/test_single_sbatch_runner.py
+++ b/tests/test_single_sbatch_runner.py
@@ -38,7 +38,12 @@ def nccl_tr(slurm_system: SlurmSystem) -> TestRun:
     tr = TestRun(
         name="nccl_test",
         test=Test(
-            test_definition=MyNCCL(name="nccl", description="desc", test_template_name="t", cmd_args=NCCLCmdArgs()),
+            test_definition=MyNCCL(
+                name="nccl",
+                description="desc",
+                test_template_name="t",
+                cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+            ),
             test_template=TestTemplate(slurm_system),
         ),
         num_nodes=2,

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -385,7 +385,10 @@ def test_run(slurm_system: SlurmSystem) -> TestRun:
         name="test_run",
         test=Test(
             test_definition=NCCLTestDefinition(
-                name="test_run", description="test_run", test_template_name="nccl", cmd_args=NCCLCmdArgs()
+                name="test_run",
+                description="test_run",
+                test_template_name="nccl",
+                cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
             ),
             test_template=TestTemplate(slurm_system),
         ),

--- a/tests/test_test_definitions.py
+++ b/tests/test_test_definitions.py
@@ -77,7 +77,11 @@ def test_extra_args_str(input: dict, expected: str):
 )
 def test_extra_args_str_nccl(input: dict, expected: str):
     t = NCCLTestDefinition(
-        name="test", description="test", test_template_name="test", cmd_args=NCCLCmdArgs(), extra_cmd_args=input
+        name="nccl",
+        description="test",
+        test_template_name="NcclTest",
+        cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+        extra_cmd_args=input,
     )
     assert t.extra_args_str == expected
 
@@ -110,7 +114,12 @@ def test_chakra_docker_image_is_required():
             test_template_name="ucc",
             cmd_args=UCCCmdArgs(docker_image_url="fake://url/ucc"),
         ),
-        NCCLTestDefinition(name="nccl", description="desc", test_template_name="nccl", cmd_args=NCCLCmdArgs()),
+        NCCLTestDefinition(
+            name="nccl",
+            description="desc",
+            test_template_name="nccl",
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+        ),
         GPTTestDefinition(
             name="gpt",
             description="desc",

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -84,7 +84,7 @@ def test(slurm_system: SlurmSystem) -> Test:
             name="t1",
             description="desc1",
             test_template_name="NcclTest",
-            cmd_args=NCCLCmdArgs(),
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
         ),
         test_template=TestTemplate(system=slurm_system),
     )
@@ -355,7 +355,10 @@ class TestInScenario:
         test_scenario_parser.test_mapping = {
             "nccl": Test(
                 test_definition=NCCLTestDefinition(
-                    name="nccl", description="desc", test_template_name="NcclTest", cmd_args=NCCLCmdArgs()
+                    name="nccl",
+                    description="desc",
+                    test_template_name="NcclTest",
+                    cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
                 ),
                 test_template=TestTemplate(system=slurm_system),
             )
@@ -381,7 +384,10 @@ class TestInScenario:
         test_scenario_parser.test_mapping = {
             "nccl": Test(
                 test_definition=NCCLTestDefinition(
-                    name="nccl", description="desc", test_template_name="NcclTest", cmd_args=NCCLCmdArgs()
+                    name="nccl",
+                    description="desc",
+                    test_template_name="NcclTest",
+                    cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
                 ),
                 test_template=TestTemplate(system=slurm_system),
             )
@@ -412,7 +418,7 @@ class TestInScenario:
             name = "nccl"
             test_template_name = "NcclTest"
             description = "desc"
-            cmd_args = { unknown = 42 }
+            cmd_args = { unknown = 42, docker_image_url = "fake://url/nccl" }
             """
             )
         )
@@ -502,7 +508,12 @@ class TestReporters:
 
     def test_get_reporters_nccl(self):
         tr_model = TestRunModel(id="id", test_name="nccl", time_limit="01:00:00", weight=10, iterations=1, num_nodes=1)
-        tdef = NCCLTestDefinition(name="nccl", description="desc", test_template_name="tt", cmd_args=NCCLCmdArgs())
+        tdef = NCCLTestDefinition(
+            name="nccl",
+            description="desc",
+            test_template_name="tt",
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+        )
         reporters = get_reporters(tr_model, tdef)
         assert len(reporters) == 1
         assert NcclTestPerformanceReportGenerationStrategy in reporters
@@ -529,7 +540,7 @@ class TestReportMetricsDSE:
             name="nccl",
             description="desc",
             test_template_name="NcclTest",
-            cmd_args=NCCLCmdArgs(),
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
             extra_env_vars={"DSE": ["v1", "v2"]},
         )
         test_scenario_parser.test_mapping["nccl"] = Test(test_definition=nccl, test_template=Mock())


### PR DESCRIPTION
## Summary
Require docker image for NCCL tests to be explicitly set in config.

## Test Plan
1. CI.
2. See comments for real runs.

## Additional Notes
—