### PR TITLE
Fix to Buggy Implemention of PR 589

### DIFF
--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -259,6 +259,7 @@ class BaseRunner(ABC):
                                 f"Job {job.id} for test {job.test_run.name} failed: {job_status_result.error_message}"
                             )
                             logging.error(error_message)
+                            await self.handle_job_completion(job)
                             await self.shutdown()
                             raise JobFailureError(job.test_run.name, error_message, job_status_result.error_message)
                     else:

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from cloudai.core import METRIC_ERROR, Registry, Runner, TestRun
 from cloudai.util.lazy_imports import lazy
+from cloudai._core.exceptions import JobFailureError
 
 from .base_gym import BaseGym
 
@@ -42,6 +43,7 @@ class CloudAIGymEnv(BaseGym):
             runner (Runner): The runner object to execute jobs.
         """
         self.test_run = test_run
+        self.original_test_run = copy.deepcopy(test_run)  # Preserve clean state for DSE
         self.runner = runner
         self.max_steps = test_run.test.test_definition.agent_steps
         self.reward_function = Registry().get_reward_function(test_run.test.test_definition.agent_reward_function)
@@ -105,9 +107,21 @@ class CloudAIGymEnv(BaseGym):
 
         logging.info(f"Running step {self.test_run.step} with action {action}")
         new_tr = copy.deepcopy(self.test_run)
+        new_tr.output_path = self.runner.runner.get_job_output_path(new_tr)
         self.runner.runner.test_scenario.test_runs = [new_tr]
+        
+        self.runner.runner.shutting_down = False
+        self.runner.runner.jobs.clear()
+        self.runner.runner.testrun_to_job_map.clear()
+        
         asyncio.run(self.runner.run())
-        self.test_run = self.runner.runner.test_scenario.test_runs[0]
+        
+        if self.runner.runner.test_scenario.test_runs and self.runner.runner.test_scenario.test_runs[0].output_path.exists():
+            self.test_run = self.runner.runner.test_scenario.test_runs[0]
+        else:
+            self.test_run = copy.deepcopy(self.original_test_run)
+            self.test_run.step = new_tr.step
+            self.test_run.output_path = new_tr.output_path
 
         observation = self.get_observation(action)
         reward = self.compute_reward(observation)


### PR DESCRIPTION
## Summary
DSE feature in CloudAI is completely broken due to buggy/faulty implementation of https://github.com/NVIDIA/cloudai/pull/589. 

DSE customers impacted by this
* Perf team blocked for finding good configuration
* AI Dynamo DSE feature also dysfunctional

### The Problem
DSE functionality was completely broken - only Step 1 would submit jobs to Slurm, while Steps 2-4 would appear to run but never actually submit jobs, resulting in immediate -1.0 rewards instead of proper parameter exploration.

Root Cause: PR #589 

Separated job status checking into two levels:

- Runner level: Slurm job status (COMPLETED, FAILED, etc.)

- Workload level: Application-specific success indicators (e.g., NeMo looking for "max_steps=" in stderr)

Started calling shutdown() for workload failures:

### Two Design Flaws Exposed
Flaw 1: Exception Swallowing
```
# In Runner.run() - masks the real problem
try:
    await self.runner.run()
except JobFailureError as exc:
    logging.debug(f"Runner failed: {exc}")  # Just logs it!
```
Flaw 2: Persistent Runner State

- shutting_down = True persists between DSE steps

- No reset mechanism for exploration scenarios

- Assumes single test scenarios, not multi-step exploration

## Test Plan
-CI/CD
- Real system

## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
