### PR TITLE
Support explicit node assignment for prefill and decode workers

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
@@ -29,7 +29,7 @@ class WorkerBaseArgs(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     num_nodes: Union[int, list[int]] = Field(alias="num-nodes")
-    node_list: Optional[str] = Field(default=None, alias="node-list")
+    nodes: Optional[str] = Field(default=None, alias="nodes")
 
 
 class PrefillWorkerArgs(WorkerBaseArgs):

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -170,8 +170,8 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         td = cast(AIDynamoTestDefinition, self.test_run.test.test_definition)
         prefill_n = td.cmd_args.dynamo.prefill_worker.num_nodes
         decode_n = td.cmd_args.dynamo.decode_worker.num_nodes
-        prefill_nodes = td.cmd_args.dynamo.prefill_worker.node_list
-        decode_nodes = td.cmd_args.dynamo.decode_worker.node_list
+        prefill_nodes = td.cmd_args.dynamo.prefill_worker.nodes
+        decode_nodes = td.cmd_args.dynamo.decode_worker.nodes
 
         assert isinstance(prefill_n, int), "prefill_worker.num_nodes must be an integer"
         assert isinstance(decode_n, int), "decode_worker.num_nodes must be an integer"


### PR DESCRIPTION
## Summary
Support explicit node assignment for prefill and decode workers

[RM4551179](https://redmine.mellanox.com/issues/4551179)

## Test Plan
1. CI passes
2. Run on CW.

**1. Run VLLM with the explicit number of nodes**
```
$ python cloudaix.py run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml   
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 5022977
```
Two nodes are assigned for decode, and one node is assigned for prefill, as expected. This PR does not break the existing node-number-based allocation.

https://drive.google.com/drive/folders/1MlzWa_U4B6umZtGgTcJzLJSUcjkreE11?usp=drive_link

**2. Run VLLM with the explicit node list**

Test Scenario
```
name = "deepseek_r1_distill_llama_8b"

[[Tests]]
...
num_nodes = "3" 
nodes = ["cw-dfw-h100-003-066-026,cw-dfw-h100-003-071-026,cw-dfw-h100-003-078-012"]
...

  [Tests.cmd_args]
    [Tests.cmd_args.dynamo]
...

      [Tests.cmd_args.dynamo.prefill_worker]
...
      nodes = "cw-dfw-h100-003-066-026,cw-dfw-h100-003-071-026"
...

      [Tests.cmd_args.dynamo.decode_worker]
...
      node = "cw-dfw-h100-003-078-012"
...
```
Command
```
$ python cloudaix.py run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml   
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 5025117
```
node_roles.log
```
cw-dfw-h100-003-071-026,prefill
cw-dfw-h100-003-066-026,prefill
cw-dfw-h100-003-078-012,frontend
cw-dfw-h100-003-078-012,decode
```
https://drive.google.com/drive/folders/1novTw81uTGsU9Qru_rmwFElvN4AHwSLd?usp=drive_link