### PR TITLE
Replace PyTorch image tag from 24.02-py3 to 25.06-py3 in all conf TOML files

### DIFF
--- a/conf/common/test/dse_nccl_all_gather.toml
+++ b/conf/common/test/dse_nccl_all_gather.toml
@@ -19,7 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "all_gather_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "128"

--- a/conf/common/test/nccl_test.toml
+++ b/conf/common/test/nccl_test.toml
@@ -19,7 +19,7 @@ description = "NCCL base test configuration"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 ngpus = 1
 minbytes = "128"
 maxbytes = "4G"

--- a/conf/common/test/nccl_test_all_gather.toml
+++ b/conf/common/test/nccl_test_all_gather.toml
@@ -19,7 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "all_gather_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "128"

--- a/conf/common/test/ucc_test.toml
+++ b/conf/common/test/ucc_test.toml
@@ -19,4 +19,4 @@ description = "Base config for UCC tests"
 test_template_name = "UCCTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/pytorch:25.06-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"

--- a/conf/common/test_scenario/nccl_test.toml
+++ b/conf/common/test_scenario/nccl_test.toml
@@ -68,7 +68,7 @@ description = "scatter_perf"
 test_template_name = "NcclTest"
 
   [Tests.cmd_args]
-  docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+  docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
   subtest_name = "scatter_perf_mpi"
   ngpus = 1
   minbytes = "128"

--- a/conf/hook/test/nccl_test_all_gather.toml
+++ b/conf/hook/test/nccl_test_all_gather.toml
@@ -19,7 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "all_gather_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "128"

--- a/conf/release/nemo_acceptance/test/nccl_test_all_reduce_loopback.toml
+++ b/conf/release/nemo_acceptance/test/nccl_test_all_reduce_loopback.toml
@@ -23,7 +23,7 @@ NCCL_P2P_DISABLE = "1"
 NCCL_SHM_DISABLE = "1"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "all_reduce_perf_mpi"
 "ngpus" = "1"
 "minbytes" = "8M"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather.toml
@@ -19,7 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "all_gather_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_gather_worst.toml
@@ -19,7 +19,7 @@ description = "all_gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "all_gather_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce.toml
@@ -19,7 +19,7 @@ description = "all_reduce"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "all_reduce_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_all_reduce_worst.toml
@@ -19,7 +19,7 @@ description = "all_reduce_worst_alloc_test"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "all_reduce_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall.toml
@@ -19,7 +19,7 @@ description = "alltoall"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "alltoall_perf_mpi"
 minbytes = "1k"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst.toml
@@ -19,7 +19,7 @@ description = "alltoall_tested_job"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "alltoall_perf_mpi"
 minbytes = "1k"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst_failover.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_alltoall_worst_failover.toml
@@ -19,7 +19,7 @@ description = "alltoall_tested_job"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "alltoall_perf_mpi"
 minbytes = "128M"
 maxbytes = "128M"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_bisection.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_bisection.toml
@@ -19,7 +19,7 @@ description = "nccl_test_bisection"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "bisection_perf_mpi"
 ngpus = "1"
 minbytes = "128"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_broadcast.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_broadcast.toml
@@ -19,5 +19,5 @@ description = "broadcast"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "broadcast_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_gather.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_gather.toml
@@ -19,5 +19,5 @@ description = "gather"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "gather_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_hypercube.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_hypercube.toml
@@ -19,5 +19,5 @@ description = "hypercube"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "hypercube_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce.toml
@@ -19,5 +19,5 @@ description = "reduce"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "reduce_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter.toml
@@ -19,7 +19,7 @@ description = "reduce_scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "reduce_scatter_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_reduce_scatter_worst.toml
@@ -19,7 +19,7 @@ description = "reduce_scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "reduce_scatter_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_scatter.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_scatter.toml
@@ -19,5 +19,5 @@ description = "scatter"
 test_template_name = "NcclTest"
 
 [cmd_args]
-"docker_image_url" = "nvcr.io#nvidia/pytorch:24.02-py3"
+"docker_image_url" = "nvcr.io#nvidia/pytorch:25.06-py3"
 "subtest_name" = "scatter_perf_mpi"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv.toml
@@ -19,7 +19,7 @@ description = "sendrecv"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "sendrecv_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"

--- a/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv_worst.toml
+++ b/conf/release/spcx/l40s/test/l40s-bc-nccl_test_sendrecv_worst.toml
@@ -19,7 +19,7 @@ description = "sendrecv"
 test_template_name = "NcclTest"
 
 [cmd_args]
-docker_image_url = "nvcr.io#nvidia/pytorch:24.02-py3"
+docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
 subtest_name = "sendrecv_perf_mpi"
 minbytes = "1K"
 maxbytes = "16G"


### PR DESCRIPTION
## Summary
Replace PyTorch image tag from 24.02-py3 to 25.06-py3 in all conf TOML files

[RM4548252](https://redmine.mellanox.com/issues/4548252)

Performed
```
$ find conf -type f -name "*.toml" -exec sed -i '' 's|nvcr.io/nvidia/pytorch:24.02-py3|nvcr.io#nvidia/pytorch:25.06-py3|g' {} +
$ find conf -type f -name "*.toml" -exec sed -i '' 's|nvcr.io/nvidia/pytorch:25.02-py3|nvcr.io#nvidia/pytorch:25.06-py3|g' {} +
```

Related PR: https://github.com/Mellanox/cloudaix/pull/322

## Test Plan
1. CI passes
2. Run on CW
```
$ cloudai install --system-config ../cloudaix/conf/common/system/cw.toml --tests-dir conf/common/test
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Not all components are ready
[INFO] Going to install 5 item(s)
[INFO] 1/6 Installation of File(src=PosixPath('/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/workloads/nemo_run/cloudai_nemorun.py')): OK
[INFO] 2/6 Installation of File(src=PosixPath('/lustre/fsw/portfolios/general/users/theo/.venv/lib/python3.10/site-packages/cloudai/systems/slurm/slurm-metadata.sh')): OK
[INFO] 3/6 Installation of PythonExecutable(git_repo=GitRepo(url=https://github.com/NVIDIA/NeMo-Framework-Launcher.git, commit=599ecfcbbd64fd2de02f2cc093b1610d73854022), venv_path=PosixPath('install/NeMo-Framework-Launcher__599ecfcbbd64fd2de02f2cc093b1610d73854022-venv'), project_subpath=None, dependencies_from_pyproject=True): OK
[INFO] 4/6 Installation of DockerImage(url='nvcr.io#nvidia/pytorch:25.06-py3'): Docker image cached successfully at install/nvcr.io_nvidia__pytorch__25.06-py3.sqsh.
[INFO] 5/6 Installation of DockerImage(url='nvcr.io/nvidia/nemo:24.12.01'): Docker image cached successfully at install/nvcr.io_nvidia__nemo__24.12.01.sqsh.
[INFO] 6/6 Installation of DockerImage(url='nvcr.io/nvidia/nemo:25.04.rc2'): Docker image cached successfully at install/nvcr.io_nvidia__nemo__25.04.rc2.sqsh.
[INFO] CloudAI is successfully installed into '/lustre/fsw/portfolios/general/users/theo/cloudai/install'.
```