### PR TITLE
Support custom matgen args and set valid ppn

### DIFF
--- a/src/cloudai/workloads/nixl_perftest/__init__.py
+++ b/src/cloudai/workloads/nixl_perftest/__init__.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .nixl_perftest import NixlPerftestCmdArgs, NixlPerftestTestDefinition
+from .nixl_perftest import MatgenCmdArgs, NixlPerftestCmdArgs, NixlPerftestTestDefinition
 from .slurm_command_gen_strategy import NixlPerftestSlurmCommandGenStrategy
 
 __all__ = [
+    "MatgenCmdArgs",
     "NixlPerftestCmdArgs",
     "NixlPerftestSlurmCommandGenStrategy",
     "NixlPerftestTestDefinition",

--- a/src/cloudai/workloads/nixl_perftest/nixl_perftest.py
+++ b/src/cloudai/workloads/nixl_perftest/nixl_perftest.py
@@ -16,7 +16,7 @@
 
 from typing import Literal, Optional
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from cloudai.core import CmdArgs, DockerImage, Installable, TestDefinition
 
@@ -60,7 +60,7 @@ class NixlPerftestCmdArgs(CmdArgs):
     num_kv_heads: int | None = None
     dtype_size: int | None = None
 
-    matgen_args: MatgenCmdArgs | None = None
+    matgen_args: MatgenCmdArgs = Field(default_factory=MatgenCmdArgs)
 
     @model_validator(mode="after")
     def model_vs_custom(self):

--- a/src/cloudai/workloads/nixl_perftest/nixl_perftest.py
+++ b/src/cloudai/workloads/nixl_perftest/nixl_perftest.py
@@ -21,6 +21,12 @@ from pydantic import model_validator
 from cloudai.core import CmdArgs, DockerImage, Installable, TestDefinition
 
 
+class MatgenCmdArgs(CmdArgs):
+    """Command args for matgen script."""
+
+    ppn: int | None = None
+
+
 class NixlPerftestCmdArgs(CmdArgs):
     """CmdArgs for NixlPerftestTestDefinition."""
 
@@ -53,6 +59,8 @@ class NixlPerftestCmdArgs(CmdArgs):
     num_heads: int | None = None
     num_kv_heads: int | None = None
     dtype_size: int | None = None
+
+    matgen_args: MatgenCmdArgs | None = None
 
     @model_validator(mode="after")
     def model_vs_custom(self):

--- a/src/cloudai/workloads/nixl_perftest/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_perftest/slurm_command_gen_strategy.py
@@ -116,6 +116,8 @@ class NixlPerftestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                 self.tdef.cmd_args.matgen_args.ppn = self.system.ntasks_per_node
 
             for arg, value in self.tdef.cmd_args.matgen_args.model_dump().items():
+                if value is None:
+                    continue
                 cmd.append(f"{self.prop_to_cli_arg(arg)}={value}")
 
         (self.matrix_gen_path).mkdir(parents=True, exist_ok=True)

--- a/src/cloudai/workloads/nixl_perftest/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_perftest/slurm_command_gen_strategy.py
@@ -111,6 +111,13 @@ class NixlPerftestSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             if getattr(self.tdef.cmd_args, arg) is not None:
                 cmd.append(f"{self.prop_to_cli_arg(arg)}={getattr(self.tdef.cmd_args, arg)}")
 
+        if self.tdef.cmd_args.matgen_args:
+            if self.system.ntasks_per_node is not None and self.tdef.cmd_args.matgen_args.ppn is None:
+                self.tdef.cmd_args.matgen_args.ppn = self.system.ntasks_per_node
+
+            for arg, value in self.tdef.cmd_args.matgen_args.model_dump().items():
+                cmd.append(f"{self.prop_to_cli_arg(arg)}={value}")
+
         (self.matrix_gen_path).mkdir(parents=True, exist_ok=True)
 
         return cmd


### PR DESCRIPTION
## Summary
Introduce custom matgen script args support. Along with any option, set correct `ppn` value.
Fixes [internal bug](https://redmine.mellanox.com/issues/4548555).

## Test Plan
1. CI (extended)
2. Manual dry-run:
    ```bash
    $ uv run cloudai dry-run --system-config ../cloudaix/conf/devops/verification/system/pre-tyche.toml --test-scenario ../cloudaix/conf/devops/verification/test_scenario/kvbench_ctperf.toml
    $ cat results/KVBenchCTPerf_2025-07-29_15-34-18/KVBenchCTPerf.1/0/cloudai_sbatch_script.sh| grep matgen | grep ppn | wc -l
       1
```

## Additional Notes
—