### PR TITLE
Control which env vars dumped for per-rand evaluation

### DIFF
--- a/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/slurm_command_gen_strategy.py
@@ -39,6 +39,8 @@ class NIXLBenchSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def _gen_srun_command(self) -> str:
         with (self.test_run.output_path / "env_vars.sh").open("w") as f:
             for key, value in self.final_env_vars.items():
+                if key == "SLURM_JOB_MASTER_NODE":  # this is an sbatch-level variable, not needed per-node
+                    continue
                 f.write(f"export {key}={value}\n")
 
         etcd_command: list[str] = self.gen_etcd_srun_command()


### PR DESCRIPTION
## Summary
Control which env vars dumped for per-rand evaluation for NIXL bench to avoid confusing warnings.

Fixes [internal bug](https://redmine.mellanox.com/issues/4554504).

## Test Plan
1. CI
2. Runs on EOS, check that `env_vars.sh: line 1: scontrol: command not found` message is gone.

## Additional Notes
—
