### PR TITLE
Rely on member test run object instead of args

### DIFF
--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -116,7 +116,7 @@ class BaseRunner(ABC):
 
     def on_job_submit(self, tr: TestRun) -> None:
         cmd_gen = self.get_cmd_gen_strategy(self.system, tr)
-        cmd_gen.store_test_run(tr)
+        cmd_gen.store_test_run()
 
     async def delayed_submit_test(self, tr: TestRun, delay: int = 5):
         """

--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -29,6 +29,7 @@ class CommandGenStrategy(TestTemplateStrategy, ABC):
     def __init__(self, system: System, test_run: TestRun) -> None:
         super().__init__(system)
         self.test_run = test_run
+        self._final_env_vars: dict[str, str | list[str]] = {}
 
     @abstractmethod
     def gen_exec_command(self) -> str:
@@ -51,6 +52,12 @@ class CommandGenStrategy(TestTemplateStrategy, ABC):
 
     @property
     def final_env_vars(self) -> dict[str, str | list[str]]:
-        final_env_vars = self.system.global_env_vars.copy()
-        final_env_vars.update(self.test_run.test.extra_env_vars)
-        return final_env_vars
+        if not self._final_env_vars:
+            final_env_vars = self.system.global_env_vars.copy()
+            final_env_vars.update(self.test_run.test.extra_env_vars)
+            self._final_env_vars = final_env_vars
+        return self._final_env_vars
+
+    @final_env_vars.setter
+    def final_env_vars(self, value: dict[str, str | list[str]]) -> None:
+        self._final_env_vars = value

--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -48,3 +48,9 @@ class CommandGenStrategy(TestTemplateStrategy, ABC):
         Only at command generation time, CloudAI has all the information to store the test run.
         """
         pass
+
+    @property
+    def final_env_vars(self) -> dict[str, str | list[str]]:
+        final_env_vars = self.system.global_env_vars.copy()
+        final_env_vars.update(self.test_run.test.extra_env_vars)
+        return final_env_vars

--- a/src/cloudai/_core/command_gen_strategy.py
+++ b/src/cloudai/_core/command_gen_strategy.py
@@ -31,12 +31,9 @@ class CommandGenStrategy(TestTemplateStrategy, ABC):
         self.test_run = test_run
 
     @abstractmethod
-    def gen_exec_command(self, tr: TestRun) -> str:
+    def gen_exec_command(self) -> str:
         """
         Generate the execution command for a test based on the given parameters.
-
-        Args:
-            tr (TestRun): Contains the test and its run-specific configurations.
 
         Returns:
             str: The generated execution command.
@@ -44,13 +41,10 @@ class CommandGenStrategy(TestTemplateStrategy, ABC):
         pass
 
     @abstractmethod
-    def store_test_run(self, tr: TestRun) -> None:
+    def store_test_run(self) -> None:
         """
         Store the test run information in output folder.
 
         Only at command generation time, CloudAI has all the information to store the test run.
-
-        Args:
-            tr (TestRun): The test run object to be stored.
         """
         pass

--- a/src/cloudai/systems/lsf/lsf_command_gen_strategy.py
+++ b/src/cloudai/systems/lsf/lsf_command_gen_strategy.py
@@ -52,7 +52,7 @@ class LSFCommandGenStrategy(CommandGenStrategy):
         Returns:
             str: The generated LSF command.
         """
-        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        env_vars = self.final_env_vars
         cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
         lsf_args = self._parse_lsf_args(
             self.test_run.test.test_template.__class__.__name__, env_vars, cmd_args, self.test_run

--- a/src/cloudai/systems/lsf/lsf_command_gen_strategy.py
+++ b/src/cloudai/systems/lsf/lsf_command_gen_strategy.py
@@ -42,7 +42,7 @@ class LSFCommandGenStrategy(CommandGenStrategy):
         super().__init__(system, test_run)
         self.system = cast(LSFSystem, system)
 
-    def gen_exec_command(self, tr: TestRun) -> str:
+    def gen_exec_command(self) -> str:
         """
         Generate the execution command for the test run.
 
@@ -52,11 +52,13 @@ class LSFCommandGenStrategy(CommandGenStrategy):
         Returns:
             str: The generated LSF command.
         """
-        env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
-        cmd_args = self._flatten_dict(tr.test.cmd_args)
-        lsf_args = self._parse_lsf_args(tr.test.test_template.__class__.__name__, env_vars, cmd_args, tr)
+        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
+        lsf_args = self._parse_lsf_args(
+            self.test_run.test.test_template.__class__.__name__, env_vars, cmd_args, self.test_run
+        )
 
-        bsub_command = self._gen_bsub_command(lsf_args, env_vars, cmd_args, tr)
+        bsub_command = self._gen_bsub_command(lsf_args, env_vars, cmd_args, self.test_run)
 
         return bsub_command.strip()
 

--- a/src/cloudai/systems/lsf/lsf_runner.py
+++ b/src/cloudai/systems/lsf/lsf_runner.py
@@ -54,7 +54,7 @@ class LSFRunner(BaseRunner):
     def _submit_test(self, tr: TestRun) -> LSFJob:
         logging.info(f"Running test: {tr.name}")
         tr.output_path = self.get_job_output_path(tr)
-        exec_cmd = self.get_cmd_gen_strategy(self.system, tr).gen_exec_command(tr)
+        exec_cmd = self.get_cmd_gen_strategy(self.system, tr).gen_exec_command()
         logging.debug(f"Executing command for test {tr.name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":

--- a/src/cloudai/systems/slurm/single_sbatch_runner.py
+++ b/src/cloudai/systems/slurm/single_sbatch_runner.py
@@ -109,11 +109,11 @@ class SingleSbatchRunner(SlurmRunner):
         max_nodes, _ = self.extract_sbatch_nodes_spec()
         tr.num_nodes = max_nodes
         cmd_gen = cast(SlurmCommandGenStrategy, self.get_cmd_gen_strategy(self.system, tr))
-        return [cmd_gen._metadata_cmd(tr), cmd_gen._ranks_mapping_cmd(tr)]
+        return [cmd_gen._metadata_cmd(), cmd_gen._ranks_mapping_cmd()]
 
     def get_single_tr_block(self, tr: TestRun) -> str:
         cmd_gen = cast(SlurmCommandGenStrategy, self.get_cmd_gen_strategy(self.system, tr))
-        srun_cmd = cmd_gen.gen_srun_command(tr)
+        srun_cmd = cmd_gen.gen_srun_command()
         nnodes, node_list = self.system.get_nodes_by_spec(tr.nnodes, tr.nodes)
         node_arg = f"--nodelist={','.join(node_list)}" if node_list else f"-N{nnodes}"
         extra_args = (

--- a/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
@@ -93,7 +93,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         return mounts
 
     def gen_exec_command(self) -> str:
-        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        env_vars = self.final_env_vars
 
         srun_command = self._gen_srun_command(env_vars)
         command_list = []
@@ -117,7 +117,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         return self._write_sbatch_script(env_vars, full_command)
 
     def gen_srun_command(self) -> str:
-        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        env_vars = self.final_env_vars
         return self._gen_srun_command(env_vars)
 
     def job_name_prefix(self) -> str:

--- a/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
@@ -94,9 +94,8 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
     def gen_exec_command(self) -> str:
         env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
-        cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
 
-        srun_command = self._gen_srun_command(env_vars, cmd_args)
+        srun_command = self._gen_srun_command(env_vars)
         command_list = []
         indent = ""
 
@@ -119,8 +118,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
     def gen_srun_command(self) -> str:
         env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
-        cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
-        return self._gen_srun_command(env_vars, cmd_args)
+        return self._gen_srun_command(env_vars)
 
     def job_name_prefix(self) -> str:
         return self.test_run.test.test_template.__class__.__name__
@@ -222,9 +220,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         return nsys.cmd_args
 
-    def _gen_srun_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> str:
+    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]]) -> str:
         srun_command_parts = self.gen_srun_prefix(use_pretest_extras=True)
         nsys_command_parts = self.gen_nsys_command()
         test_command_parts = self.generate_test_command()

--- a/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
@@ -48,27 +48,28 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         """
         super().__init__(system, test_run)
         self.system = cast(SlurmSystem, system)
+        self.test_run = test_run
 
         self._node_spec_cache: dict[str, tuple[int, list[str]]] = {}
 
     @abstractmethod
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         """Return CommandGenStrategy specific container mounts for the test run."""
         ...
 
-    def store_test_run(self, tr: TestRun) -> None:
+    def store_test_run(self) -> None:
         test_cmd, srun_cmd = (
-            " ".join(self.generate_test_command(env_vars={}, cmd_args={}, tr=tr)),
-            self.gen_srun_command(tr),
+            " ".join(self.generate_test_command(env_vars={}, cmd_args={})),
+            self.gen_srun_command(),
         )
-        with (tr.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w") as f:
-            trd = TestRunDetails.from_test_run(tr, test_cmd=test_cmd, full_cmd=srun_cmd)
+        with (self.test_run.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w") as f:
+            trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=srun_cmd)
             toml.dump(trd.model_dump(), f)
 
     @final
-    def container_mounts(self, tr: TestRun) -> list[str]:
+    def container_mounts(self) -> list[str]:
         """Return the container mounts for the test run."""
-        tdef = tr.test.test_definition
+        tdef = self.test_run.test.test_definition
 
         repo_mounts = []
         for repo in tdef.git_repos:
@@ -76,16 +77,16 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             repo_mounts.append(f"{path}:{repo.container_mount}")
 
         mounts = [
-            f"{tr.output_path.absolute()}:/cloudai_run_results",
+            f"{self.test_run.output_path.absolute()}:/cloudai_run_results",
             f"{self.system.install_path.absolute()}:/cloudai_install",
-            f"{tr.output_path.absolute()}",
+            f"{self.test_run.output_path.absolute()}",
             *tdef.extra_container_mounts,
             *repo_mounts,
-            *self._container_mounts(tr),
+            *self._container_mounts(),
         ]
 
         merged_env = self.system.global_env_vars.copy()
-        merged_env.update(tr.test.extra_env_vars)
+        merged_env.update(self.test_run.test.extra_env_vars)
         if "NCCL_TOPO_FILE" in merged_env:
             nccl_topo_file = merged_env["NCCL_TOPO_FILE"]
             if isinstance(nccl_topo_file, str):
@@ -94,41 +95,41 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         return mounts
 
-    def gen_exec_command(self, tr: TestRun) -> str:
-        env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
-        cmd_args = self._flatten_dict(tr.test.cmd_args)
+    def gen_exec_command(self) -> str:
+        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
 
-        srun_command = self._gen_srun_command(env_vars, cmd_args, tr)
+        srun_command = self._gen_srun_command(env_vars, cmd_args)
         command_list = []
         indent = ""
 
-        if tr.pre_test:
-            pre_test_command = self.gen_pre_test(tr.pre_test, tr.output_path)
+        if self.test_run.pre_test:
+            pre_test_command = self.gen_pre_test(self.test_run.pre_test, self.test_run.output_path)
             command_list = [pre_test_command, "if [ $PRE_TEST_SUCCESS -eq 1 ]; then"]
             indent = "    "
 
         command_list.append(f"{indent}{srun_command}")
 
-        if tr.post_test:
-            post_test_command = self.gen_post_test(tr.post_test, tr.output_path)
+        if self.test_run.post_test:
+            post_test_command = self.gen_post_test(self.test_run.post_test, self.test_run.output_path)
             command_list.append(f"{indent}{post_test_command}")
 
-        if tr.pre_test:
+        if self.test_run.pre_test:
             command_list.append("fi")
 
         full_command = "\n".join(command_list).strip()
-        return self._write_sbatch_script(env_vars, full_command, tr)
+        return self._write_sbatch_script(env_vars, full_command)
 
-    def gen_srun_command(self, tr: TestRun) -> str:
-        env_vars = self._override_env_vars(self.system.global_env_vars, tr.test.extra_env_vars)
-        cmd_args = self._flatten_dict(tr.test.cmd_args)
-        return self._gen_srun_command(env_vars, cmd_args, tr)
+    def gen_srun_command(self) -> str:
+        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
+        return self._gen_srun_command(env_vars, cmd_args)
 
-    def job_name_prefix(self, tr: TestRun) -> str:
-        return tr.test.test_template.__class__.__name__
+    def job_name_prefix(self) -> str:
+        return self.test_run.test.test_template.__class__.__name__
 
-    def job_name(self, tr: TestRun) -> str:
-        job_name_prefix = self.job_name_prefix(tr)
+    def job_name(self) -> str:
+        job_name_prefix = self.job_name_prefix()
         job_name = f"{job_name_prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         if self.system.account:
             job_name = f"{self.system.account}-{job_name_prefix}.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
@@ -178,7 +179,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         for idx, tr in enumerate(pre_test.test_runs):
             strategy = self._get_cmd_gen_strategy(tr)
             strategy._set_hook_output_path(tr, base_output_path / "pre_test")
-            srun_command = strategy.gen_srun_command(tr)
+            srun_command = strategy.gen_srun_command()
             srun_command_with_output = srun_command.replace(
                 "srun ", f"srun --output={tr.output_path / 'stdout.txt'} --error={tr.output_path / 'stderr.txt'} "
             )
@@ -186,7 +187,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
             success_var = f"SUCCESS_{idx}"
             success_vars.append(success_var)
-            success_check_command = strategy.gen_srun_success_check(tr)
+            success_check_command = strategy.gen_srun_success_check()
             pre_test_commands.append(f"{success_var}=$({success_check_command})")
 
         combined_success_var = " && ".join([f"[ ${var} -eq 1 ]" for var in success_vars])
@@ -209,7 +210,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         for tr in post_test.test_runs:
             strategy = self._get_cmd_gen_strategy(tr)
             strategy._set_hook_output_path(tr, base_output_path / "post_test")
-            srun_command = strategy.gen_srun_command(tr)
+            srun_command = strategy.gen_srun_command()
             srun_command_with_output = srun_command.replace(
                 "srun ", f"srun --output={tr.output_path / 'stdout.txt'} --error={tr.output_path / 'stderr.txt'} "
             )
@@ -217,44 +218,44 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         return "\n".join(post_test_commands)
 
-    def gen_nsys_command(self, tr: TestRun) -> list[str]:
-        nsys = tr.test.test_definition.nsys
+    def gen_nsys_command(self) -> list[str]:
+        nsys = self.test_run.test.test_definition.nsys
         if not nsys or not nsys.enable:
             return []
 
         return nsys.cmd_args
 
     def _gen_srun_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> str:
-        srun_command_parts = self.gen_srun_prefix(tr, use_pretest_extras=True)
-        nsys_command_parts = self.gen_nsys_command(tr)
-        test_command_parts = self.generate_test_command(env_vars, cmd_args, tr)
+        srun_command_parts = self.gen_srun_prefix(use_pretest_extras=True)
+        nsys_command_parts = self.gen_nsys_command()
+        test_command_parts = self.generate_test_command(env_vars, cmd_args)
 
-        with (tr.output_path / "env_vars.sh").open("w") as f:
+        with (self.test_run.output_path / "env_vars.sh").open("w") as f:
             for key, value in env_vars.items():
                 f.write(f'export {key}="{value}"\n')
 
         full_test_cmd = (
-            f'bash -c "source {(tr.output_path / "env_vars.sh").absolute()}; '
+            f'bash -c "source {(self.test_run.output_path / "env_vars.sh").absolute()}; '
             + " ".join(nsys_command_parts + test_command_parts)
             + '"'
         )
 
         return " ".join(srun_command_parts) + " " + full_test_cmd
 
-    def image_path(self, tr: TestRun) -> Optional[str]:
+    def image_path(self) -> Optional[str]:
         return None
 
-    def gen_srun_prefix(self, tr: TestRun, use_pretest_extras: bool = False) -> List[str]:
+    def gen_srun_prefix(self, use_pretest_extras: bool = False) -> List[str]:
         srun_command_parts = ["srun", "--export=ALL", f"--mpi={self.system.mpi}"]
-        if use_pretest_extras and tr.pre_test:
-            for pre_tr in tr.pre_test.test_runs:
-                srun_command_parts.extend(self._get_cmd_gen_strategy(pre_tr).pre_test_srun_extra_args(tr))
+        if use_pretest_extras and self.test_run.pre_test:
+            for pre_tr in self.test_run.pre_test.test_runs:
+                srun_command_parts.extend(self._get_cmd_gen_strategy(pre_tr).pre_test_srun_extra_args(self.test_run))
 
-        if image_path := self.image_path(tr):
+        if image_path := self.image_path():
             srun_command_parts.append(f"--container-image={image_path}")
-            mounts = self.container_mounts(tr)
+            mounts = self.container_mounts()
             if mounts:
                 srun_command_parts.append(f"--container-mounts={','.join(mounts)}")
 
@@ -267,7 +268,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         return srun_command_parts
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> List[str]:
         return []
 
@@ -288,51 +289,51 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         return batch_script_content
 
-    def _ranks_mapping_cmd(self, tr: TestRun) -> str:
+    def _ranks_mapping_cmd(self) -> str:
         return " ".join(
             [
-                *self.gen_srun_prefix(tr),
-                f"--output={tr.output_path.absolute() / 'mapping-stdout.txt'}",
-                f"--error={tr.output_path.absolute() / 'mapping-stderr.txt'}",
+                *self.gen_srun_prefix(),
+                f"--output={self.test_run.output_path.absolute() / 'mapping-stdout.txt'}",
+                f"--error={self.test_run.output_path.absolute() / 'mapping-stderr.txt'}",
                 "bash",
                 "-c",
                 r'"echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."',
             ]
         )
 
-    def _metadata_cmd(self, tr: TestRun) -> str:
-        (tr.output_path.absolute() / "metadata").mkdir(parents=True, exist_ok=True)
-        num_nodes, _ = self.get_cached_nodes_spec(tr)
+    def _metadata_cmd(self) -> str:
+        (self.test_run.output_path.absolute() / "metadata").mkdir(parents=True, exist_ok=True)
+        num_nodes, _ = self.get_cached_nodes_spec()
         metadata_script_path = "/cloudai_install"
-        if not self.image_path(tr):
+        if not self.image_path():
             metadata_script_path = str(self.system.install_path.absolute())
         return " ".join(
             [
-                *self.gen_srun_prefix(tr),
+                *self.gen_srun_prefix(),
                 f"--ntasks={num_nodes}",
                 "--ntasks-per-node=1",
-                f"--output={tr.output_path.absolute() / 'metadata' / 'node-%N.toml'}",
-                f"--error={tr.output_path.absolute() / 'metadata' / 'nodes.err'}",
+                f"--output={self.test_run.output_path.absolute() / 'metadata' / 'node-%N.toml'}",
+                f"--error={self.test_run.output_path.absolute() / 'metadata' / 'nodes.err'}",
                 "bash",
                 f"{metadata_script_path}/slurm-metadata.sh",
             ]
         )
 
-    def _enable_vboost_cmd(self, tr: TestRun) -> str:
-        num_nodes, _ = self.system.get_nodes_by_spec(tr.nnodes, tr.nodes)
+    def _enable_vboost_cmd(self) -> str:
+        num_nodes, _ = self.system.get_nodes_by_spec(self.test_run.nnodes, self.test_run.nodes)
         return " ".join(
             [
                 "srun",
                 f"--ntasks={num_nodes}",
-                f"--output={tr.output_path.absolute() / 'vboost.out'}",
-                f"--error={tr.output_path.absolute() / 'vboost.err'}",
+                f"--output={self.test_run.output_path.absolute() / 'vboost.out'}",
+                f"--error={self.test_run.output_path.absolute() / 'vboost.err'}",
                 "bash",
                 "-c",
                 '"sudo nvidia-smi boost-slider --vboost 1"',
             ]
         )
 
-    def _enable_numa_control_cmd(self, tr: TestRun) -> str:
+    def _enable_numa_control_cmd(self) -> str:
         return " ".join(
             [
                 "srun",
@@ -343,7 +344,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             ]
         )
 
-    def _write_sbatch_script(self, env_vars: Dict[str, Union[str, List[str]]], srun_command: str, tr: TestRun) -> str:
+    def _write_sbatch_script(self, env_vars: Dict[str, Union[str, List[str]]], srun_command: str) -> str:
         """
         Write the batch script for Slurm submission and return the sbatch command.
 
@@ -359,45 +360,44 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         batch_script_content = [
             "#!/bin/bash",
             f"# generated by CloudAI@{version('cloudai')}",
-            f"#SBATCH --job-name={self.job_name(tr)}",
+            f"#SBATCH --job-name={self.job_name()}",
         ]
 
-        self._append_sbatch_directives(batch_script_content, tr)
+        self._append_sbatch_directives(batch_script_content)
 
         batch_script_content.extend([self._format_env_vars(env_vars)])
 
         if env_vars.get("ENABLE_VBOOST") == "1":
-            batch_script_content.extend([self._enable_vboost_cmd(tr), ""])
+            batch_script_content.extend([self._enable_vboost_cmd(), ""])
         if env_vars.get("ENABLE_NUMA_CONTROL") == "1":
-            batch_script_content.extend([self._enable_numa_control_cmd(tr), ""])
-        batch_script_content.extend([self._ranks_mapping_cmd(tr), ""])
-        batch_script_content.extend([self._metadata_cmd(tr), ""])
+            batch_script_content.extend([self._enable_numa_control_cmd(), ""])
+        batch_script_content.extend([self._ranks_mapping_cmd(), ""])
+        batch_script_content.extend([self._metadata_cmd(), ""])
 
         batch_script_content.append(srun_command)
 
-        batch_script_path = tr.output_path / "cloudai_sbatch_script.sh"
+        batch_script_path = self.test_run.output_path / "cloudai_sbatch_script.sh"
         with batch_script_path.open("w") as batch_file:
             batch_file.write("\n".join(batch_script_content))
 
         return f"sbatch {batch_script_path}"
 
-    def _append_sbatch_directives(self, batch_script_content: List[str], tr: TestRun) -> None:
+    def _append_sbatch_directives(self, batch_script_content: List[str]) -> None:
         """
         Append SBATCH directives to the batch script content.
 
         Args:
             batch_script_content (List[str]): The list of script lines to append to.
-            tr (TestRun): Test run object.
         """
         batch_script_content = self._add_reservation(batch_script_content)
 
-        batch_script_content.append(f"#SBATCH --output={tr.output_path / 'stdout.txt'}")
-        batch_script_content.append(f"#SBATCH --error={tr.output_path / 'stderr.txt'}")
+        batch_script_content.append(f"#SBATCH --output={self.test_run.output_path / 'stdout.txt'}")
+        batch_script_content.append(f"#SBATCH --error={self.test_run.output_path / 'stderr.txt'}")
         batch_script_content.append(f"#SBATCH --partition={self.system.default_partition}")
         if self.system.account:
             batch_script_content.append(f"#SBATCH --account={self.system.account}")
 
-        hostfile = self._append_nodes_related_directives(batch_script_content, tr)
+        hostfile = self._append_nodes_related_directives(batch_script_content)
 
         if self.system.gpus_per_node and self.system.supports_gpu_directives:
             batch_script_content.append(f"#SBATCH --gpus-per-node={self.system.gpus_per_node}")
@@ -405,8 +405,8 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         if self.system.ntasks_per_node:
             batch_script_content.append(f"#SBATCH --ntasks-per-node={self.system.ntasks_per_node}")
-        if tr.time_limit:
-            batch_script_content.append(f"#SBATCH --time={tr.time_limit}")
+        if self.test_run.time_limit:
+            batch_script_content.append(f"#SBATCH --time={self.test_run.time_limit}")
 
         for arg in self.system.extra_sbatch_args:
             batch_script_content.append(f"#SBATCH {arg}")
@@ -418,14 +418,14 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             "\nexport SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)"
         )
 
-    def _append_nodes_related_directives(self, content: List[str], tr: TestRun) -> Optional[Path]:
-        num_nodes, node_list = self.get_cached_nodes_spec(tr)
+    def _append_nodes_related_directives(self, content: List[str]) -> Optional[Path]:
+        num_nodes, node_list = self.get_cached_nodes_spec()
 
         if node_list:
             content.append("#SBATCH --distribution=arbitrary")
             content.append(f"#SBATCH --nodelist={','.join(node_list)}")
 
-            hostfile = (tr.output_path / "hostfile.txt").absolute()
+            hostfile = (self.test_run.output_path / "hostfile.txt").absolute()
             with hostfile.open("w") as hf:
                 tasks = self.system.ntasks_per_node or 1
                 for node in node_list:
@@ -457,30 +457,35 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
             formatted_vars.append(f"export {key}={formatted_value}")
         return "\n".join(formatted_vars)
 
-    def gen_srun_success_check(self, tr: TestRun) -> str:
+    def gen_srun_success_check(self) -> str:
         """
         Generate the Slurm success check command to verify if a test run was successful.
-
-        Args:
-            tr (TestRun): Contains the test and its run-specific configurations.
 
         Returns:
             str: The generated command to check the success of the test run.
         """
         return ""
 
-    def get_cached_nodes_spec(self, tr: TestRun) -> tuple[int, list[str]]:
+    def get_cached_nodes_spec(self) -> tuple[int, list[str]]:
         """
         Get nodes for a test run, using cache when available.
 
         It is needed to avoid multiple calls to the system.get_nodes_by_spec method which in turn queries the Slurm API.
         For a single test run it is not required, we can get actual nodes status only once.
         """
-        cache_key = f"{tr.name}:{tr.current_iteration}:{tr.step}:{tr.num_nodes}:{','.join(tr.nodes)}"
+        cache_key = ":".join(
+            [
+                self.test_run.name,
+                str(self.test_run.current_iteration),
+                str(self.test_run.step),
+                str(self.test_run.num_nodes),
+                ",".join(self.test_run.nodes),
+            ]
+        )
 
         if cache_key in self._node_spec_cache:
             logging.debug(f"Using cached node allocation for {cache_key}: {self._node_spec_cache[cache_key]}")
             return self._node_spec_cache[cache_key]
 
-        self._node_spec_cache[cache_key] = self.system.get_nodes_by_spec(tr.nnodes, tr.nodes)
+        self._node_spec_cache[cache_key] = self.system.get_nodes_by_spec(self.test_run.nnodes, self.test_run.nodes)
         return self._node_spec_cache[cache_key]

--- a/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
@@ -58,10 +58,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
         ...
 
     def store_test_run(self) -> None:
-        test_cmd, srun_cmd = (
-            " ".join(self.generate_test_command(env_vars={}, cmd_args={})),
-            self.gen_srun_command(),
-        )
+        test_cmd, srun_cmd = (" ".join(self.generate_test_command()), self.gen_srun_command())
         with (self.test_run.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w") as f:
             trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=srun_cmd)
             toml.dump(trd.model_dump(), f)
@@ -230,7 +227,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
     ) -> str:
         srun_command_parts = self.gen_srun_prefix(use_pretest_extras=True)
         nsys_command_parts = self.gen_nsys_command()
-        test_command_parts = self.generate_test_command(env_vars, cmd_args)
+        test_command_parts = self.generate_test_command()
 
         with (self.test_run.output_path / "env_vars.sh").open("w") as f:
             for key, value in env_vars.items():
@@ -267,9 +264,7 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         return srun_command_parts
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> List[str]:
+    def generate_test_command(self) -> List[str]:
         return []
 
     def _add_reservation(self, batch_script_content: List[str]):

--- a/src/cloudai/systems/slurm/slurm_runner.py
+++ b/src/cloudai/systems/slurm/slurm_runner.py
@@ -56,7 +56,7 @@ class SlurmRunner(BaseRunner):
 
     def _submit_test(self, tr: TestRun) -> SlurmJob:
         logging.info(f"Running test: {tr.name}")
-        exec_cmd = self.get_cmd_gen_strategy(self.system, tr).gen_exec_command(tr)
+        exec_cmd = self.get_cmd_gen_strategy(self.system, tr).gen_exec_command()
         logging.debug(f"Executing command for test {tr.name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":
@@ -104,8 +104,8 @@ class SlurmRunner(BaseRunner):
             end_time=steps_metadata[0].end_time,
             elapsed_time_sec=steps_metadata[0].elapsed_time_sec,
             job_steps=steps_metadata[1:],
-            srun_cmd=cmd_gen.gen_srun_command(job.test_run),
-            test_cmd=" ".join(cmd_gen.generate_test_command({}, {}, job.test_run)),
+            srun_cmd=cmd_gen.gen_srun_command(),
+            test_cmd=" ".join(cmd_gen.generate_test_command({}, {})),
             job_root=job.test_run.output_path.absolute(),
         )
 

--- a/src/cloudai/systems/slurm/slurm_runner.py
+++ b/src/cloudai/systems/slurm/slurm_runner.py
@@ -105,7 +105,7 @@ class SlurmRunner(BaseRunner):
             elapsed_time_sec=steps_metadata[0].elapsed_time_sec,
             job_steps=steps_metadata[1:],
             srun_cmd=cmd_gen.gen_srun_command(),
-            test_cmd=" ".join(cmd_gen.generate_test_command({}, {})),
+            test_cmd=" ".join(cmd_gen.generate_test_command()),
             job_root=job.test_run.output_path.absolute(),
         )
 

--- a/src/cloudai/systems/standalone/standalone_runner.py
+++ b/src/cloudai/systems/standalone/standalone_runner.py
@@ -38,7 +38,7 @@ class StandaloneRunner(BaseRunner):
     def _submit_test(self, tr: TestRun) -> StandaloneJob:
         logging.info(f"Running test: {tr.name}")
         tr.output_path = self.get_job_output_path(tr)
-        exec_cmd = self.get_cmd_gen_strategy(self.system, tr).gen_exec_command(tr)
+        exec_cmd = self.get_cmd_gen_strategy(self.system, tr).gen_exec_command()
         logging.info(f"Executing command for test {tr.name}: {exec_cmd}")
         job_id = 0
         if self.mode == "run":

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -19,7 +19,6 @@ from typing import Dict, List, Optional, Union, cast
 
 import yaml
 
-from cloudai.models.workload import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 from .ai_dynamo import AIDynamoTestDefinition
@@ -259,7 +258,15 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return " ".join([*srun_prefix, "/opt/run.sh"])
 
     def get_cached_nodes_spec(self) -> tuple[int, list[str]]:
-        cache_key = f"{self.test_run.current_iteration}:{self.test_run.step}:{self.test_run.num_nodes}:{','.join(self.test_run.nodes)}"
+        cache_key = ":".join(
+            [
+                self.test_run.name,
+                str(self.test_run.current_iteration),
+                str(self.test_run.step),
+                str(self.test_run.num_nodes),
+                ",".join(self.test_run.nodes),
+            ]
+        )
 
         if cache_key in self._node_spec_cache:
             return self._node_spec_cache[cache_key]

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -243,9 +243,7 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             cmd.append(f"--request-rate {args.genai_perf.request_rate}")
         return " ".join(cmd)
 
-    def _gen_srun_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> str:
+    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]]) -> str:
         num_nodes, _ = self.get_cached_nodes_spec()
         srun_prefix = self.gen_srun_prefix()
         srun_prefix.extend(

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Dict, List, Optional, Union, cast
+from typing import List, Optional, cast
 
 import yaml
 
@@ -243,7 +243,7 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             cmd.append(f"--request-rate {args.genai_perf.request_rate}")
         return " ".join(cmd)
 
-    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]]) -> str:
+    def _gen_srun_command(self) -> str:
         num_nodes, _ = self.get_cached_nodes_spec()
         srun_prefix = self.gen_srun_prefix()
         srun_prefix.extend(

--- a/src/cloudai/workloads/bash_cmd/bash_cmd.py
+++ b/src/cloudai/workloads/bash_cmd/bash_cmd.py
@@ -39,22 +39,22 @@ class BashCmdTestDefinition(TestDefinition):
 class BashCmdCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for generic Slurm container tests."""
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         return []
 
-    def gen_nsys_command(self, tr: TestRun) -> list[str]:
+    def gen_nsys_command(self) -> list[str]:
         """NSYS command is generated as part of the test command and disabled here."""
         return []
 
-    def gen_srun_prefix(self, tr: TestRun, use_pretest_extras: bool = False) -> list[str]:  # noqa: Vulture
+    def gen_srun_prefix(self, use_pretest_extras: bool = False) -> list[str]:  # noqa: Vulture
         return []
 
     def generate_test_command(
-        self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]], tr: TestRun
+        self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]]
     ) -> list[str]:
-        tdef: BashCmdTestDefinition = cast(BashCmdTestDefinition, tr.test.test_definition)
-        srun_command_parts: list[str] = [*super().gen_nsys_command(tr), tdef.cmd_args.cmd]
+        tdef: BashCmdTestDefinition = cast(BashCmdTestDefinition, self.test_run.test.test_definition)
+        srun_command_parts: list[str] = [*super().gen_nsys_command(), tdef.cmd_args.cmd]
         return [" ".join(srun_command_parts)]
 
-    def gen_srun_success_check(self, tr: TestRun) -> str:
+    def gen_srun_success_check(self) -> str:
         return "[ $? -eq 0 ] && echo 1 || echo 0"

--- a/src/cloudai/workloads/bash_cmd/bash_cmd.py
+++ b/src/cloudai/workloads/bash_cmd/bash_cmd.py
@@ -49,9 +49,7 @@ class BashCmdCommandGenStrategy(SlurmCommandGenStrategy):
     def gen_srun_prefix(self, use_pretest_extras: bool = False) -> list[str]:  # noqa: Vulture
         return []
 
-    def generate_test_command(
-        self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]]
-    ) -> list[str]:
+    def generate_test_command(self) -> list[str]:
         tdef: BashCmdTestDefinition = cast(BashCmdTestDefinition, self.test_run.test.test_definition)
         srun_command_parts: list[str] = [*super().gen_nsys_command(), tdef.cmd_args.cmd]
         return [" ".join(srun_command_parts)]

--- a/src/cloudai/workloads/bash_cmd/bash_cmd.py
+++ b/src/cloudai/workloads/bash_cmd/bash_cmd.py
@@ -16,7 +16,7 @@
 
 from typing import cast
 
-from cloudai.core import CmdArgs, Installable, TestDefinition, TestRun
+from cloudai.core import CmdArgs, Installable, TestDefinition
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 

--- a/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
@@ -33,9 +33,7 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
         tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> List[str]:
+    def generate_test_command(self) -> List[str]:
         tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, self.test_run.test.test_definition)
 
         additional_cmd_args_dict = tdef.cmd_args.model_extra or {}

--- a/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
@@ -16,7 +16,6 @@
 
 from typing import Dict, List, Union, cast
 
-from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 from cloudai.workloads.chakra_replay import ChakraReplayTestDefinition
 

--- a/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
@@ -24,20 +24,20 @@ from cloudai.workloads.chakra_replay import ChakraReplayTestDefinition
 class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for ChakraReplay on Slurm systems."""
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
-        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, tr.test.test_definition)
+    def _container_mounts(self) -> list[str]:
+        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, self.test_run.test.test_definition)
         if tdef.cmd_args.trace_path:
             return [f"{tdef.cmd_args.trace_path}:{tdef.cmd_args.trace_path}"]
         return []
 
-    def image_path(self, tr: TestRun) -> str | None:
-        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, tr.test.test_definition)
+    def image_path(self) -> str | None:
+        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> List[str]:
-        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, tr.test.test_definition)
+        tdef: ChakraReplayTestDefinition = cast(ChakraReplayTestDefinition, self.test_run.test.test_definition)
 
         additional_cmd_args_dict = tdef.cmd_args.model_extra or {}
 
@@ -47,6 +47,6 @@ class ChakraReplaySlurmCommandGenStrategy(SlurmCommandGenStrategy):
             f"--trace-path {tdef.cmd_args.trace_path}",
             f"--num-replays {tdef.cmd_args.num_replays}",
             *[f"--{k.replace('_', '-')} {v}" for k, v in additional_cmd_args_dict.items()],
-            tr.test.extra_cmd_args,
+            self.test_run.test.extra_cmd_args,
         ]
         return srun_command_parts

--- a/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/chakra_replay/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, cast
+from typing import List, cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 from cloudai.workloads.chakra_replay import ChakraReplayTestDefinition

--- a/src/cloudai/workloads/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/jax_toolbox/slurm_command_gen_strategy.py
@@ -331,7 +331,7 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def _generate_run_command(self) -> List[str]:
         """Generate the srun command for executing the test."""
         output_path = self.test_run.output_path.resolve()
-        env_vars = self._override_env_vars(self.system.global_env_vars, self.test_run.test.extra_env_vars)
+        env_vars = self.final_env_vars
         output_suffix = "-%j.txt" if env_vars.get("UNIFIED_STDOUT_STDERR") == "1" else "-%j-%n-%t.txt"
         output, error = output_path / f"output{output_suffix}", output_path / f"error{output_suffix}"
         return [

--- a/src/cloudai/workloads/jax_toolbox/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/jax_toolbox/slurm_command_gen_strategy.py
@@ -142,7 +142,8 @@ class JaxToolboxSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return " ".join(sorted(xla_flags))
 
-    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Any]) -> str:
+    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]]) -> str:
+        cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
         self._create_run_script(env_vars, cmd_args, self.test_run.test.extra_cmd_args)
 
         commands = []

--- a/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-from typing import Dict, List, Union, cast
+from typing import cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 

--- a/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
@@ -17,7 +17,6 @@
 
 from typing import Dict, List, Union, cast
 
-from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 from .megatron_run import MegatronRunTestDefinition

--- a/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
@@ -32,9 +32,7 @@ class MegatronRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def _container_mounts(self) -> list[str]:
         return []
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: dict[str, Union[str, list[str]]]
-    ) -> list[str]:
+    def generate_test_command(self) -> list[str]:
         tdef: MegatronRunTestDefinition = cast(MegatronRunTestDefinition, self.test_run.test.test_definition)
 
         command = [

--- a/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_run/slurm_command_gen_strategy.py
@@ -26,17 +26,17 @@ from .megatron_run import MegatronRunTestDefinition
 class MegatronRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for MegatronRun on Slurm systems."""
 
-    def image_path(self, tr: TestRun) -> str | None:
-        tdef: MegatronRunTestDefinition = cast(MegatronRunTestDefinition, tr.test.test_definition)
+    def image_path(self) -> str | None:
+        tdef: MegatronRunTestDefinition = cast(MegatronRunTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         return []
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: dict[str, Union[str, list[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: dict[str, Union[str, list[str]]]
     ) -> list[str]:
-        tdef: MegatronRunTestDefinition = cast(MegatronRunTestDefinition, tr.test.test_definition)
+        tdef: MegatronRunTestDefinition = cast(MegatronRunTestDefinition, self.test_run.test.test_definition)
 
         command = [
             "python",
@@ -44,7 +44,7 @@ class MegatronRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             *[f"{k} {v}" for k, v in tdef.cmd_args_dict.items()],
         ]
 
-        if tr.test.extra_cmd_args:
-            command.append(tr.test.extra_cmd_args)
+        if self.test_run.test.extra_cmd_args:
+            command.append(self.test_run.test.extra_cmd_args)
 
         return command

--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -31,9 +31,7 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         tdef: NCCLTestDefinition = cast(NCCLTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> List[str]:
+    def generate_test_command(self) -> List[str]:
         tdef: NCCLTestDefinition = cast(NCCLTestDefinition, self.test_run.test.test_definition)
         srun_command_parts = [f"{tdef.cmd_args.subtest_name}"]
         nccl_test_args = tdef.cmd_args.model_dump().keys()

--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, cast
+from typing import List, cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 

--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -14,10 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
 from typing import Dict, List, Union, cast
 
-from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 from .nccl import NCCLTestDefinition

--- a/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nccl_test/slurm_command_gen_strategy.py
@@ -26,17 +26,17 @@ from .nccl import NCCLTestDefinition
 class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for NCCL tests on Slurm systems."""
 
-    def _container_mounts(self, tr: TestRun) -> List[str]:
+    def _container_mounts(self) -> List[str]:
         return []
 
-    def image_path(self, tr: TestRun) -> str | None:
-        tdef: NCCLTestDefinition = cast(NCCLTestDefinition, tr.test.test_definition)
+    def image_path(self) -> str | None:
+        tdef: NCCLTestDefinition = cast(NCCLTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> List[str]:
-        tdef: NCCLTestDefinition = cast(NCCLTestDefinition, tr.test.test_definition)
+        tdef: NCCLTestDefinition = cast(NCCLTestDefinition, self.test_run.test.test_definition)
         srun_command_parts = [f"{tdef.cmd_args.subtest_name}"]
         nccl_test_args = tdef.cmd_args.model_dump().keys()
         for arg in nccl_test_args:
@@ -52,11 +52,11 @@ class NcclTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             else:
                 srun_command_parts.append(f"-{arg} {value}")
 
-        if tr.test.extra_cmd_args:
-            srun_command_parts.append(tr.test.extra_cmd_args)
+        if self.test_run.test.extra_cmd_args:
+            srun_command_parts.append(self.test_run.test.extra_cmd_args)
 
         return srun_command_parts
 
-    def gen_srun_success_check(self, tr: TestRun) -> str:
-        output_file = Path(tr.output_path) / "stdout.txt"
+    def gen_srun_success_check(self) -> str:
+        output_file = self.test_run.output_path / "stdout.txt"
         return f'grep -q "Avg bus bandwidth" {output_file} && echo 1 || echo 0'

--- a/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_launcher/slurm_command_gen_strategy.py
@@ -34,9 +34,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         return []
 
     def gen_exec_command(self) -> str:
-        self._prepare_environment(
-            self.test_run.test.cmd_args, self.test_run.test.extra_env_vars, self.test_run.output_path
-        )
+        self._prepare_environment()
 
         _, nodes = self.system.get_nodes_by_spec(self.test_run.nnodes, self.test_run.nodes)
         self._set_node_config(nodes, self.test_run.nnodes)
@@ -112,12 +110,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             env_vars_str += " \\\n"
         return env_vars_str
 
-    def _prepare_environment(
-        self,
-        cmd_args: Dict[str, Union[str, List[str]]],
-        extra_env_vars: Dict[str, Union[str, List[str]]],
-        output_path: Path,
-    ) -> None:
+    def _prepare_environment(self) -> None:
         """
         Prepare the environment variables and command arguments.
 
@@ -126,9 +119,7 @@ class NeMoLauncherSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             extra_env_vars (Dict[str, Union[str, List[str]]]): Additional environment variables.
             output_path (Path): Path to the output directory.
         """
-        self.final_env_vars = self._override_env_vars(self.system.global_env_vars, extra_env_vars)
-
-        overriden_cmd_args = self._flatten_dict(cmd_args)
+        overriden_cmd_args = self._flatten_dict(self.test_run.test.cmd_args)
         overriden_cmd_args.pop("launcher_script", None)
         self.final_cmd_args = {k: self._handle_special_keys(k, v) for k, v in sorted(overriden_cmd_args.items())}
 

--- a/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
@@ -105,9 +105,7 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         return recipe_name
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> List[str]:
+    def generate_test_command(self) -> List[str]:
         tdef: NeMoRunTestDefinition = cast(NeMoRunTestDefinition, self.test_run.test.test_definition)
 
         tdef.cmd_args.data.num_train_samples = tdef.update_num_train_samples

--- a/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
@@ -31,10 +31,10 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         tdef: NeMoRunTestDefinition = cast(NeMoRunTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
-    def _gen_srun_command(self, env_vars: Dict[str, str | List[str]], cmd_args: Dict[str, str | List[str]]) -> str:
+    def _gen_srun_command(self, env_vars: Dict[str, str | List[str]]) -> str:
         tdef: NeMoRunTestDefinition = cast(NeMoRunTestDefinition, self.test_run.test.test_definition)
         self._set_additional_env_vars(env_vars, tdef)
-        return super()._gen_srun_command(env_vars, cmd_args)
+        return super()._gen_srun_command(env_vars)
 
     def _set_additional_env_vars(self, env_vars: Dict[str, Union[str, List[str]]], tdef: NeMoRunTestDefinition):
         """Set environment variables based on NeMoRunTestDefinition."""

--- a/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
@@ -36,9 +36,9 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def _container_mounts(self) -> list[str]:
         return []
 
-    def _gen_srun_command(self, env_vars: dict[str, str | list[str]]) -> str:
+    def _gen_srun_command(self) -> str:
         with (self.test_run.output_path / "env_vars.sh").open("w") as f:
-            for key, value in env_vars.items():
+            for key, value in self.final_env_vars.items():
                 f.write(f"export {key}={value}\n")
 
         etcd_command: list[str] = self.gen_etcd_srun_command()

--- a/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
@@ -36,7 +36,7 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def _container_mounts(self) -> list[str]:
         return []
 
-    def _gen_srun_command(self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]]) -> str:
+    def _gen_srun_command(self, env_vars: dict[str, str | list[str]]) -> str:
         with (self.test_run.output_path / "env_vars.sh").open("w") as f:
             for key, value in env_vars.items():
                 f.write(f"export {key}={value}\n")

--- a/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
@@ -30,25 +30,23 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         self._current_image_url: str | None = None
 
-    def image_path(self, tr: TestRun) -> str | None:
+    def image_path(self) -> str | None:
         return self._current_image_url
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         return []
 
-    def _gen_srun_command(
-        self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]], tr: TestRun
-    ) -> str:
-        with (tr.output_path / "env_vars.sh").open("w") as f:
+    def _gen_srun_command(self, env_vars: dict[str, str | list[str]], cmd_args: dict[str, str | list[str]]) -> str:
+        with (self.test_run.output_path / "env_vars.sh").open("w") as f:
             for key, value in env_vars.items():
                 f.write(f"export {key}={value}\n")
 
-        etcd_command: list[str] = self.gen_etcd_srun_command(tr)
-        nixl_command: list[str] = self.gen_nixl_srun_command(tr)
+        etcd_command: list[str] = self.gen_etcd_srun_command()
+        nixl_command: list[str] = self.gen_nixl_srun_command()
         return " ".join(etcd_command) + "\netcd_pid=$!\nsleep 5\n" + " ".join(nixl_command) + "\nkill -9 $etcd_pid\n"
 
-    def gen_etcd_srun_command(self, tr: TestRun) -> list[str]:
-        tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, tr.test.test_definition)
+    def gen_etcd_srun_command(self) -> list[str]:
+        tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, self.test_run.test.test_definition)
         self._current_image_url = str(tdef.etcd_image.installed_path)
         etcd_cmd = [
             "/usr/local/bin/etcd",
@@ -58,7 +56,7 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             "http://$(hostname -I | awk '{print $1}'):2379",
         ]
         cmd = [
-            *self.gen_srun_prefix(tr),
+            *self.gen_srun_prefix(),
             "--overlap",
             "--ntasks-per-node=1",
             "--ntasks=1",
@@ -71,32 +69,34 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         self._current_image_url = None
         return cmd
 
-    def gen_nixlbench_command(self, tr: TestRun) -> list[str]:
-        tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, tr.test.test_definition)
+    def gen_nixlbench_command(self) -> list[str]:
+        tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, self.test_run.test.test_definition)
         cmd = [tdef.cmd_args.path_to_benchmark, f"--etcd-endpoints {tdef.cmd_args.etcd_endpoint}"]
 
-        other_args = tdef.cmd_args.model_dump(exclude={"docker_image_url", "etcd_endpoint", "path_to_benchmark"})
+        other_args = tdef.cmd_args.model_dump(
+            exclude={"docker_image_url", "etcd_endpoint", "path_to_benchmark", "cmd_args"}
+        )
         for k, v in other_args.items():
             cmd.append(f"--{k} {v}")
 
         return cmd
 
-    def gen_nixl_srun_command(self, tr: TestRun) -> list[str]:
-        tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, tr.test.test_definition)
+    def gen_nixl_srun_command(self) -> list[str]:
+        tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, self.test_run.test.test_definition)
         self._current_image_url = str(tdef.docker_image.installed_path)
-        nnodes, _ = self.get_cached_nodes_spec(tr)
+        nnodes, _ = self.get_cached_nodes_spec()
         tpn, ntasks = 1, nnodes
         if nnodes == 1:
             tpn, ntasks = 2, 2
         cmd = [
-            *self.gen_srun_prefix(tr),
+            *self.gen_srun_prefix(),
             "--overlap",
             f"--ntasks-per-node={tpn}",
             f"--ntasks={ntasks}",
             f"-N{nnodes}",
             "bash",
             "-c",
-            f'"source {(tr.output_path / "env_vars.sh").absolute()}; {" ".join(self.gen_nixlbench_command(tr))}"',
+            f'"source {(self.test_run.output_path / "env_vars.sh").absolute()}; {" ".join(self.gen_nixlbench_command())}"',
         ]
         self._current_image_url = None
         return cmd

--- a/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
@@ -96,7 +96,8 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             f"-N{nnodes}",
             "bash",
             "-c",
-            f'"source {(self.test_run.output_path / "env_vars.sh").absolute()}; {" ".join(self.gen_nixlbench_command())}"',
+            f'"source {(self.test_run.output_path / "env_vars.sh").absolute()}; '
+            f'{" ".join(self.gen_nixlbench_command())}"',
         ]
         self._current_image_url = None
         return cmd

--- a/src/cloudai/workloads/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/slurm_command_gen_strategy.py
@@ -27,9 +27,7 @@ class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def _container_mounts(self) -> list[str]:
         return []
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> List[str]:
+    def generate_test_command(self) -> List[str]:
         tdef: SleepTestDefinition = cast(SleepTestDefinition, self.test_run.test.test_definition)
         tdef_cmd_args: SleepCmdArgs = tdef.cmd_args
         return [f"sleep {tdef_cmd_args.seconds}"]

--- a/src/cloudai/workloads/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, cast
+from typing import List, cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 

--- a/src/cloudai/workloads/sleep/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/slurm_command_gen_strategy.py
@@ -16,7 +16,6 @@
 
 from typing import Dict, List, Union, cast
 
-from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 from .sleep import SleepCmdArgs, SleepTestDefinition
@@ -25,12 +24,12 @@ from .sleep import SleepCmdArgs, SleepTestDefinition
 class SleepSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for Sleep on Slurm systems."""
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         return []
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> List[str]:
-        tdef: SleepTestDefinition = cast(SleepTestDefinition, tr.test.test_definition)
+        tdef: SleepTestDefinition = cast(SleepTestDefinition, self.test_run.test.test_definition)
         tdef_cmd_args: SleepCmdArgs = tdef.cmd_args
         return [f"sleep {tdef_cmd_args.seconds}"]

--- a/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
@@ -16,7 +16,7 @@
 
 from typing import cast
 
-from cloudai.core import CommandGenStrategy, TestRun
+from cloudai.core import CommandGenStrategy
 
 from .sleep import SleepCmdArgs, SleepTestDefinition
 
@@ -24,8 +24,8 @@ from .sleep import SleepCmdArgs, SleepTestDefinition
 class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
     """Command generation strategy for the Sleep test on standalone systems."""
 
-    def gen_exec_command(self, tr: TestRun) -> str:
-        tdef: SleepTestDefinition = cast(SleepTestDefinition, tr.test.test_definition)
+    def gen_exec_command(self) -> str:
+        tdef: SleepTestDefinition = cast(SleepTestDefinition, self.test_run.test.test_definition)
         tdef_cmd_args: SleepCmdArgs = tdef.cmd_args
         sec = tdef_cmd_args.seconds
         return f"sleep {sec}"

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -40,9 +40,7 @@ class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
         tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test.test_definition)
         return [*cmd, *tdef.extra_srun_args]
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> list[str]:
+    def generate_test_command(self) -> list[str]:
         tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test.test_definition)
         command_parts: list[str] = [*super().gen_nsys_command(), tdef.cmd_args.cmd]
         if self.test_run.test.extra_cmd_args:

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, cast
+from typing import cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -16,7 +16,6 @@
 
 from typing import Dict, List, Union, cast
 
-from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 from .slurm_container import SlurmContainerTestDefinition
@@ -25,28 +24,28 @@ from .slurm_container import SlurmContainerTestDefinition
 class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for generic Slurm container tests."""
 
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         return []
 
-    def gen_nsys_command(self, tr: TestRun) -> list[str]:
+    def gen_nsys_command(self) -> list[str]:
         """NSYS command is generated as part of the test command and disabled here."""
         return []
 
-    def image_path(self, tr: TestRun) -> str | None:
-        tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, tr.test.test_definition)
+    def image_path(self) -> str | None:
+        tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
-    def gen_srun_prefix(self, tr: TestRun, use_pretest_extras: bool = False) -> list[str]:
-        cmd = super().gen_srun_prefix(tr)
-        tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, tr.test.test_definition)
+    def gen_srun_prefix(self, use_pretest_extras: bool = False) -> list[str]:
+        cmd = super().gen_srun_prefix()
+        tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test.test_definition)
         return [*cmd, *tdef.extra_srun_args]
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> list[str]:
-        tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, tr.test.test_definition)
-        command_parts: list[str] = [*super().gen_nsys_command(tr), tdef.cmd_args.cmd]
-        if tr.test.extra_cmd_args:
-            command_parts.append(tr.test.extra_cmd_args)
+        tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test.test_definition)
+        command_parts: list[str] = [*super().gen_nsys_command(), tdef.cmd_args.cmd]
+        if self.test_run.test.extra_cmd_args:
+            command_parts.append(self.test_run.test.extra_cmd_args)
 
         return command_parts

--- a/src/cloudai/workloads/triton_inference/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/triton_inference/slurm_command_gen_strategy.py
@@ -75,9 +75,7 @@ class TritonInferenceSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             f.write("\n".join(lines))
         script_path.chmod(0o755)
 
-    def _gen_srun_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> str:
+    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]]) -> str:
         num_server_nodes, num_client_nodes = self._get_server_client_split()
         server_line = self._build_server_srun(num_server_nodes)
         client_line = self._build_client_srun(num_client_nodes)

--- a/src/cloudai/workloads/triton_inference/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/triton_inference/slurm_command_gen_strategy.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Union, cast
+from typing import Any, Dict, List, Tuple, cast
 
 from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy, SlurmSystem
@@ -75,7 +75,7 @@ class TritonInferenceSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             f.write("\n".join(lines))
         script_path.chmod(0o755)
 
-    def _gen_srun_command(self, env_vars: Dict[str, Union[str, List[str]]]) -> str:
+    def _gen_srun_command(self) -> str:
         num_server_nodes, num_client_nodes = self._get_server_client_split()
         server_line = self._build_server_srun(num_server_nodes)
         client_line = self._build_client_srun(num_client_nodes)

--- a/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
@@ -25,17 +25,17 @@ from .ucc import UCCCmdArgs, UCCTestDefinition
 class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     """Command generation strategy for UCC tests on Slurm systems."""
 
-    def _container_mounts(self, tr: TestRun) -> List[str]:
+    def _container_mounts(self) -> List[str]:
         return []
 
-    def image_path(self, tr: TestRun) -> str | None:
-        tdef: UCCTestDefinition = cast(UCCTestDefinition, tr.test.test_definition)
+    def image_path(self) -> str | None:
+        tdef: UCCTestDefinition = cast(UCCTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
     def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]], tr: TestRun
+        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
     ) -> List[str]:
-        tdef: UCCTestDefinition = cast(UCCTestDefinition, tr.test.test_definition)
+        tdef: UCCTestDefinition = cast(UCCTestDefinition, self.test_run.test.test_definition)
         tdef_cmd_args: UCCCmdArgs = tdef.cmd_args
 
         srun_command_parts = ["/opt/hpcx/ucc/bin/ucc_perftest"]
@@ -45,7 +45,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         srun_command_parts.append("-m cuda")
         srun_command_parts.append("-F")
 
-        if tr.test.extra_cmd_args:
-            srun_command_parts.append(tr.test.extra_cmd_args)
+        if self.test_run.test.extra_cmd_args:
+            srun_command_parts.append(self.test_run.test.extra_cmd_args)
 
         return srun_command_parts

--- a/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Union, cast
+from typing import List, cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 

--- a/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
@@ -31,9 +31,7 @@ class UCCTestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         tdef: UCCTestDefinition = cast(UCCTestDefinition, self.test_run.test.test_definition)
         return str(tdef.docker_image.installed_path)
 
-    def generate_test_command(
-        self, env_vars: Dict[str, Union[str, List[str]]], cmd_args: Dict[str, Union[str, List[str]]]
-    ) -> List[str]:
+    def generate_test_command(self) -> List[str]:
         tdef: UCCTestDefinition = cast(UCCTestDefinition, self.test_run.test.test_definition)
         tdef_cmd_args: UCCCmdArgs = tdef.cmd_args
 

--- a/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ucc_test/slurm_command_gen_strategy.py
@@ -16,7 +16,6 @@
 
 from typing import Dict, List, Union, cast
 
-from cloudai.core import TestRun
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
 from .ucc import UCCCmdArgs, UCCTestDefinition

--- a/tests/slurm_command_gen_strategy/test_ai_dynamo_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ai_dynamo_slurm_command_gen_strategy.py
@@ -139,7 +139,7 @@ def test_hugging_face_home_path_missing(test_run: TestRun) -> None:
 
 
 def test_container_mounts(strategy: AIDynamoSlurmCommandGenStrategy, test_run: TestRun) -> None:
-    mounts = strategy._container_mounts(test_run)
+    mounts = strategy._container_mounts()
     td = cast(AIDynamoTestDefinition, test_run.test.test_definition)
     script_host = test_run.output_path / "run.sh"
     yaml_config_path = test_run.output_path / "dynamo_config.yaml"

--- a/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
@@ -48,28 +48,28 @@ def bash_cmd_gen(slurm_system: SlurmSystem, bash_tr: TestRun) -> BashCmdCommandG
     return BashCmdCommandGenStrategy(slurm_system, bash_tr)
 
 
-def test_gen_srun_success_check(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
-    res = bash_cmd_gen.gen_srun_success_check(bash_tr)
+def test_gen_srun_success_check(bash_cmd_gen: BashCmdCommandGenStrategy):
+    res = bash_cmd_gen.gen_srun_success_check()
     assert res == "[ $? -eq 0 ] && echo 1 || echo 0"
 
 
-def test_generate_test_command(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
-    res = bash_cmd_gen.generate_test_command({}, {}, bash_tr)
+def test_generate_test_command(bash_cmd_gen: BashCmdCommandGenStrategy):
+    res = bash_cmd_gen.generate_test_command({}, {})
     assert res == ["echo 'Hello, world!'"]
 
 
-def test_gen_srun_prefix(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
-    res = bash_cmd_gen.gen_srun_prefix(bash_tr)
+def test_gen_srun_prefix(bash_cmd_gen: BashCmdCommandGenStrategy):
+    res = bash_cmd_gen.gen_srun_prefix()
     assert res == []
 
 
-def test_gen_nsys_command(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
-    res = bash_cmd_gen.gen_nsys_command(bash_tr)
+def test_gen_nsys_command(bash_cmd_gen: BashCmdCommandGenStrategy):
+    res = bash_cmd_gen.gen_nsys_command()
     assert res == []
 
 
-def test_gen_container_mounts(bash_cmd_gen: BashCmdCommandGenStrategy, bash_tr: TestRun):
-    res = bash_cmd_gen._container_mounts(bash_tr)
+def test_gen_container_mounts(bash_cmd_gen: BashCmdCommandGenStrategy):
+    res = bash_cmd_gen._container_mounts()
     assert res == []
 
 

--- a/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_bash_cmd_slurm_command_gen_strategy.py
@@ -54,7 +54,7 @@ def test_gen_srun_success_check(bash_cmd_gen: BashCmdCommandGenStrategy):
 
 
 def test_generate_test_command(bash_cmd_gen: BashCmdCommandGenStrategy):
-    res = bash_cmd_gen.generate_test_command({}, {})
+    res = bash_cmd_gen.generate_test_command()
     assert res == ["echo 'Hello, world!'"]
 
 

--- a/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
@@ -76,5 +76,5 @@ class TestChakraReplaySlurmCommandGenStrategy:
         tr.test.test_definition.cmd_args = ChakraReplayCmdArgs(docker_image_url="", **cmd_args)
         tr.test.extra_cmd_args = extra_cmd_args
         cmd_gen_strategy = ChakraReplaySlurmCommandGenStrategy(slurm_system, tr)
-        command = cmd_gen_strategy.generate_test_command({}, {}, tr)
+        command = cmd_gen_strategy.generate_test_command({}, {})
         assert command == expected_result

--- a/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_chakra_replay_slurm_command_gen_strategy.py
@@ -76,5 +76,5 @@ class TestChakraReplaySlurmCommandGenStrategy:
         tr.test.test_definition.cmd_args = ChakraReplayCmdArgs(docker_image_url="", **cmd_args)
         tr.test.extra_cmd_args = extra_cmd_args
         cmd_gen_strategy = ChakraReplaySlurmCommandGenStrategy(slurm_system, tr)
-        command = cmd_gen_strategy.generate_test_command({}, {})
+        command = cmd_gen_strategy.generate_test_command()
         assert command == expected_result

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import List, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -52,11 +52,9 @@ def strategy_fixture(slurm_system: SlurmSystem, testrun_fixture: TestRun) -> Slu
 
 
 def test_filename_generation(strategy_fixture: SlurmCommandGenStrategy):
-    env_vars: Dict[str, Union[str, List[str]]] = {"TEST_VAR": "VALUE"}
+    srun_command = strategy_fixture._gen_srun_command()
 
-    srun_command = strategy_fixture._gen_srun_command(env_vars)
-
-    sbatch_command = strategy_fixture._write_sbatch_script(env_vars, srun_command)
+    sbatch_command = strategy_fixture._write_sbatch_script(srun_command)
     filepath_from_command = sbatch_command.split()[-1]
 
     assert strategy_fixture.test_run.output_path.joinpath("cloudai_sbatch_script.sh").exists()

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -53,9 +53,8 @@ def strategy_fixture(slurm_system: SlurmSystem, testrun_fixture: TestRun) -> Slu
 
 def test_filename_generation(strategy_fixture: SlurmCommandGenStrategy):
     env_vars: Dict[str, Union[str, List[str]]] = {"TEST_VAR": "VALUE"}
-    cmd_args: Dict[str, Union[str, List[str]]] = {"test_arg": "test_value"}
 
-    srun_command = strategy_fixture._gen_srun_command(env_vars, cmd_args)
+    srun_command = strategy_fixture._gen_srun_command(env_vars)
 
     sbatch_command = strategy_fixture._write_sbatch_script(env_vars, srun_command)
     filepath_from_command = sbatch_command.split()[-1]

--- a/tests/slurm_command_gen_strategy/test_jax_toolbox_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_jax_toolbox_slurm_command_gen_strategy.py
@@ -84,16 +84,10 @@ class TestJaxToolboxSlurmCommandGenStrategy:
         slurm_system.output_path.mkdir(parents=True, exist_ok=True)
 
         test = Test(test_definition=test_def, test_template=TestTemplate(slurm_system))
-        test_run = TestRun(
-            test=test,
-            num_nodes=1,
-            nodes=["node1"],
-            output_path=tmp_path / "output",
-            name="test-job",
-        )
+        test_run = TestRun(test=test, num_nodes=1, nodes=["node1"], output_path=tmp_path / "output", name="test-job")
 
         cmd_gen_strategy = JaxToolboxSlurmCommandGenStrategy(slurm_system, test_run)
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
         assert cmd == f"sbatch {test_run.output_path}/cloudai_sbatch_script.sh"
         assert (test_run.output_path / "run.sh").exists()
 

--- a/tests/slurm_command_gen_strategy/test_jax_toolbox_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_jax_toolbox_slurm_command_gen_strategy.py
@@ -183,7 +183,7 @@ class TestJaxToolboxSlurmCommandGenStrategy:
         )
         cmd_gen.test_name = "Grok"
         cmd_gen._script_content = MagicMock(return_value="")
-        cmd_gen._create_run_script({}, cargs, "")
+        cmd_gen._create_run_script(cargs)
         assert cmd_gen._script_content.call_count == expected_ncalls
 
     def test_generate_python_command(
@@ -195,7 +195,7 @@ class TestJaxToolboxSlurmCommandGenStrategy:
         cmd_gen_strategy.test_name = "GPT"
 
         stage = "training"
-        python_cli = cmd_gen_strategy._generate_python_command(stage, cargs, "").splitlines()
+        python_cli = cmd_gen_strategy._generate_python_command(stage, cargs).splitlines()
 
         fdl_args = gpt_test.cmd_args.fdl.model_dump()
         fdl_args_list = [f"    --fdl.{k.upper()}={v} \\" for k, v in sorted(fdl_args.items())]

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -77,7 +77,7 @@ class TestNcclTestSlurmCommandGenStrategy:
         tr = TestRun(name="t1", test=t, nodes=[], num_nodes=1)
 
         cmd_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system, tr)
-        cmd = " ".join(cmd_gen_strategy.generate_test_command({}, {}))
+        cmd = " ".join(cmd_gen_strategy.generate_test_command())
 
         for arg in args:
             if args[arg] is None:

--- a/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nccl_slurm_command_gen_strategy.py
@@ -60,7 +60,7 @@ class TestNcclTestSlurmCommandGenStrategy:
         t = Test(test_definition=nccl, test_template=Mock())
         tr = TestRun(name="t1", test=t, nodes=nodes, num_nodes=num_nodes)
         cmd_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system, tr)
-        assert expected_result["container_mounts"] in cmd_gen_strategy.container_mounts(tr)
+        assert expected_result["container_mounts"] in cmd_gen_strategy.container_mounts()
 
     @pytest.mark.parametrize(
         "args",
@@ -77,7 +77,7 @@ class TestNcclTestSlurmCommandGenStrategy:
         tr = TestRun(name="t1", test=t, nodes=[], num_nodes=1)
 
         cmd_gen_strategy = NcclTestSlurmCommandGenStrategy(slurm_system, tr)
-        cmd = " ".join(cmd_gen_strategy.generate_test_command({}, {}, tr))
+        cmd = " ".join(cmd_gen_strategy.generate_test_command({}, {}))
 
         for arg in args:
             if args[arg] is None:

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
@@ -95,11 +95,10 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
     def test_generate_exec_command(
         self,
         cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy,
-        test_run: TestRun,
         expected_content: List[str],
         nodes: List[str],
     ) -> None:
-        test_run.nodes = nodes
+        cmd_gen_strategy.test_run.nodes = nodes
         cmd = cmd_gen_strategy.gen_exec_command()
 
         for content in expected_content:
@@ -108,16 +107,18 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         assert "extra_args" in cmd
         assert "base_results_dir=" in cmd
         assert "launcher_scripts_path=" in cmd
-        tdef: NeMoLauncherTestDefinition = cast(NeMoLauncherTestDefinition, test_run.test.test_definition)
+        tdef: NeMoLauncherTestDefinition = cast(
+            NeMoLauncherTestDefinition, cmd_gen_strategy.test_run.test.test_definition
+        )
         assert f"container={tdef.docker_image.url}" in cmd
 
-    def test_tokenizer_handling(
-        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun, tmp_path: Path
-    ) -> None:
+    def test_tokenizer_handling(self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, tmp_path: Path) -> None:
         tokenizer_path = tmp_path / "tokenizer"
         tokenizer_path.touch()
 
-        test_run.test.test_definition.extra_cmd_args = {f"training.model.tokenizer.model={tokenizer_path}": ""}
+        cmd_gen_strategy.test_run.test.test_definition.extra_cmd_args = {
+            f"training.model.tokenizer.model={tokenizer_path}": ""
+        }
         cmd = cmd_gen_strategy.gen_exec_command()
 
         assert f'container_mounts=["{tokenizer_path}:{tokenizer_path}"]' in cmd
@@ -130,11 +131,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         ],
     )
     def test_reservation_handling(
-        self,
-        cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy,
-        test_run: TestRun,
-        extra_srun_args: str,
-        expected_reservation: str,
+        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, extra_srun_args: str, expected_reservation: str
     ) -> None:
         cmd_gen_strategy.system.extra_srun_args = extra_srun_args
         cmd = cmd_gen_strategy.gen_exec_command()
@@ -144,11 +141,9 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         else:
             assert "+cluster.reservation" not in cmd
 
-    def test_invalid_tokenizer_path(
-        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun
-    ) -> None:
+    def test_invalid_tokenizer_path(self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy) -> None:
         invalid_tokenizer_path = Path("/invalid/path/to/tokenizer")
-        test_run.test.test_definition.extra_cmd_args = {
+        cmd_gen_strategy.test_run.test.test_definition.extra_cmd_args = {
             f"training.model.tokenizer.model={invalid_tokenizer_path}": "",
         }
 
@@ -191,7 +186,6 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
     def test_gpus_per_node_value(
         self,
         cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy,
-        test_run: TestRun,
         gpus_per_node: int,
         expected_gpus: str,
     ) -> None:
@@ -200,10 +194,10 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
 
         assert expected_gpus in cmd
 
-    def test_data_prefix_validation(
-        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun
-    ) -> None:
-        tdef: NeMoLauncherTestDefinition = cast(NeMoLauncherTestDefinition, test_run.test.test_definition)
+    def test_data_prefix_validation(self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy) -> None:
+        tdef: NeMoLauncherTestDefinition = cast(
+            NeMoLauncherTestDefinition, cmd_gen_strategy.test_run.test.test_definition
+        )
         tdef.cmd_args.training.model.data.data_impl = "not_mock"
         tdef.cmd_args.training.model.data.data_prefix = "[]"
 
@@ -212,13 +206,15 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
 
     @patch("pathlib.Path.open", new_callable=mock_open)
     def test_log_command_to_file(
-        self, mock_file, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun, tmp_path: Path
+        self, mock_file, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, tmp_path: Path
     ) -> None:
-        test_run.output_path = tmp_path / "output_dir"
-        test_run.output_path.mkdir()
+        cmd_gen_strategy.test_run.output_path = tmp_path / "output_dir"
+        cmd_gen_strategy.test_run.output_path.mkdir()
 
         repo_path = (tmp_path / "repo").relative_to(tmp_path)
-        tdef: NeMoLauncherTestDefinition = cast(NeMoLauncherTestDefinition, test_run.test.test_definition)
+        tdef: NeMoLauncherTestDefinition = cast(
+            NeMoLauncherTestDefinition, cmd_gen_strategy.test_run.test.test_definition
+        )
         tdef.python_executable.git_repo.installed_path = repo_path
         tdef.python_executable.venv_path = repo_path.parent / f"{repo_path.name}-venv"
         cmd_gen_strategy.gen_exec_command()
@@ -235,20 +231,16 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
             f"launcher_scripts_path={(repo_path / tdef.cmd_args.launcher_script).parent.absolute()} " in written_content
         )
 
-    def test_container_mounts_with_nccl_topo_file(
-        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun
-    ) -> None:
+    def test_container_mounts_with_nccl_topo_file(self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy) -> None:
         nccl_topo_file_path = "/opt/topo.toml"
-        test_run.test.test_definition.extra_env_vars["NCCL_TOPO_FILE"] = nccl_topo_file_path
+        cmd_gen_strategy.test_run.test.test_definition.extra_env_vars["NCCL_TOPO_FILE"] = nccl_topo_file_path
 
         cmd = cmd_gen_strategy.gen_exec_command()
 
         expected_mount = f'container_mounts=["{nccl_topo_file_path}:{nccl_topo_file_path}"]'
         assert expected_mount in cmd
 
-    def test_env_vars_with_spaces(
-        self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy, test_run: TestRun
-    ) -> None:
+    def test_env_vars_with_spaces(self, cmd_gen_strategy: NeMoLauncherSlurmCommandGenStrategy) -> None:
         env: dict[str, str | list[str]] = {"VAR1": "value with spaces", "VAR2": r"$(cmd \$vv| cmd)"}
         cmd = cmd_gen_strategy._gen_env_vars_str(env)
 

--- a/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_launcher_slurm_command_gen_strategy.py
@@ -100,7 +100,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         nodes: List[str],
     ) -> None:
         test_run.nodes = nodes
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
 
         for content in expected_content:
             assert any(content in part for part in cmd.split())
@@ -118,7 +118,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         tokenizer_path.touch()
 
         test_run.test.test_definition.extra_cmd_args = {f"training.model.tokenizer.model={tokenizer_path}": ""}
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
 
         assert f'container_mounts=["{tokenizer_path}:{tokenizer_path}"]' in cmd
 
@@ -137,7 +137,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         expected_reservation: str,
     ) -> None:
         cmd_gen_strategy.system.extra_srun_args = extra_srun_args
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
 
         if expected_reservation:
             assert expected_reservation in cmd
@@ -153,7 +153,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         }
 
         with pytest.raises(ValueError, match=r"The provided tokenizer path '/invalid/path/to/tokenizer' is not valid"):
-            cmd_gen_strategy.gen_exec_command(test_run)
+            cmd_gen_strategy.gen_exec_command()
 
     @pytest.mark.parametrize(
         "account, expected_prefix_pattern",
@@ -170,7 +170,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         expected_prefix_pattern: str,
     ) -> None:
         cmd_gen_strategy.system.account = account
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
 
         if account:
             assert f"cluster.account={account}" in cmd
@@ -196,7 +196,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         expected_gpus: str,
     ) -> None:
         cmd_gen_strategy.system.gpus_per_node = gpus_per_node
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
 
         assert expected_gpus in cmd
 
@@ -208,7 +208,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         tdef.cmd_args.training.model.data.data_prefix = "[]"
 
         with pytest.raises(ValueError, match="The 'data_prefix' field of the NeMo launcher test is missing or empty."):
-            cmd_gen_strategy.gen_exec_command(test_run)
+            cmd_gen_strategy.gen_exec_command()
 
     @patch("pathlib.Path.open", new_callable=mock_open)
     def test_log_command_to_file(
@@ -221,7 +221,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         tdef: NeMoLauncherTestDefinition = cast(NeMoLauncherTestDefinition, test_run.test.test_definition)
         tdef.python_executable.git_repo.installed_path = repo_path
         tdef.python_executable.venv_path = repo_path.parent / f"{repo_path.name}-venv"
-        cmd_gen_strategy.gen_exec_command(test_run)
+        cmd_gen_strategy.gen_exec_command()
 
         written_content = mock_file().write.call_args[0][0]
 
@@ -241,7 +241,7 @@ class TestNeMoLauncherSlurmCommandGenStrategy:
         nccl_topo_file_path = "/opt/topo.toml"
         test_run.test.test_definition.extra_env_vars["NCCL_TOPO_FILE"] = nccl_topo_file_path
 
-        cmd = cmd_gen_strategy.gen_exec_command(test_run)
+        cmd = cmd_gen_strategy.gen_exec_command()
 
         expected_mount = f'container_mounts=["{nccl_topo_file_path}:{nccl_topo_file_path}"]'
         assert expected_mount in cmd

--- a/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
@@ -75,10 +75,7 @@ class TestNeMoRunSlurmCommandGenStrategy:
 
         recipe_name = cmd_gen_strategy._validate_recipe_name(cmd_args.recipe_name)
 
-        cmd = cmd_gen_strategy.generate_test_command(
-            cmd_gen_strategy.test_run.test.test_definition.extra_env_vars,
-            cmd_gen_strategy.test_run.test.test_definition.cmd_args.model_dump(),
-        )
+        cmd = cmd_gen_strategy.generate_test_command()
         assert cmd is not None
         assert cmd[:5] == [
             "python",
@@ -97,9 +94,7 @@ class TestNeMoRunSlurmCommandGenStrategy:
         cmd_args_dict = cmd_gen_strategy.test_run.test.test_definition.cmd_args.model_dump()
         cmd_args_dict["trainer"]["num_nodes"] = len(cmd_gen_strategy.test_run.nodes)
 
-        cmd = cmd_gen_strategy.generate_test_command(
-            cmd_gen_strategy.test_run.test.test_definition.extra_env_vars, cmd_args_dict
-        )
+        cmd = cmd_gen_strategy.generate_test_command()
 
         assert any("trainer.num_nodes=1" in param for param in cmd)
 
@@ -116,8 +111,5 @@ class TestNeMoRunSlurmCommandGenStrategy:
         cmd_gen_strategy.test_run.test.test_definition.cmd_args = cmd_args
 
         with caplog.at_level(logging.WARNING):
-            cmd_gen_strategy.generate_test_command(
-                cmd_gen_strategy.test_run.test.test_definition.extra_env_vars,
-                cmd_gen_strategy.test_run.test.test_definition.cmd_args.model_dump(),
-            )
+            cmd_gen_strategy.generate_test_command()
         assert "Mismatch in num_nodes" in caplog.text

--- a/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
@@ -61,7 +61,7 @@ class TestNeMoRunSlurmCommandGenStrategy:
     def cmd_gen_strategy(self, slurm_system: SlurmSystem, test_run: TestRun) -> NeMoRunSlurmCommandGenStrategy:
         return NeMoRunSlurmCommandGenStrategy(slurm_system, test_run)
 
-    def test_generate_test_command(self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy, test_run: TestRun) -> None:
+    def test_generate_test_command(self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy) -> None:
         cmd_args = NeMoRunCmdArgs(
             docker_image_url="nvcr.io/nvidia/nemo:24.09",
             task="fine_tune",
@@ -71,12 +71,13 @@ class TestNeMoRunSlurmCommandGenStrategy:
             ),
             data=Data(micro_batch_size=1),
         )
-        test_run.test.test_definition.cmd_args = cmd_args
+        cmd_gen_strategy.test_run.test.test_definition.cmd_args = cmd_args
 
         recipe_name = cmd_gen_strategy._validate_recipe_name(cmd_args.recipe_name)
 
         cmd = cmd_gen_strategy.generate_test_command(
-            test_run.test.test_definition.extra_env_vars, test_run.test.test_definition.cmd_args.model_dump()
+            cmd_gen_strategy.test_run.test.test_definition.extra_env_vars,
+            cmd_gen_strategy.test_run.test.test_definition.cmd_args.model_dump(),
         )
         assert cmd is not None
         assert cmd[:5] == [
@@ -91,29 +92,32 @@ class TestNeMoRunSlurmCommandGenStrategy:
         )
         assert f"data.micro_batch_size={cmd_args.data.micro_batch_size}" in cmd
 
-    def test_num_nodes(self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy, test_run: TestRun) -> None:
-        test_run.nodes = ["node1"]
-        cmd_args_dict = test_run.test.test_definition.cmd_args.model_dump()
-        cmd_args_dict["trainer"]["num_nodes"] = len(test_run.nodes)
+    def test_num_nodes(self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy) -> None:
+        cmd_gen_strategy.test_run.nodes = ["node1"]
+        cmd_args_dict = cmd_gen_strategy.test_run.test.test_definition.cmd_args.model_dump()
+        cmd_args_dict["trainer"]["num_nodes"] = len(cmd_gen_strategy.test_run.nodes)
 
-        cmd = cmd_gen_strategy.generate_test_command(test_run.test.test_definition.extra_env_vars, cmd_args_dict)
+        cmd = cmd_gen_strategy.generate_test_command(
+            cmd_gen_strategy.test_run.test.test_definition.extra_env_vars, cmd_args_dict
+        )
 
         assert any("trainer.num_nodes=1" in param for param in cmd)
 
     def test_trainer_num_nodes_greater_than_num_nodes(
-        self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy, test_run: TestRun, caplog
+        self, cmd_gen_strategy: NeMoRunSlurmCommandGenStrategy, caplog: pytest.LogCaptureFixture
     ) -> None:
-        test_run.num_nodes = 1
+        cmd_gen_strategy.test_run.num_nodes = 1
         cmd_args = NeMoRunCmdArgs(
             docker_image_url="nvcr.io/nvidia/nemo:24.09",
             task="fine_tune",
             recipe_name="llama7_13b",
             trainer=Trainer(num_nodes=4),
         )
-        test_run.test.test_definition.cmd_args = cmd_args
+        cmd_gen_strategy.test_run.test.test_definition.cmd_args = cmd_args
 
         with caplog.at_level(logging.WARNING):
             cmd_gen_strategy.generate_test_command(
-                test_run.test.test_definition.extra_env_vars, test_run.test.test_definition.cmd_args.model_dump()
+                cmd_gen_strategy.test_run.test.test_definition.extra_env_vars,
+                cmd_gen_strategy.test_run.test.test_definition.cmd_args.model_dump(),
             )
         assert "Mismatch in num_nodes" in caplog.text

--- a/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nemo_run_slurm_command_gen_strategy.py
@@ -76,12 +76,12 @@ class TestNeMoRunSlurmCommandGenStrategy:
         recipe_name = cmd_gen_strategy._validate_recipe_name(cmd_args.recipe_name)
 
         cmd = cmd_gen_strategy.generate_test_command(
-            test_run.test.test_definition.extra_env_vars, test_run.test.test_definition.cmd_args.model_dump(), test_run
+            test_run.test.test_definition.extra_env_vars, test_run.test.test_definition.cmd_args.model_dump()
         )
         assert cmd is not None
         assert cmd[:5] == [
             "python",
-            f"/cloudai_install/{cmd_gen_strategy._run_script(test_run).name}",
+            f"/cloudai_install/{cmd_gen_strategy._run_script().name}",
             "--factory",
             recipe_name,
             "-y",
@@ -96,11 +96,7 @@ class TestNeMoRunSlurmCommandGenStrategy:
         cmd_args_dict = test_run.test.test_definition.cmd_args.model_dump()
         cmd_args_dict["trainer"]["num_nodes"] = len(test_run.nodes)
 
-        cmd = cmd_gen_strategy.generate_test_command(
-            test_run.test.test_definition.extra_env_vars,
-            cmd_args_dict,
-            test_run,
-        )
+        cmd = cmd_gen_strategy.generate_test_command(test_run.test.test_definition.extra_env_vars, cmd_args_dict)
 
         assert any("trainer.num_nodes=1" in param for param in cmd)
 
@@ -118,8 +114,6 @@ class TestNeMoRunSlurmCommandGenStrategy:
 
         with caplog.at_level(logging.WARNING):
             cmd_gen_strategy.generate_test_command(
-                test_run.test.test_definition.extra_env_vars,
-                test_run.test.test_definition.cmd_args.model_dump(),
-                test_run,
+                test_run.test.test_definition.extra_env_vars, test_run.test.test_definition.cmd_args.model_dump()
             )
         assert "Mismatch in num_nodes" in caplog.text

--- a/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
@@ -110,5 +110,5 @@ def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 
 def test_gen_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
     strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
-    cmd = strategy._gen_srun_command({})
+    cmd = strategy._gen_srun_command()
     assert "sleep 5" in cmd

--- a/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
@@ -50,7 +50,7 @@ def nixl_bench_tr(slurm_system: SlurmSystem) -> TestRun:
 class TestNIXLBenchCommand:
     def test_default(self, nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
         strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
-        cmd = strategy.gen_nixlbench_command(nixl_bench_tr)
+        cmd = strategy.gen_nixlbench_command()
         assert cmd == ["./nixlbench", "--etcd-endpoints http://127.0.0.1:2379"]
 
     def test_can_set_any_cmd_arg(self, nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
@@ -66,7 +66,7 @@ class TestNIXLBenchCommand:
         strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
         nixl_bench_tr.test.test_definition.cmd_args = cmd_args
 
-        cmd = " ".join(strategy.gen_nixlbench_command(nixl_bench_tr))
+        cmd = " ".join(strategy.gen_nixlbench_command())
 
         for k, v in in_args.items():
             assert f"--{k} {v}" in cmd
@@ -74,7 +74,7 @@ class TestNIXLBenchCommand:
 
 def test_gen_etcd_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
     strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
-    cmd = " ".join(strategy.gen_etcd_srun_command(nixl_bench_tr))
+    cmd = " ".join(strategy.gen_etcd_srun_command())
     assert (
         "/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 "
         "--advertise-client-urls http://$(hostname -I | awk '{print $1}'):2379"
@@ -94,7 +94,7 @@ def test_gen_etcd_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem, nnodes: int):
     strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
     nixl_bench_tr.num_nodes = nnodes
-    cmd = " ".join(strategy.gen_nixl_srun_command(nixl_bench_tr))
+    cmd = " ".join(strategy.gen_nixl_srun_command())
 
     tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, nixl_bench_tr.test.test_definition)
 
@@ -110,5 +110,5 @@ def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 
 def test_gen_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
     strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
-    cmd = strategy._gen_srun_command({}, {}, nixl_bench_tr)
+    cmd = strategy._gen_srun_command({}, {})
     assert "sleep 5" in cmd

--- a/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
@@ -63,8 +63,8 @@ class TestNIXLBenchCommand:
                 **in_args,
             }
         )
-        strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
         nixl_bench_tr.test.test_definition.cmd_args = cmd_args
+        strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
 
         cmd = " ".join(strategy.gen_nixlbench_command())
 
@@ -92,8 +92,8 @@ def test_gen_etcd_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 
 @pytest.mark.parametrize("nnodes", (1, 2))
 def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem, nnodes: int):
-    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
     nixl_bench_tr.num_nodes = nnodes
+    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
     cmd = " ".join(strategy.gen_nixl_srun_command())
 
     tdef: NIXLBenchTestDefinition = cast(NIXLBenchTestDefinition, nixl_bench_tr.test.test_definition)

--- a/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_nixl_bench_slurm_command_gen_strategy.py
@@ -110,5 +110,5 @@ def test_gen_nixl_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem
 
 def test_gen_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
     strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
-    cmd = strategy._gen_srun_command({}, {})
+    cmd = strategy._gen_srun_command({})
     assert "sleep 5" in cmd

--- a/tests/slurm_command_gen_strategy/test_sleep_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_sleep_slurm_command_gen_strategy.py
@@ -54,6 +54,6 @@ class TestSleepSlurmCommandGenStrategy:
         tr = TestRun(test=test_obj, num_nodes=1, nodes=[], output_path=tmp_path / "output", name="sleep-job")
 
         cmd_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system, tr)
-        command = cmd_gen_strategy.generate_test_command(test_def.extra_env_vars, test_def.cmd_args_dict)
+        command = cmd_gen_strategy.generate_test_command()
 
         assert command == expected_command

--- a/tests/slurm_command_gen_strategy/test_sleep_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_sleep_slurm_command_gen_strategy.py
@@ -51,15 +51,9 @@ class TestSleepSlurmCommandGenStrategy:
 
         test_obj = Test(test_definition=test_def, test_template=Mock())
 
-        tr = TestRun(
-            test=test_obj,
-            num_nodes=1,
-            nodes=[],
-            output_path=tmp_path / "output",
-            name="sleep-job",
-        )
+        tr = TestRun(test=test_obj, num_nodes=1, nodes=[], output_path=tmp_path / "output", name="sleep-job")
 
         cmd_gen_strategy = SleepSlurmCommandGenStrategy(slurm_system, tr)
-        command = cmd_gen_strategy.generate_test_command(test_def.extra_env_vars, test_def.cmd_args_dict, tr)
+        command = cmd_gen_strategy.generate_test_command(test_def.extra_env_vars, test_def.cmd_args_dict)
 
         assert command == expected_command

--- a/tests/slurm_command_gen_strategy/test_slurm_container_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_slurm_container_slurm_command_gen_strategy.py
@@ -44,7 +44,7 @@ def test_run(slurm_system: SlurmSystem) -> TestRun:
 
 def test_default(slurm_system: SlurmSystem, test_run: TestRun) -> None:
     cgs = SlurmContainerCommandGenStrategy(slurm_system, test_run)
-    cmd = cgs.gen_srun_command(test_run)
+    cmd = cgs.gen_srun_command()
     srun_part = (
         f"srun --export=ALL --mpi={slurm_system.mpi} "
         f"--container-image={test_run.test.test_definition.cmd_args.docker_image_url} "
@@ -61,7 +61,7 @@ def test_with_nsys(slurm_system: SlurmSystem, test_run: TestRun) -> None:
     cgs = SlurmContainerCommandGenStrategy(slurm_system, test_run)
     nsys = NsysConfiguration()
     test_run.test.test_definition.nsys = nsys
-    cmd = cgs.gen_srun_command(test_run)
+    cmd = cgs.gen_srun_command()
 
     srun_part = (
         f"srun --export=ALL --mpi={slurm_system.mpi} "
@@ -81,7 +81,7 @@ def test_with_extra_srun_args(slurm_system: SlurmSystem, test_run: TestRun) -> N
     tdef.extra_srun_args = extra_args
 
     cgs = SlurmContainerCommandGenStrategy(slurm_system, test_run)
-    cmd = cgs.gen_srun_command(test_run)
+    cmd = cgs.gen_srun_command()
 
     srun_part = (
         f"srun --export=ALL --mpi={slurm_system.mpi} "

--- a/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
@@ -153,5 +153,5 @@ def test_build_client_srun(strategy: TritonInferenceSlurmCommandGenStrategy, str
 def test_gen_srun_command(strategy: TritonInferenceSlurmCommandGenStrategy) -> None:
     strategy._build_server_srun = Mock(return_value="S")
     strategy._build_client_srun = Mock(return_value="C")
-    cmd = strategy._gen_srun_command({}, {})
+    cmd = strategy._gen_srun_command({})
     assert cmd == f"S &\n\nsleep {strategy.test_run.test.test_definition.cmd_args.sleep_seconds}\n\nC"

--- a/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
@@ -153,5 +153,5 @@ def test_build_client_srun(strategy: TritonInferenceSlurmCommandGenStrategy, str
 def test_gen_srun_command(strategy: TritonInferenceSlurmCommandGenStrategy) -> None:
     strategy._build_server_srun = Mock(return_value="S")
     strategy._build_client_srun = Mock(return_value="C")
-    cmd = strategy._gen_srun_command({})
+    cmd = strategy._gen_srun_command()
     assert cmd == f"S &\n\nsleep {strategy.test_run.test.test_definition.cmd_args.sleep_seconds}\n\nC"

--- a/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_triton_inference_slurm_command_gen_strategy.py
@@ -72,10 +72,7 @@ def test_container_mounts_invalid_model(tmp_path: Path, strategy: TritonInferenc
 
 
 def test_container_mounts_with_model_and_cache(
-    tmp_path: Path,
-    strategy: TritonInferenceSlurmCommandGenStrategy,
-    test_run: TestRun,
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, strategy: TritonInferenceSlurmCommandGenStrategy, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr(
@@ -90,7 +87,7 @@ def test_container_mounts_with_model_and_cache(
     model_dir.mkdir()
     cache_dir.mkdir()
 
-    tdef = cast(TritonInferenceTestDefinition, test_run.test.test_definition)
+    tdef = cast(TritonInferenceTestDefinition, strategy.test_run.test.test_definition)
     tdef.extra_env_vars["NIM_MODEL_NAME"] = str(model_dir)
     tdef.extra_env_vars["NIM_CACHE_PATH"] = str(cache_dir)
 
@@ -105,10 +102,7 @@ def test_container_mounts_with_model_and_cache(
     assert mounts == expected
 
 
-def test_generate_start_wrapper_script(
-    tmp_path: Path,
-    strategy: TritonInferenceSlurmCommandGenStrategy,
-) -> None:
+def test_generate_start_wrapper_script(tmp_path: Path, strategy: TritonInferenceSlurmCommandGenStrategy) -> None:
     script_path = tmp_path / "script.sh"
     env_vars = {"KEY": "VALUE", "NIM_LEADER_IP_ADDRESS": "X", "NIM_NODE_RANK": "Y"}
     strategy._generate_start_wrapper_script(script_path, env_vars)
@@ -120,7 +114,7 @@ def test_generate_start_wrapper_script(
     assert bool(mode & stat.S_IXUSR)
 
 
-def test_append_sbatch_directives(strategy: TritonInferenceSlurmCommandGenStrategy, test_run: TestRun) -> None:
+def test_append_sbatch_directives(strategy: TritonInferenceSlurmCommandGenStrategy) -> None:
     lines: List[str] = []
     strategy._append_sbatch_directives(lines)
     assert "export HEAD_NODE=$SLURM_JOB_MASTER_NODE" in lines
@@ -132,21 +126,9 @@ def test_append_sbatch_directives(strategy: TritonInferenceSlurmCommandGenStrate
 def test_build_server_srun(strategy: TritonInferenceSlurmCommandGenStrategy) -> None:
     strategy.gen_srun_prefix = Mock(return_value=["P"])
     strategy.gen_nsys_command = Mock(return_value=["N"])
-    tdef = TritonInferenceTestDefinition(
-        name="z",
-        description="",
-        test_template_name="",
-        cmd_args=TritonInferenceCmdArgs(
-            server_docker_image_url="nvcr.io/nim/deepseek-ai/deepseek-r1:1.7.2",
-            client_docker_image_url="nvcr.io/nvidia/tritonserver:25.01-py3-sdk",
-            served_model_name="",
-            tokenizer="",
-        ),
-        extra_env_vars={"NIM_CACHE_PATH": "/tmp"},
-    )
-    test = Test(test_definition=tdef, test_template=Mock())
-    tr = TestRun(name="run", test=test, nodes=["n1", "n2", "n3"], num_nodes=3)
+
     result = strategy._build_server_srun(2)
+
     parts = result.split()
     assert parts[:2] == ["P", "--nodes=2"]
     assert "--ntasks=2" in parts
@@ -155,12 +137,10 @@ def test_build_server_srun(strategy: TritonInferenceSlurmCommandGenStrategy) -> 
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-def test_build_client_srun(
-    strategy: TritonInferenceSlurmCommandGenStrategy, test_run: TestRun, streaming: bool
-) -> None:
-    test_run.test.test_definition.cmd_args.streaming = streaming
+def test_build_client_srun(strategy: TritonInferenceSlurmCommandGenStrategy, streaming: bool) -> None:
+    strategy.test_run.test.test_definition.cmd_args.streaming = streaming
     result = strategy._build_client_srun(1)
-    assert test_run.test.test_definition.cmd_args.client_docker_image_url in result
+    assert strategy.test_run.test.test_definition.cmd_args.client_docker_image_url in result
     assert "--nodes=1" in result
     assert "--ntasks=1" in result
     assert "genai-perf" in result
@@ -170,8 +150,8 @@ def test_build_client_srun(
         assert "--streaming" not in result
 
 
-def test_gen_srun_command(strategy: TritonInferenceSlurmCommandGenStrategy, test_run: TestRun) -> None:
+def test_gen_srun_command(strategy: TritonInferenceSlurmCommandGenStrategy) -> None:
     strategy._build_server_srun = Mock(return_value="S")
     strategy._build_client_srun = Mock(return_value="C")
     cmd = strategy._gen_srun_command({}, {})
-    assert cmd == f"S &\n\nsleep {test_run.test.test_definition.cmd_args.sleep_seconds}\n\nC"
+    assert cmd == f"S &\n\nsleep {strategy.test_run.test.test_definition.cmd_args.sleep_seconds}\n\nC"

--- a/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
@@ -81,18 +81,8 @@ class TestUCCTestSlurmCommandGenStrategy:
 
         test_obj = Test(test_definition=test_def, test_template=Mock())
 
-        tr = TestRun(
-            test=test_obj,
-            num_nodes=1,
-            nodes=[],
-            output_path=tmp_path / "output",
-            name="test-job",
-        )
+        tr = TestRun(test=test_obj, num_nodes=1, nodes=[], output_path=tmp_path / "output", name="test-job")
 
         cmd_gen_strategy = UCCTestSlurmCommandGenStrategy(slurm_system, tr)
-        command = cmd_gen_strategy.generate_test_command(
-            test_def.extra_env_vars,
-            test_def.cmd_args_dict,
-            tr,
-        )
+        command = cmd_gen_strategy.generate_test_command(test_def.extra_env_vars, test_def.cmd_args_dict)
         assert command == expected_command

--- a/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_ucc_slurm_command_gen_strategy.py
@@ -84,5 +84,5 @@ class TestUCCTestSlurmCommandGenStrategy:
         tr = TestRun(test=test_obj, num_nodes=1, nodes=[], output_path=tmp_path / "output", name="test-job")
 
         cmd_gen_strategy = UCCTestSlurmCommandGenStrategy(slurm_system, tr)
-        command = cmd_gen_strategy.generate_test_command(test_def.extra_env_vars, test_def.cmd_args_dict)
+        command = cmd_gen_strategy.generate_test_command()
         assert command == expected_command

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -471,7 +471,7 @@ def test_sbatch_generation(slurm_system: SlurmSystem, test_req: tuple[TestRun, s
         cmd_gen.job_name = Mock(return_value="job_name")
     if isinstance(cmd_gen, NeMoLauncherSlurmCommandGenStrategy):
         cmd_gen.job_prefix = "test_account-cloudai.nemo"
-    sbatch_script = cmd_gen.gen_exec_command(tr).split()[-1]
+    sbatch_script = cmd_gen.gen_exec_command().split()[-1]
     if "nemo-launcher" in test_req[1]:
         sbatch_script = slurm_system.output_path / "generated_command.sh"
     curr = Path(sbatch_script).read_text().strip()

--- a/tests/test_command_gen_strategy.py
+++ b/tests/test_command_gen_strategy.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from cloudai.core import CommandGenStrategy, Test, TestRun, TestTemplate
+from cloudai.models.workload import CmdArgs, TestDefinition
+from cloudai.systems.slurm.slurm_system import SlurmSystem
+
+
+class MyCmdGen(CommandGenStrategy):
+    def gen_exec_command(self) -> str:
+        return "echo 'Hello, World!'"
+
+    def store_test_run(self) -> None:
+        pass
+
+
+@pytest.fixture
+def test_run(slurm_system: SlurmSystem) -> TestRun:
+    return TestRun(
+        name="test_a",
+        num_nodes=1,
+        nodes=["node1"],
+        test=Test(
+            test_definition=TestDefinition(name="n", description="d", test_template_name="tt", cmd_args=CmdArgs()),
+            test_template=TestTemplate(slurm_system),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "sys_env,tr_env,expected",
+    [
+        ({}, {}, {}),
+        ({"VAR1": "V1"}, {}, {"VAR1": "V1"}),
+        ({"VAR1": "V1"}, {"VAR2": "V2"}, {"VAR1": "V1", "VAR2": "V2"}),
+        ({"VAR1": "V1"}, {"VAR1": "V2"}, {"VAR1": "V2"}),
+    ],
+)
+def test_final_env_vars(
+    slurm_system: SlurmSystem,
+    test_run: TestRun,
+    sys_env: dict[str, str],
+    tr_env: dict[str, str | list[str]],
+    expected: dict[str, str],
+):
+    slurm_system.global_env_vars = sys_env
+    test_run.test.test_definition.extra_env_vars = tr_env
+    cmd_gen = MyCmdGen(slurm_system, test_run)
+
+    assert cmd_gen.final_env_vars == expected
+
+
+def test_final_env_vars_can_override(slurm_system: SlurmSystem, test_run: TestRun):
+    slurm_system.global_env_vars = {}
+    test_run.test.test_definition.extra_env_vars = {}
+    cmd_gen = MyCmdGen(slurm_system, test_run)
+    cmd_gen.final_env_vars["VAR1"] = "V1"
+
+    assert cmd_gen.final_env_vars == {"VAR1": "V1"}

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -372,7 +372,7 @@ class ConcreteSlurmStrategy(SlurmCommandGenStrategy):
     def _container_mounts(self) -> list[str]:
         return []
 
-    def generate_test_command(self, env_vars, cmd_args):
+    def generate_test_command(self):
         return ["test_command"]
 
     def job_name(self) -> str:

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -369,13 +369,13 @@ class TestGetNodesBySpec:
 
 
 class ConcreteSlurmStrategy(SlurmCommandGenStrategy):
-    def _container_mounts(self, tr: TestRun) -> list[str]:
+    def _container_mounts(self) -> list[str]:
         return []
 
-    def generate_test_command(self, env_vars, cmd_args, tr):
+    def generate_test_command(self, env_vars, cmd_args):
         return ["test_command"]
 
-    def job_name(self, tr: TestRun) -> str:
+    def job_name(self) -> str:
         return "job_name"
 
 
@@ -407,24 +407,24 @@ class TestSlurmCommandGenStrategyCache:
         strategy = ConcreteSlurmStrategy(slurm_system, test_run)
 
         # First call to get nodes
-        res = strategy.get_cached_nodes_spec(test_run)
+        res = strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 1
         assert res == (2, ["node01", "node02"])
 
         # Second call with same parameters should use cache
-        res = strategy.get_cached_nodes_spec(test_run)
+        res = strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 1
         assert res == (2, ["node01", "node02"])
 
         # Different node spec should call get_nodes_by_spec again
         test_run.num_nodes = 1
         test_run.nodes = []
-        strategy.get_cached_nodes_spec(test_run)
+        strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 2
 
         test_run.num_nodes = 2
         test_run.nodes = ["node01", "node03"]
-        strategy.get_cached_nodes_spec(test_run)
+        strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 3
 
     @patch("cloudai.systems.slurm.SlurmSystem.get_nodes_by_spec")
@@ -437,11 +437,11 @@ class TestSlurmCommandGenStrategyCache:
             ConcreteSlurmStrategy(slurm_system, test_run),
         )
 
-        res = strategy1.get_cached_nodes_spec(test_run)
+        res = strategy1.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 1
         assert res == (2, ["node01", "node02"])
 
-        res = strategy2.get_cached_nodes_spec(test_run)
+        res = strategy2.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 2
         assert res == (2, ["node03", "node04"])
 
@@ -453,12 +453,12 @@ class TestSlurmCommandGenStrategyCache:
 
         strategy = ConcreteSlurmStrategy(slurm_system, test_run)
 
-        res = strategy.get_cached_nodes_spec(test_run)
+        res = strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 1
         assert res == (2, ["node01", "node02"])
 
-        test_run.current_iteration = 1
-        res = strategy.get_cached_nodes_spec(test_run)
+        strategy.test_run.current_iteration = 1
+        res = strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 2
         assert res == (2, ["node03", "node04"])
 
@@ -468,12 +468,12 @@ class TestSlurmCommandGenStrategyCache:
 
         strategy = ConcreteSlurmStrategy(slurm_system, test_run)
 
-        res = strategy.get_cached_nodes_spec(test_run)
+        res = strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 1
         assert res == (2, ["node01", "node02"])
 
-        test_run.step = 1
-        res = strategy.get_cached_nodes_spec(test_run)
+        strategy.test_run.step = 1
+        res = strategy.get_cached_nodes_spec()
         assert mock_get_nodes.call_count == 2
         assert res == (2, ["node03", "node04"])
 


### PR DESCRIPTION
## Summary
Rely on member test run object instead of args to simplify code:
1. No need to pass TR as it is part of CmdGen strategy now.
2. No need to pass `env_vars` and `cmd_args` as they are taken from TR and in 95% cases were not used already.
3. As result, functions' signature became cleaner.

## Test Plan
1. CI
2. See comments for real runs.

## Additional Notes
—