### PR TITLE
Improve prepare_output_dir error handling for permissions and read-only fs (continued)

### DIFF
--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -200,6 +200,11 @@ class TestPrepareOutputDir:
         assert prepare_output_dir(subdir) is None
         assert f"Output path '{subdir.absolute()}' is not writable." in caplog.text
 
+    def test_invalid_path_no_stacktrace(self, caplog: pytest.LogCaptureFixture):
+        invalid_path = Path("/non/existent/path")
+        assert prepare_output_dir(invalid_path) is None
+        assert "Traceback" not in caplog.text
+
 
 def test_system_installables_are_used(slurm_system: SlurmSystem):
     installer = MyInstaller(slurm_system)


### PR DESCRIPTION
## Summary
Improve prepare_output_dir error handling for permissions and read-only fs (continued)

https://github.com/NVIDIA/cloudai/pull/629
https://github.com/NVIDIA/cloudai/pull/629#discussion_r2262500135

## Test Plan
CI passes