### PR TITLE
Handle multi-section CSV format in AI Dynamo report generation

### DIFF
--- a/tests/report_generation_strategy/test_ai_dynamo_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_ai_dynamo_report_generation_strategy.py
@@ -42,11 +42,18 @@ def get_csv_content() -> str:
         '"7777.77","8888.88","9999.99"\n'
         "Inter Token Latency (ms),12.34,23.45,34.56,45.67,56.78,67.89,78.90,89.01,90.12\n"
         "Output Sequence Length (tokens),101.01,202.02,303.03,404.04,505.05,606.06,707.07,808.08,909.09\n"
-        "Input Sequence Length (tokens),123.45,234.56,345.67,456.78,567.89,678.90,789.01,890.12,901.23\n\n"
+        "Input Sequence Length (tokens),123.45,234.56,345.67,456.78,567.89,678.90,789.01,890.12,901.23\n"
+        "\n"
         "Metric,Value\n"
         "Output Token Throughput (tokens/sec),24\n"
         "Request Throughput (per sec),1.23\n"
         "Request Count (count),40.00\n"
+        "\n"
+        "Metric,GPU,avg,min,max,p99,p95,p90,p75,p50,p25\n"
+        "GPU Power Usage (W),0,119.93,117.61,120.81,120.81,120.81,120.81,120.81,120.60,119.85\n"
+        "GPU Power Usage (W),1,120.50,120.49,120.52,120.52,120.52,120.52,120.52,120.50,120.49\n"
+        "GPU Memory Used (GB),0,84.11,82.41,84.68,84.68,84.68,84.68,84.68,84.67,84.11\n"
+        "GPU Memory Used (GB),1,82.44,82.44,82.44,82.44,82.44,82.44,82.44,82.44,82.44\n"
     )
 
 
@@ -116,8 +123,31 @@ def test_ai_dynamo_generate_report(slurm_system: SlurmSystem, ai_dynamo_tr: Test
     assert report_file.is_file(), "Report CSV was not generated."
 
     report_content = report_file.read_text()
-    expected_content = csv_content + "Overall Output Tokens per Second per GPU,1.0\n"
-    assert report_content == expected_content, "Report content does not match expected."
+
+    def split_into_sections(content: str) -> list[str]:
+        sections = content.split("\n\n")
+        return [s.strip() for s in sections if s.strip()]
+
+    def normalize_csv_section(section: str) -> str:
+        return section.replace('"', "").strip()
+
+    actual_sections = [normalize_csv_section(s) for s in split_into_sections(report_content)]
+    expected_sections = [normalize_csv_section(s) for s in split_into_sections(csv_content)]
+
+    # First section should match after normalization
+    assert actual_sections[0] == expected_sections[0], "First section (metrics) does not match"
+
+    # Second section should have our additional metric
+    second_section_lines = actual_sections[1].split("\n")
+    assert second_section_lines[0] == "Metric,Value", "Second section header does not match"
+    assert second_section_lines[1] == "Output Token Throughput (tokens/sec),24", "Throughput line does not match"
+    assert second_section_lines[2] == "Overall Output Tokens per Second per GPU,1.0", "Added metric line is incorrect"
+    assert second_section_lines[3:] == ["Request Throughput (per sec),1.23", "Request Count (count),40.00"], (
+        "Remaining lines do not match"
+    )
+
+    # Third section (GPU metrics) should be identical
+    assert actual_sections[2] == expected_sections[2], "Third section (GPU metrics) does not match"
 
 
 def test_ai_dynamo_get_metric_single_values(slurm_system: SlurmSystem, ai_dynamo_tr: TestRun) -> None:


### PR DESCRIPTION
## Summary
Report generation was working fine for the last release ([v1.3.0](https://github.com/NVIDIA/cloudai/releases/tag/v1.3.0)), but it started failing after https://github.com/NVIDIA/cloudai/pull/615. This is due to multiple sections being printed in the genai-perf results.

**[RM4554591](https://redmine.mellanox.com/issues/4554591): AI Dynamo reporter needs to handle extra lines in genai-perf profile.csv**
**Isssue 1: AI Dynamo runs successfully, but the report generation stage fails (`[WARNING] Error generating report...`)**
```
$ python cloudaix.py run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml   
...
[WARNING] Error generating report for 'results/deepseek_r1_distill_llama_8b_2025-08-08_04-21-04/Tests.1/0' with strategy=AIDynamoReportGenerationStrategy: could not convert string to float: '"1'
...
[INFO] All jobs are complete.
```

**Issue 2: `report.csv` is missing `Overall Output Tokens per Second per GPU` due to a parsing failure**
```
...
Metric,Value
Output Token Throughput (tokens/sec),"1,742.35"
Request Throughput (per sec),35.72
Request Count (count),32.00
...
```

**[RM4554587](https://redmine.mellanox.com/issues/4554587): AI Dynamo: Dry-Run with DSE fails**
**Issue 3: dry-run fails with AI dynamo**
```
diff --git a/conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml b/conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
index e208c13..fbf96db 100644
--- a/conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
+++ b/conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
@@ -3,9 +3,9 @@ name = "deepseek_r1_distill_llama_8b"
 [[Tests]]
 id = "Tests.1"
 test_name = "vllm"
-num_nodes = "3"
+num_nodes = "4"
 time_limit = "00:20:00"
-agent =  "bo_gp"
+agent =  "grid_search"
 agent_steps = 4
 
   [Tests.cmd_args]
@@ -19,7 +19,7 @@ agent_steps = 4
       data-parallel-size = 1
 
       [Tests.cmd_args.dynamo.decode_worker]
-      num-nodes = 1
+      num-nodes = [1, 2]
       tensor-parallel-size = 8
       pipeline-parallel-size = 1
       data-parallel-size = 1
```

```
$ python cloudaix.py dry-run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner
[INFO] Running step 1 with action {'dynamo.decode_worker.num_nodes': 1}
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 0
[INFO] Job completed: Tests.1 (iteration 1 of 1)
Traceback (most recent call last):
  File "/lustre/fsw/portfolios/general/users/theo/cloudaix/cloudaix.py", line 49, in <module>
    main()
  File "/lustre/fsw/portfolios/general/users/theo/cloudaix/cloudaix.py", line 44, in main
    rc = cloudai_cli.run()
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/cli/cli.py", line 181, in run
    return self.handlers[args.mode](args)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/cli/handlers.py", line 249, in handle_dry_run_and_run
    handle_dse_job(runner, args)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/cli/handlers.py", line 141, in handle_dse_job
    observation, reward, done, info = env.step(action)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/configurator/cloudai_gym.py", line 128, in step
    observation = self.get_observation(action)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/configurator/cloudai_gym.py", line 182, in get_observation
    v = self.test_run.get_metric_value(self.runner.runner.system, metric)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/_core/test_scenario.py", line 108, in get_metric_value
    return report(system, self).get_metric(metric)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/workloads/ai_dynamo/report_generation_strategy.py", line 86, in get_metric
    return self._read_metric_from_csv(mapped_metric)
  File "/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/workloads/ai_dynamo/report_generation_strategy.py", line 49, in _read_metric_from_csv
    source_csv = next(output_path.rglob("profile_genai_perf.csv"))
StopIteration
```

## Test Plan
1. CI passes
2. TODO: Run on CW

[RM4554591](https://redmine.mellanox.com/issues/4554591)
**Issue 1: The warning is no longer observed**
```
$ python cloudaix.py run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml   
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 4903377
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] All test scenario results stored at: results/deepseek_r1_distill_llama_8b_2025-08-08_10-07-27
[INFO] Generated scenario report at results/deepseek_r1_distill_llama_8b_2025-08-08_10-07-27/deepseek_r1_distill_llama_8b.html
[INFO] All jobs are complete.
```

**Issue 2: `report.csv` now includes `Overall Output Tokens per Second per GPU`**
```
...
Metric,Value
Output Token Throughput (tokens/sec),"1,589.93"
Overall Output Tokens per Second per GPU,49.6853125
Request Throughput (per sec),32.45
Request Count (count),32.00
...
```

[RM4554587](https://redmine.mellanox.com/issues/4554587)
**Issue 3: Dry-run completes successfully with AI Dynamo**
```
$ python cloudaix.py dry-run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner
[INFO] Running step 1 with action {'dynamo.decode_worker.num_nodes': 1}
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 0
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] Step 1: Observation: [-1.0], Reward: -1.0
[INFO] Running step 2 with action {'dynamo.decode_worker.num_nodes': 2}
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 0
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] Step 2: Observation: [-1.0], Reward: -1.0
[INFO] All jobs are complete.
```