### PR TITLE
Docker cache fix

### DIFF
--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -67,6 +67,9 @@ class DockerImage(Installable):
             parts = wo_tag.split("/")
             img_name = "_".join(parts[:-1]) + "__" + parts[-1]
 
+        # Replace # with _ in img_name to avoid filesystem issues
+        img_name = img_name.replace("#", "_")
+
         return f"{img_name}__{tag}.sqsh"
 
     @property

--- a/src/cloudai/systems/slurm/docker_image_cache_manager.py
+++ b/src/cloudai/systems/slurm/docker_image_cache_manager.py
@@ -195,9 +195,8 @@ class DockerImageCacheManager:
         else:
             job_name = f"{job_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
-        enroot_import_cmd = (
-            f"{srun_prefix} --job-name={job_name} enroot import -o {docker_image_path} docker://{docker_image_url}"
-        )
+        # Use -N1 --ntasks=1 to ensure only one compute node downloads the image
+        enroot_import_cmd = f"{srun_prefix} -N1 --ntasks=1 --job-name={job_name} enroot import -o {docker_image_path} docker://{docker_image_url}"
         logging.debug(f"Importing Docker image: {enroot_import_cmd}")
         try:
             p = subprocess.run(enroot_import_cmd, shell=True, check=True, capture_output=True, text=True)

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -135,6 +135,7 @@ class TestBaseInstaller:
         ("http://fake_url/img", "fake_url__img__notag.sqsh"),
         ("nvcr.io/nvidia/pytorch:24.02-py3", "nvcr.io_nvidia__pytorch__24.02-py3.sqsh"),
         ("/local/disk/file", "file__notag.sqsh"),
+        ("gitlab.com#org/team/image:latest", "gitlab.com_org_team__image__latest.sqsh"),
     ],
 )
 def test_docker_cache_filename(url: str, expected: str):

--- a/tests/test_docker_image_cache_manager.py
+++ b/tests/test_docker_image_cache_manager.py
@@ -112,6 +112,8 @@ def test_cache_docker_image(
     assert mock_run.call_count == 1
     actual_command = mock_run.call_args[0][0]
     assert f"srun --export=ALL --partition={slurm_system.default_partition}" in actual_command
+    assert "--ntasks=1" in actual_command
+    assert "-N1" in actual_command
     assert "--job-name=CloudAI_install_docker_image_" in actual_command
     assert f"enroot import -o {slurm_system.install_path}/image.tar.gz docker://docker.io/hello-world" in actual_command
     assert mock_run.call_args[1] == {"shell": True, "check": True, "capture_output": True, "text": True}
@@ -219,6 +221,7 @@ def test_docker_import_with_extra_system_config(
 
     expected_prefix = f"srun --export=ALL --partition={slurm_system.default_partition}"
     assert expected_prefix in actual_command
+    assert "-N1" in actual_command
 
     if account:
         assert f"--account={account}" in actual_command


### PR DESCRIPTION
## Summary
There are two changes here: 
- using --ntasks=1 when downloading docker images to ensure there are no parallel downloads
- replacing `#` in docker image url with `_` to avoid shell issues.

## Test Plan
Added UT and verified manually.