### PR TITLE
Follow-up for PR641 (Support for DeepSeekR1 model with SGLang / AI Dynamo)

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -254,7 +254,7 @@ _patch_section_args() {
 }
 
 _compute_worker_allocation_sglang() {
-  local num_gpus=$(echo "${CUDA_VISIBLE_DEVICES:-}" | tr ',' '\n' | grep -c .)
+  local num_gpus="$(_gpus_per_node)"
   if [[ $num_gpus -eq 0 ]]; then
     log "ERROR: No GPUs found in CUDA_VISIBLE_DEVICES"
     exit 1

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -420,19 +420,11 @@ _total_workers_decode() {
 }
 
 _count_initialized_prefill() {
-  if _is_sglang; then
-    grep -l "Request handler initialized" "${RESULTS_DIR}"/dynamo_*prefill* 2>/dev/null | wc -l
-  else
-    grep -i -l -E "${dynamo_args["prefill-initialized-regex"]}" "${RESULTS_DIR}"/dynamo_*prefill* 2>/dev/null | wc -l
-  fi
+  grep -i -l -E "${dynamo_args["prefill-initialized-regex"]}" "${RESULTS_DIR}"/dynamo_*prefill* 2>/dev/null | wc -l
 }
 
 _count_initialized_decode() {
-  if _is_sglang; then
-    grep -l "Decode request handler initialized" "${RESULTS_DIR}"/dynamo_*decode* 2>/dev/null | wc -l
-  else
-    grep -i -l -E "${dynamo_args["decode-initialized-regex"]}" "${RESULTS_DIR}"/dynamo_*decode* 2>/dev/null | wc -l
-  fi
+  grep -i -l -E "${dynamo_args["decode-initialized-regex"]}" "${RESULTS_DIR}"/dynamo_*decode* 2>/dev/null | wc -l
 }
 
 _expected_ready_prefill() {


### PR DESCRIPTION
## Summary
Follow up for [PR641](https://github.com/NVIDIA/cloudai/pull/641) (Support for DeepSeekR1 model with SGLang / AI Dynamo)

**Resolved by this PR**
1. Use _gpus_per_node ([link](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278015139))
2. prefill-initialized-regex from TOML ([link1](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278015867), [link2](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278016229))
3. Partially resolved - Initializing prefill-cmd ([link](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2277998091))
    * My response
      * It is okay to have an initial value. This does not prevent users from specifying prefill-cmd.
      * Updated the sglang.toml file to set prefill-cmd as we did for vllm.toml (https://github.com/Mellanox/cloudaix/pull/332).

**TODOs in follow-up PRs**
1. Differentiate HF_PATH from MODEL_PATH ([link1](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2277993254), [link2](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2277996028)). Currently, these two concepts are mixed up.
    * Related PR: https://github.com/NVIDIA/cloudai/pull/655
2. Deprecate prefill.num_nodes and decode.num_nodes ([link](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2277999243))
3. Multi-node support for SGLang ([link](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278008177))

**Potentially Rejected**
1. Mounting dynamo_repo_path ([link](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2277990146))
    * My response: There is no strong reason to make this mount optional. I also need dynamo_repo for K8s support. Therefore, it should always be mounted. There is no downside.
2. SGLang-specific container mounts ([link](https://github.com/NVIDIA/cloudai/pull/641#discussion_r2277997134))
    * My response: It is acceptable to use if-else statements to support different backends. There's no strong reason not to have backend-specific container mounts.

**Discussion Needed**
* https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278002812
* https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278004082
* https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278007626

## Test Plan
1. CI passes
2. TODO: Run on EOS

**VLLM LLAMA8b works**
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml 
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 3452142
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] All test scenario results stored at: results/deepseek_r1_distill_llama_8b_2025-08-15_04-27-40
[WARNING] gpus_per_node is None, skipping Overall Output Tokens per Second per GPU calculation.
[INFO] Generated scenario report at results/deepseek_r1_distill_llama_8b_2025-08-15_04-27-40/deepseek_r1_distill_llama_8b.html
[INFO] All jobs are complete.
```
https://drive.google.com/drive/folders/1rWqsnuVswFvpIm6b1oQ79plesauoIqba?usp=drive_link

**SGlang DSR1 works**
Take https://github.com/Mellanox/cloudaix/pull/332
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_ai_DSR1.toml 
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_ai_DeepSeek_R1
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_ai_DeepSeek_R1

Section Name: Tests.1
  Test Name: sglang
  Description: sglang
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 3452004
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] All test scenario results stored at: results/deepseek_ai_DeepSeek_R1_2025-08-15_03-36-48
[WARNING] gpus_per_node is None, skipping Overall Output Tokens per Second per GPU calculation.
[INFO] Generated scenario report at results/deepseek_ai_DeepSeek_R1_2025-08-15_03-36-48/deepseek_ai_DeepSeek_R1.html
[INFO] All jobs are complete.
```
https://drive.google.com/drive/folders/1O3yEUbyYlgsAn_BN-7fJAVmUJvgnWwNu?usp=drive_link