### PR TITLE
Align extra_env_vars definition in test and scenario

### DIFF
--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -84,7 +84,7 @@ class TestRunModel(BaseModel):
     description: Optional[str] = None
     test_template_name: Optional[str] = None
     cmd_args: Optional[CmdArgs] = None
-    extra_env_vars: Optional[dict[str, str]] = None
+    extra_env_vars: dict[str, str | list[str]] | None = None
     extra_container_mounts: Optional[list[str]] = None
     git_repos: Optional[list[GitRepo]] = None
     nsys: Optional[NsysConfiguration] = None


### PR DESCRIPTION
## Summary
Align `extra_env_vars` definition in test and scenario to allow sweeps definition in a scenario, for example:
```toml
[[Tests]]
id = "nccl.scatter_perf"
num_nodes = 2
time_limit = "00:20:00"

name = "nccl-scatter_perf"
description = "scatter_perf"
test_template_name = "NcclTest"

  [Tests.cmd_args]
  docker_image_url = "nvcr.io#nvidia/pytorch:25.06-py3"
  subtest_name = "scatter_perf_mpi"

  [Tests.extra_env_vars]
  NCCL_TESTS_SPLIT_MASK = ["0x0", "0x3", "0x7"]
```

## Test Plan
1. CI
2. Manual run for the scenario above.

## Additional Notes
—
