### PR TITLE
Fix docker image cache CLI for gres support

### DIFF
--- a/src/cloudai/systems/slurm/docker_image_cache_manager.py
+++ b/src/cloudai/systems/slurm/docker_image_cache_manager.py
@@ -259,7 +259,7 @@ class DockerImageCacheManager:
         srun_prefix = f"srun --export=ALL --partition={self.system.default_partition}"
         if self.system.account:
             srun_prefix += f" --account={self.system.account}"
-        if self.system.gpus_per_node:
+        if self.system.supports_gpu_directives:
             srun_prefix += " --gres=gpu:1"
 
         return self._import_docker_image(srun_prefix, docker_image_url, docker_image_path)

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -197,11 +197,13 @@ def test_ensure_docker_image_no_local_cache(slurm_system: SlurmSystem):
 
 
 @pytest.mark.parametrize(
-    "account, gpus_per_node", [(None, None), ("test_account", None), (None, 8), ("test_account", 8)]
+    "account, supports_gpu_directives", [(None, False), ("test_account", True), (None, False), ("test_account", True)]
 )
-def test_docker_import_with_extra_system_config(slurm_system: SlurmSystem, account, gpus_per_node):
+def test_docker_import_with_extra_system_config(
+    slurm_system: SlurmSystem, account: str | None, supports_gpu_directives: bool | None
+):
     slurm_system.account = account
-    slurm_system.gpus_per_node = gpus_per_node
+    slurm_system.supports_gpu_directives_cache = supports_gpu_directives
     slurm_system.install_path.mkdir(parents=True, exist_ok=True)
 
     manager = DockerImageCacheManager(slurm_system)
@@ -224,7 +226,7 @@ def test_docker_import_with_extra_system_config(slurm_system: SlurmSystem, accou
     else:
         assert "--job-name=CloudAI_install_docker_image_" in actual_command
 
-    if gpus_per_node:
+    if supports_gpu_directives:
         assert "--gres=gpu:1" in actual_command
 
     assert (


### PR DESCRIPTION
## Summary
Fix docker image cache CLI for gres support, check `supports_gpu_directives` instead of `gpus_per_node`. Fixes [internal bug](https://redmine.mellanox.com/issues/4520777).

## Test Plan
1. CI (updated).
2. Run installation on pre-tyche system.

## Additional Notes
—