### PR TITLE
Improve prepare_output_dir error handling for permissions and read-only fs

### DIFF
--- a/src/cloudai/util/__init__.py
+++ b/src/cloudai/util/__init__.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -35,33 +34,27 @@ def _validate_path_format(path: Path) -> Optional[Path]:
 def _validate_parent_dir(path: Path, parent: Path) -> bool:
     try:
         if not parent.exists():
-            msg = f"{path} does not exist."
-            logging.error(msg)
-            sys.exit(1)
+            logging.error(f"Output path '{path.absolute()}' does not exist.")
+            return False
         if not parent.is_dir():
-            msg = f"{path} is not a directory."
-            logging.error(msg)
-            sys.exit(1)
+            logging.error(f"Output path '{path.absolute()}' is not a directory.")
+            return False
         if not os.access(parent, os.W_OK):
-            msg = f"{path} is not writable."
-            logging.error(msg)
-            sys.exit(1)
+            logging.error(f"Output path '{path.absolute()}' is not writable.")
+            return False
         return True
-    except PermissionError:
-        msg = f"Cannot access {path}: Permission denied."
-        logging.error(msg)
-        sys.exit(1)
+    except PermissionError as e:
+        logging.error(f"Output path '{path.absolute()}' is not accessible: {e}")
+        return False
 
 
 def _validate_existing_path(path: Path) -> Optional[Path]:
     if not path.is_dir():
-        msg = f"{path} is not a directory."
-        logging.error(msg)
-        sys.exit(1)
+        logging.error(f"Output path '{path.absolute()}' exists but is not a directory.")
+        return None
     if not os.access(path, os.W_OK):
-        msg = f"{path} is not writable."
-        logging.error(msg)
-        sys.exit(1)
+        logging.error(f"Output path '{path.absolute()}' exists but is not writable.")
+        return None
     return path
 
 
@@ -82,12 +75,11 @@ def prepare_output_dir(path: Path) -> Optional[Path]:
             resolved_path.mkdir(parents=True)
             return resolved_path
         except OSError as e:
-            msg = (
+            logging.error(
                 f"Failed to create directory '{resolved_path.absolute()}': {e}. "
                 "Please check directory permissions and available disk space."
             )
-            logging.error(msg)
-            sys.exit(1)
+            return None
     except PermissionError:
         logging.error(
             f"Cannot access path '{resolved_path.absolute()}': Permission denied. Please check directory permissions."

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -188,17 +188,23 @@ class TestPrepareOutputDir:
     def test_exists_but_file(self, tmp_path: Path, caplog: pytest.LogCaptureFixture):
         p = tmp_path / "file"
         p.touch()
-        assert prepare_output_dir(p) is None
-        assert f"Output path '{p.absolute()}' exists but is not a directory." in caplog.text
+        with pytest.raises(SystemExit) as exc_info:
+            prepare_output_dir(p)
+        assert exc_info.value.code == 1
+        assert f"{p} is not a directory." in caplog.text
 
     def test_not_writable(self, no_access_dir: Path, caplog: pytest.LogCaptureFixture):
-        assert prepare_output_dir(no_access_dir) is None
-        assert f"Output path '{no_access_dir.absolute()}' exists but is not writable." in caplog.text
+        with pytest.raises(SystemExit) as exc_info:
+            prepare_output_dir(no_access_dir)
+        assert exc_info.value.code == 1
+        assert f"{no_access_dir} is not writable." in caplog.text
 
     def test_parent_wo_access(self, no_access_dir: Path, caplog: pytest.LogCaptureFixture):
         subdir = no_access_dir / "subdir"
-        assert prepare_output_dir(subdir) is None
-        assert f"Output path '{subdir.absolute()}' is not accessible:" in caplog.text
+        with pytest.raises(SystemExit) as exc_info:
+            prepare_output_dir(subdir)
+        assert exc_info.value.code == 1
+        assert f"{subdir} is not writable." in caplog.text
 
 
 def test_system_installables_are_used(slurm_system: SlurmSystem):

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -188,23 +188,17 @@ class TestPrepareOutputDir:
     def test_exists_but_file(self, tmp_path: Path, caplog: pytest.LogCaptureFixture):
         p = tmp_path / "file"
         p.touch()
-        with pytest.raises(SystemExit) as exc_info:
-            prepare_output_dir(p)
-        assert exc_info.value.code == 1
-        assert f"{p} is not a directory." in caplog.text
+        assert prepare_output_dir(p) is None
+        assert f"Output path '{p.absolute()}' exists but is not a directory." in caplog.text
 
     def test_not_writable(self, no_access_dir: Path, caplog: pytest.LogCaptureFixture):
-        with pytest.raises(SystemExit) as exc_info:
-            prepare_output_dir(no_access_dir)
-        assert exc_info.value.code == 1
-        assert f"{no_access_dir} is not writable." in caplog.text
+        assert prepare_output_dir(no_access_dir) is None
+        assert f"Output path '{no_access_dir.absolute()}' exists but is not writable." in caplog.text
 
     def test_parent_wo_access(self, no_access_dir: Path, caplog: pytest.LogCaptureFixture):
         subdir = no_access_dir / "subdir"
-        with pytest.raises(SystemExit) as exc_info:
-            prepare_output_dir(subdir)
-        assert exc_info.value.code == 1
-        assert f"{subdir} is not writable." in caplog.text
+        assert prepare_output_dir(subdir) is None
+        assert f"Output path '{subdir.absolute()}' is not writable." in caplog.text
 
 
 def test_system_installables_are_used(slurm_system: SlurmSystem):


### PR DESCRIPTION
## Summary
Improve prepare_output_dir error handling for permissions and read-only fs

[RM4540741](https://redmine.mellanox.com/issues/4540741)

## Test Plan
1. CI passes
2. Run on laptop
```
$ ueue --states=running,pending --noheader -o '%P|%T|%N|%u'': /bin/bash: squeue: command not found

[INFO] System Name: example-cluster
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: nccl-test
[INFO] Checking if test templates are installed.
[ERROR] Output path '/install_dir' is not writable.
[INFO] Test Scenario: nccl-test

Section Name: Tests.all_reduce
  Test Name: nccl_base_test
  Description: NCCL base test configuration
  No dependencies
Section Name: Tests.all_gather
  Test Name: nccl_test_all_gather
  Description: all_gather
  Start Post Comp: Tests.all_reduce
Section Name: Tests.reduce_scatter
  Test Name: nccl_base_test
  Description: NCCL base test configuration
  Start Post Comp: Tests.all_gather
Section Name: Tests.alltoall
  Test Name: nccl_base_test
  Description: NCCL base test configuration
  Start Post Comp: Tests.reduce_scatter
Section Name: nccl.scatter_perf
  Test Name: nccl-scatter_perf
  Description: scatter_perf
  No dependencies
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.all_reduce
[INFO] Running test: Tests.all_reduce
[ERROR] Error executing command 'scontrol show config': /bin/bash: scontrol: command not found

[WARNING] Error checking GPU support: /bin/bash: scontrol: command not found

[INFO] Submitted slurm job: 0
[INFO] Starting test: nccl.scatter_perf
[INFO] Running test: nccl.scatter_perf
[INFO] Submitted slurm job: 0
[ERROR] Error executing command 'sacct -j 0 -p --noheader -X --format=NodeList': /bin/bash: sacct: command not found

[INFO] Job completed: Tests.all_reduce (iteration 1 of 1)
[INFO] Delayed start for test Tests.all_gather by 5 seconds.
[INFO] Starting test: Tests.all_gather
[INFO] Running test: Tests.all_gather
[INFO] Submitted slurm job: 0
[ERROR] Error executing command 'sacct -j 0 -p --noheader -X --format=NodeList': /bin/bash: sacct: command not found

[INFO] Job completed: nccl.scatter_perf (iteration 1 of 1)
[ERROR] Error executing command 'sacct -j 0 -p --noheader -X --format=NodeList': /bin/bash: sacct: command not found

[INFO] Job completed: Tests.all_gather (iteration 1 of 1)
[INFO] Delayed start for test Tests.reduce_scatter by 5 seconds.
...
```