### PR TITLE
Comparison report for NCCL workloads

### DIFF
--- a/src/cloudai/_core/base_reporter.py
+++ b/src/cloudai/_core/base_reporter.py
@@ -22,6 +22,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import toml
+
 from .system import System
 from .test_scenario import TestRun, TestScenario
 
@@ -62,6 +64,10 @@ class Reporter(ABC):
                         tr.current_iteration = int(iter.name)
                         tr.step = int(step.name)
                         tr.output_path = tr_root / f"{tr.current_iteration}" / f"{tr.step}"
+                        tr_file = tr.output_path / "test-run.toml"
+                        if tr_file.exists():
+                            tr_file = toml.load(tr_file)
+                            tr.test.test_definition = tr.test.test_definition.model_validate(tr_file["test_definition"])
                         self.trs.append(copy.deepcopy(tr))
                 else:
                     tr.current_iteration = int(iter.name)

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -170,7 +170,7 @@ def generate_reports(system: System, test_scenario: TestScenario, result_dir: Pa
             reporter.generate()
         except Exception as e:
             logging.warning(f"Error generating report '{name}', see debug log for details")
-            logging.debug(e, stack_info=True)
+            logging.debug(e, exc_info=True)
 
 
 def handle_non_dse_job(runner: Runner, args: argparse.Namespace) -> None:

--- a/src/cloudai/registration.py
+++ b/src/cloudai/registration.py
@@ -61,6 +61,8 @@ def register_all():
         MegatronRunTestDefinition,
     )
     from cloudai.workloads.nccl_test import (
+        NcclComparissonReport,
+        NcclComparissonReportConfig,
         NCCLTestDefinition,
         NcclTestGradingStrategy,
         NcclTestKubernetesJsonGenStrategy,
@@ -68,7 +70,6 @@ def register_all():
         NcclTestRunAIJsonGenStrategy,
         NcclTestSlurmCommandGenStrategy,
     )
-    from cloudai.workloads.nccl_test.nccl_comparisson_report import NcclComparissonReport
     from cloudai.workloads.nemo_launcher import (
         NeMoLauncherGradingStrategy,
         NeMoLauncherReportGenerationStrategy,
@@ -207,7 +208,7 @@ def register_all():
     Registry().add_scenario_report("status", StatusReporter, ReportConfig(enable=True))
     Registry().add_scenario_report("tarball", TarballReporter, ReportConfig(enable=True))
     Registry().add_scenario_report("nixl_bench_summary", NIXLBenchSummaryReport, ReportConfig(enable=True))
-    Registry().add_scenario_report("nccl_comparisson", NcclComparissonReport, ReportConfig(enable=True))
+    Registry().add_scenario_report("nccl_comparisson", NcclComparissonReport, NcclComparissonReportConfig(enable=True))
 
     Registry().add_reward_function("inverse", inverse_reward)
     Registry().add_reward_function("negative", negative_reward)

--- a/src/cloudai/registration.py
+++ b/src/cloudai/registration.py
@@ -68,6 +68,7 @@ def register_all():
         NcclTestRunAIJsonGenStrategy,
         NcclTestSlurmCommandGenStrategy,
     )
+    from cloudai.workloads.nccl_test.nccl_comparisson_report import NcclComparissonReport
     from cloudai.workloads.nemo_launcher import (
         NeMoLauncherGradingStrategy,
         NeMoLauncherReportGenerationStrategy,
@@ -206,6 +207,7 @@ def register_all():
     Registry().add_scenario_report("status", StatusReporter, ReportConfig(enable=True))
     Registry().add_scenario_report("tarball", TarballReporter, ReportConfig(enable=True))
     Registry().add_scenario_report("nixl_bench_summary", NIXLBenchSummaryReport, ReportConfig(enable=True))
+    Registry().add_scenario_report("nccl_comparisson", NcclComparissonReport, ReportConfig(enable=True))
 
     Registry().add_reward_function("inverse", inverse_reward)
     Registry().add_reward_function("negative", negative_reward)

--- a/src/cloudai/report_generator/groups.py
+++ b/src/cloudai/report_generator/groups.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from cloudai.core import TestDefinition, TestRun
+
+from .util import diff_test_runs
+
+
+@dataclass
+class TRGroupItem:
+    """Item in a group of TestRuns."""
+
+    name: str
+    tr: TestRun
+
+
+@dataclass
+class GroupedTestRuns:
+    """Group of TestRuns."""
+
+    name: str
+    items: list[TRGroupItem]
+
+
+@dataclass
+class TestRunsGrouper:
+    """Group TestRuns based on cmd_args or/and extra_env_vars."""
+
+    __test__ = False
+
+    trs: list[TestRun]
+    group_by: list[str]
+
+    def get_value(self, tdef: TestDefinition, field: str) -> str:
+        """Get field value for cmd_args or extra_env_vars."""
+        if field.startswith("extra_env_vars."):
+            f_name = field[len("extra_env_vars.") :]
+            v = str(tdef.extra_env_vars.get(f_name))
+        else:
+            v = getattr(tdef.cmd_args, field)
+        return v
+
+    def group_name(self, trs: list[TestRun]) -> str:
+        """
+        Get group name for a list of TestRuns.
+
+        Assume all test runs are grouped by the group_by fields, so take all the values from the first test run.
+        """
+        if not self.group_by:
+            return "all-in-one"
+        parts = [f"{field}={self.get_value(trs[0].test.test_definition, field)}" for field in self.group_by]
+        return " ".join(parts).replace("extra_env_vars.", "")
+
+    def create_group(self, trs: list[TestRun], group_idx: str = "0") -> GroupedTestRuns:
+        diff = diff_test_runs(trs)
+        items: list[TRGroupItem] = []
+        for idx, _ in enumerate(trs):
+            name = f"{group_idx}.{idx}"
+            if diff:
+                item_name_parts = [f"{field}={vals[idx]}" for field, vals in diff.items()]
+                name = " ".join(item_name_parts).replace("extra_env_vars.", "")
+            items.append(TRGroupItem(name=name, tr=trs[idx]))
+        return GroupedTestRuns(name=self.group_name(trs), items=items)
+
+    def groups(self) -> list[GroupedTestRuns]:
+        if not self.group_by:
+            return [self.create_group(self.trs)]
+
+        groups: list[list[TestRun]] = []
+        for tr in self.trs:
+            for group in groups:
+                matched = all(
+                    self.get_value(tr.test.test_definition, field)
+                    == self.get_value(group[0].test.test_definition, field)
+                    for field in self.group_by
+                )
+
+                if matched:
+                    group.append(tr)
+                    break
+            else:  # runs only if no break happened
+                groups.append([tr])
+
+        res: list[GroupedTestRuns] = []
+        for grp_idx, group in enumerate(groups):
+            res.append(self.create_group(group, group_idx=str(grp_idx)))
+        return res

--- a/src/cloudai/workloads/nccl_test/__init__.py
+++ b/src/cloudai/workloads/nccl_test/__init__.py
@@ -17,7 +17,7 @@
 from .grading_strategy import NcclTestGradingStrategy
 from .kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
 from .nccl import NCCLCmdArgs, NCCLTestDefinition
-from .nccl_comparisson_report import NcclComparissonReport
+from .nccl_comparisson_report import NcclComparissonReport, NcclComparissonReportConfig
 from .performance_report_generation_strategy import NcclTestPerformanceReportGenerationStrategy
 from .prediction_report_generation_strategy import NcclTestPredictionReportGenerationStrategy
 from .runai_json_gen_strategy import NcclTestRunAIJsonGenStrategy
@@ -27,6 +27,7 @@ __all__ = [
     "NCCLCmdArgs",
     "NCCLTestDefinition",
     "NcclComparissonReport",
+    "NcclComparissonReportConfig",
     "NcclTestGradingStrategy",
     "NcclTestKubernetesJsonGenStrategy",
     "NcclTestPerformanceReportGenerationStrategy",

--- a/src/cloudai/workloads/nccl_test/__init__.py
+++ b/src/cloudai/workloads/nccl_test/__init__.py
@@ -17,6 +17,7 @@
 from .grading_strategy import NcclTestGradingStrategy
 from .kubernetes_json_gen_strategy import NcclTestKubernetesJsonGenStrategy
 from .nccl import NCCLCmdArgs, NCCLTestDefinition
+from .nccl_comparisson_report import NcclComparissonReport
 from .performance_report_generation_strategy import NcclTestPerformanceReportGenerationStrategy
 from .prediction_report_generation_strategy import NcclTestPredictionReportGenerationStrategy
 from .runai_json_gen_strategy import NcclTestRunAIJsonGenStrategy
@@ -25,6 +26,7 @@ from .slurm_command_gen_strategy import NcclTestSlurmCommandGenStrategy
 __all__ = [
     "NCCLCmdArgs",
     "NCCLTestDefinition",
+    "NcclComparissonReport",
     "NcclTestGradingStrategy",
     "NcclTestKubernetesJsonGenStrategy",
     "NcclTestPerformanceReportGenerationStrategy",

--- a/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
+++ b/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from itertools import cycle
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable
+
+import jinja2
+import toml
+from rich.console import Console
+from rich.table import Table
+
+from cloudai.core import Reporter, System, TestRun, TestScenario
+from cloudai.models.scenario import ReportConfig
+from cloudai.models.workload import TestDefinition
+from cloudai.report_generator.util import add_human_readable_sizes
+from cloudai.util.lazy_imports import lazy
+
+from .nccl import NCCLTestDefinition
+from .performance_report_generation_strategy import extract_nccl_data
+
+if TYPE_CHECKING:
+    import bokeh.plotting as bk
+    import pandas as pd
+
+
+@dataclass
+class GroupItem:
+    name: str
+    tr: TestRun
+
+
+@dataclass
+class GroupedfResult:
+    name: str
+    items: list[GroupItem]
+
+
+def diff_trs(trs: list[TestRun]) -> dict[str, list[str]]:
+    """Acts like .action_space for a DSE TestRun, but for a list of TestRuns."""
+    dicts: list[dict] = []
+    for tr in trs:
+        dicts.append(
+            {
+                "NUM_NODES": tr.num_nodes,
+                **tr.test.test_definition.cmd_args.model_dump(),
+                **{f"extra_env_vars.{k}": v for k, v in tr.test.test_definition.extra_env_vars.items()},
+            }
+        )
+    all_keys = set().union(*[d.keys() for d in dicts])
+
+    diff = {}
+    for key in all_keys:
+        all_values = [d[key] for d in dicts]
+        if len(set(all_values)) > 1:
+            diff[key] = all_values
+
+    return diff
+
+
+def group_for_comparison(trs: list[TestRun], group_by: list[str]) -> list[GroupedfResult]:
+    def _grp_name() -> str:
+        if not group_by:
+            return "all-in-one"
+        parts = [f"{field}={_get_value(tr.test.test_definition, field)}" for field in group_by]
+        return " ".join(parts).replace("extra_env_vars.", "")
+
+    if len(trs) == 1 or not group_by:
+        items: list[GroupItem] = []
+        diff = diff_trs(trs)
+        for idx, _ in enumerate(trs):
+            item_name_parts = [f"{field}={vals[idx]}" for field, vals in diff.items()]
+            name = " ".join(item_name_parts).replace("extra_env_vars.", "")
+            if not diff:
+                name = f"{idx}"
+            items.append(GroupItem(name=name, tr=trs[idx]))
+        return [GroupedfResult(name=_grp_name(), items=items)]
+
+    def _get_value(tdef: TestDefinition, field: str) -> str:
+        if field.startswith("extra_env_vars."):
+            f_name = field[len("extra_env_vars.") :]
+            v = str(tdef.extra_env_vars.get(f_name))
+        else:
+            v = getattr(tdef.cmd_args, field)
+
+        return v
+
+    groups: list[list[TestRun]] = []
+    for tr in trs:
+        for group in groups:
+            matched = all(
+                _get_value(tr.test.test_definition, field) == _get_value(group[0].test.test_definition, field)
+                for field in group_by
+            )
+
+            if matched:
+                group.append(tr)
+                break
+        else:  # runs only if no break happened
+            groups.append([tr])
+
+    res: list[GroupedfResult] = []
+    for grp_idx, group in enumerate(groups):
+        items: list[GroupItem] = []
+        diff = diff_trs(group)
+        for idx, tr in enumerate(group):
+            item_name_parts = [f"{field}={vals[idx]}" for field, vals in diff.items()]
+            name = " ".join(item_name_parts).replace("extra_env_vars.", "")
+            if not diff:
+                name = f"{grp_idx}"
+            items.append(GroupItem(name=name, tr=tr))
+        res.append(GroupedfResult(name=_grp_name(), items=items))
+    return res
+
+
+class NcclComparissonReport(Reporter):
+    """Comparisson report for NCCL Test."""
+
+    INFO_COLUMNS = ("Size (B)", "Count", "Type", "Redop")
+    LATENCY_DATA_COLUMNS = ("Time (us) Out-of-place", "Time (us) In-place")
+    BANDWIDTH_DATA_COLUMNS = ("Busbw (GB/s) Out-of-place", "Busbw (GB/s) In-place")
+
+    def __init__(self, system: System, test_scenario: TestScenario, results_root: Path, config: ReportConfig) -> None:
+        super().__init__(system, test_scenario, results_root, config)
+        self.group_by: list[str] = [
+            # "extra_env_vars.NCCL_TESTS_SPLIT_MASK",
+            "subtest_name",
+        ]
+
+    def generate(self) -> None:
+        self.load_test_runs()
+        if not self.trs:
+            logging.debug(f"No NCCL results found, skipping {self.__class__.__name__} report generation.")
+            return
+
+        console = Console(record=True)
+        cmp_groups = group_for_comparison(self.trs, self.group_by)
+
+        for group in cmp_groups:
+            table = self.create_table(
+                group, title="Latecy", info_columns=self.INFO_COLUMNS, data_columns=self.LATENCY_DATA_COLUMNS
+            )
+            console.print(table)
+            console.print()
+
+            table = self.create_table(
+                group, title="Bandwidth", info_columns=self.INFO_COLUMNS, data_columns=self.BANDWIDTH_DATA_COLUMNS
+            )
+            console.print(table)
+            console.print()
+
+        bokeh_script, bokeh_div = self.get_bokeh_html()
+
+        template = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(Path(__file__).parent.parent.parent / "util")
+        ).get_template("nixl_report_template.jinja2")
+        html_content = template.render(
+            title=f"{self.test_scenario.name} NCCL Bench Report",
+            bokeh_script=bokeh_script,
+            bokeh_div=bokeh_div,
+            rich_html=console.export_html(),
+        )
+
+        html_file = self.results_root / "nccl_comparisson.html"
+        with open(html_file, "w") as f:
+            f.write(html_content)
+
+        logging.info(f"NCCL comparisson report created: {html_file}")
+
+    def create_table(
+        self, group: GroupedfResult, title: str, info_columns: Iterable[str], data_columns: Iterable[str]
+    ) -> Table:
+        dfs = [self._extract_data(item.tr) for item in group.items]
+
+        style_cycle = cycle(["green", "cyan", "magenta", "blue", "yellow"])
+
+        table = Table(title=f"{title}: {group.name}", title_justify="left", expand=True)
+        for col in info_columns:
+            table.add_column(col)
+        for item in group.items:
+            style = next(style_cycle)
+            for col in data_columns:
+                table.add_column(f"{item.name}\n{col}", overflow="fold", style=style, header_style=style)
+
+        for row_idx in range(len(dfs[0][info_columns[0]])):
+            data = []
+            for df in dfs:
+                data.extend([str(df[col][row_idx]) for col in data_columns])
+
+            table.add_row(*[str(dfs[0][col][row_idx]) for col in info_columns], *data)
+
+        return table
+
+    def _extract_data(self, tr: TestRun) -> pd.DataFrame:
+        parsed_data_rows, gpu_type, num_devices_per_node, num_ranks = extract_nccl_data(tr.output_path / "stdout.txt")
+        if not parsed_data_rows:
+            return lazy.pd.DataFrame()
+
+        df: pd.DataFrame = lazy.pd.DataFrame(
+            parsed_data_rows,
+            columns=[
+                "Size (B)",
+                "Count",
+                "Type",
+                "Redop",
+                "Root",
+                "Time (us) Out-of-place",
+                "Algbw (GB/s) Out-of-place",
+                "Busbw (GB/s) Out-of-place",
+                "#Wrong Out-of-place",
+                "Time (us) In-place",
+                "Algbw (GB/s) In-place",
+                "Busbw (GB/s) In-place",
+                "#Wrong In-place",
+            ],
+        )
+
+        df["GPU Type"] = gpu_type
+        df["Devices per Node"] = num_devices_per_node
+        df["Ranks"] = num_ranks
+
+        df["Size (B)"] = df["Size (B)"].astype(int)
+        df["Time (us) Out-of-place"] = df["Time (us) Out-of-place"].astype(float).round(2)
+        df["Time (us) In-place"] = df["Time (us) In-place"].astype(float).round(2)
+        df["Algbw (GB/s) Out-of-place"] = df["Algbw (GB/s) Out-of-place"].astype(float)
+        df["Busbw (GB/s) Out-of-place"] = df["Busbw (GB/s) Out-of-place"].astype(float)
+        df["Algbw (GB/s) In-place"] = df["Algbw (GB/s) In-place"].astype(float)
+        df["Busbw (GB/s) In-place"] = df["Busbw (GB/s) In-place"].astype(float)
+
+        df = add_human_readable_sizes(df, "Size (B)", "Size Human-readable")
+
+        return df
+
+    def get_bokeh_html(self) -> tuple[str, str]:
+        cmp_groups = group_for_comparison(self.trs, self.group_by)
+        charts: list[bk.figure] = []
+        for group in cmp_groups:
+            if chart := self.create_chart(group, "Latecy", self.INFO_COLUMNS, self.LATENCY_DATA_COLUMNS, "Time (us)"):
+                charts.append(chart)
+            if chart := self.create_chart(
+                group, "Bandwidth", self.INFO_COLUMNS, self.BANDWIDTH_DATA_COLUMNS, "Busbw (GB/s)"
+            ):
+                charts.append(chart)
+
+        # layout with 2 charts per row
+        rows = []
+        for i in range(0, len(charts), 2):
+            if i + 1 < len(charts):
+                rows.append(lazy.bokeh_layouts.row(charts[i], charts[i + 1]))
+            else:
+                rows.append(lazy.bokeh_layouts.row(charts[i]))
+        layout = lazy.bokeh_layouts.column(*rows, name="charts_layout")
+
+        bokeh_script, bokeh_div = lazy.bokeh_embed.components(layout)
+        return bokeh_script, bokeh_div
+
+    def create_chart(
+        self,
+        group: GroupedfResult,
+        title: str,
+        info_columns: Iterable[str],
+        data_columns: Iterable[str],
+        y_axis_label: str,
+    ) -> bk.figure | None:
+        dfs = [self._extract_data(item.tr) for item in group.items]
+
+        style_cycle = cycle(["green", "cyan", "magenta", "blue", "yellow"])
+
+        p = lazy.bokeh_plotting.figure(
+            title=f"{title}: {group.name}",
+            x_axis_label=info_columns[0],
+            y_axis_label=y_axis_label,
+            width=800,
+            height=500,
+            tools="pan,box_zoom,wheel_zoom,reset,save",
+            active_drag="pan",
+            active_scroll="wheel_zoom",
+            x_axis_type="log",
+        )
+
+        hover = lazy.bokeh_models.HoverTool(tooltips=[("X", "@x"), ("Y", "@y"), ("Segment Type", "@segment_type")])
+        p.add_tools(hover)
+
+        for df, name in zip(dfs, [item.name for item in group.items], strict=True):
+            for col in data_columns:
+                source = lazy.bokeh_models.ColumnDataSource(
+                    data={
+                        "x": df[info_columns[0]].tolist(),
+                        "y": df[col].tolist(),
+                        "segment_type": [col] * len(df),
+                    }
+                )
+
+                color = next(style_cycle)
+                p.line("x", "y", source=source, line_color=color, line_width=2, legend_label=f"{name} {col}")
+                p.scatter("x", "y", source=source, fill_color=color, size=8, legend_label=f"{name} {col}")
+
+        p.legend.location = "top_left"
+        p.legend.click_policy = "hide"
+
+        y_max = max(df[col].max() for df in dfs for col in data_columns)
+        y_min = min(df[col].min() for df in dfs for col in data_columns)
+        p.y_range = lazy.bokeh_models.Range1d(start=y_min * -1 * y_max * 0.01, end=y_max * 1.1)
+
+        return p

--- a/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
+++ b/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import jinja2
+from pydantic import Field
 from rich.console import Console
 from rich.table import Table
 
@@ -42,6 +43,12 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
+class NcclComparissonReportConfig(ReportConfig):
+    """Configuration for NCCL comparisson report."""
+
+    group_by: list[str] = Field(default_factory=lambda: ["subtest_name"])
+
+
 class NcclComparissonReport(Reporter):
     """Comparisson report for NCCL Test."""
 
@@ -49,12 +56,11 @@ class NcclComparissonReport(Reporter):
     LATENCY_DATA_COLUMNS = ("Time (us) Out-of-place", "Time (us) In-place")
     BANDWIDTH_DATA_COLUMNS = ("Busbw (GB/s) Out-of-place", "Busbw (GB/s) In-place")
 
-    def __init__(self, system: System, test_scenario: TestScenario, results_root: Path, config: ReportConfig) -> None:
+    def __init__(
+        self, system: System, test_scenario: TestScenario, results_root: Path, config: NcclComparissonReportConfig
+    ) -> None:
         super().__init__(system, test_scenario, results_root, config)
-        self.group_by: list[str] = [
-            # "extra_env_vars.NCCL_TESTS_SPLIT_MASK",
-            "subtest_name",
-        ]
+        self.group_by: list[str] = config.group_by
 
     def generate(self) -> None:
         self.load_test_runs()

--- a/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
+++ b/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
@@ -35,6 +35,7 @@ from cloudai.report_generator.util import (
     calculate_power_of_two_ticks,
 )
 from cloudai.util.lazy_imports import lazy
+from cloudai.workloads.nccl_test.nccl import NCCLTestDefinition
 
 from .performance_report_generation_strategy import extract_nccl_data
 
@@ -64,6 +65,7 @@ class NcclComparissonReport(Reporter):
 
     def generate(self) -> None:
         self.load_test_runs()
+        self.trs = [tr for tr in self.trs if isinstance(tr.test.test_definition, NCCLTestDefinition)]
         if not self.trs:
             logging.debug(f"No NCCL results found, skipping {self.__class__.__name__} report generation.")
             return

--- a/tests/report_generation_strategy/conftest.py
+++ b/tests/report_generation_strategy/conftest.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from cloudai import Test, TestRun
+from cloudai.workloads.nccl_test import NCCLCmdArgs, NCCLTestDefinition
+
+
+@pytest.fixture
+def nccl_tr(tmp_path: Path) -> TestRun:
+    test = Test(
+        test_definition=NCCLTestDefinition(
+            name="nccl",
+            description="desc",
+            test_template_name="t",
+            cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+        ),
+        test_template=Mock(),
+    )
+    tr = TestRun(name="nccl_test", test=test, num_nodes=2, nodes=[], output_path=tmp_path)
+
+    stdout_content = """# Rank  0 Group  0 Pid 1000 on node1 device  0 [0xaa] NVIDIA H100
+# Rank  1 Group  0 Pid 1001 on node1 device  1 [0xbb] NVIDIA H100
+# Rank  2 Group  0 Pid 1002 on node1 device  2 [0xcc] NVIDIA H100
+# Rank  3 Group  0 Pid 1003 on node1 device  3 [0xdd] NVIDIA H100
+# Rank  4 Group  0 Pid 1004 on node1 device  4 [0xee] NVIDIA H100
+# Rank  5 Group  0 Pid 1005 on node1 device  5 [0xff] NVIDIA H100
+# Rank  6 Group  0 Pid 1006 on node1 device  6 [0x11] NVIDIA H100
+# Rank  7 Group  0 Pid 1007 on node1 device  7 [0x22] NVIDIA H100
+# Rank  8 Group  0 Pid 2000 on node2 device  0 [0xaa] NVIDIA H100
+# Rank  9 Group  0 Pid 2001 on node2 device  1 [0xbb] NVIDIA H100
+# Rank 10 Group  0 Pid 2002 on node2 device  2 [0xcc] NVIDIA H100
+# Rank 11 Group  0 Pid 2003 on node2 device  3 [0xdd] NVIDIA H100
+# Rank 12 Group  0 Pid 2004 on node2 device  4 [0xee] NVIDIA H100
+# Rank 13 Group  0 Pid 2005 on node2 device  5 [0xff] NVIDIA H100
+# Rank 14 Group  0 Pid 2006 on node2 device  6 [0x11] NVIDIA H100
+# Rank 15 Group  0 Pid 2007 on node2 device  7 [0x22] NVIDIA H100
+#
+#                                                              out-of-place                       in-place
+#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
+     1000000       1000000     float     sum      -1    1.11   10.10   20.20      0    1.12   10.11   20.21      0
+     2000000       2000000     float     sum      -1    2.22   20.20   30.30      0    2.23   20.21   30.31      0
+     12000000      12000000     float     sum      -1   13.13  120.30  130.40      0   13.14  120.31  130.41      0
+# Avg bus bandwidth    : 111.111
+"""
+    (tr.output_path / "stdout.txt").write_text(stdout_content)
+
+    return tr

--- a/tests/report_generation_strategy/test_report_groups.py
+++ b/tests/report_generation_strategy/test_report_groups.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+import pandas as pd
+
+from cloudai import TestRun
+from cloudai.report_generator.groups import TestRunsGrouper
+from cloudai.report_generator.util import diff_test_runs
+
+
+class TestGrouping:
+    def _mock_extract_data(self, tr: TestRun) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    def test_single_tr(self, nccl_tr: TestRun) -> None:
+        groups = TestRunsGrouper(trs=[nccl_tr], group_by=[]).groups()
+        assert len(groups) == 1
+        assert groups[0].name == "all-in-one"
+        assert groups[0].items[0].name == "0.0"
+
+    def test_multiple_trs_no_group_by_fields_same_trs(self, nccl_tr: TestRun) -> None:
+        groups = TestRunsGrouper(trs=[nccl_tr, nccl_tr], group_by=[]).groups()
+        assert len(groups) == 1
+        assert groups[0].name == "all-in-one"
+        assert groups[0].items[0].name == "0.0"
+        assert groups[0].items[1].name == "0.1"
+
+    def test_multiple_trs_no_group_by_fields(self, nccl_tr: TestRun) -> None:
+        nccl1 = copy.deepcopy(nccl_tr)
+        nccl2 = copy.deepcopy(nccl_tr)
+        nccl1.test.test_definition.cmd_args.subtest_name = "all_gather_perf"
+        nccl2.test.test_definition.cmd_args.subtest_name = "all_reduce_perf"
+        groups = TestRunsGrouper(trs=[nccl1, nccl2], group_by=[]).groups()
+        assert len(groups) == 1
+        assert groups[0].name == "all-in-one"
+        assert groups[0].items[0].name == "subtest_name=all_gather_perf"
+        assert groups[0].items[1].name == "subtest_name=all_reduce_perf"
+
+    def test_group_by_one_field(self, nccl_tr: TestRun) -> None:
+        nccl1 = copy.deepcopy(nccl_tr)
+        nccl2 = copy.deepcopy(nccl_tr)
+        nccl1.test.test_definition.cmd_args.subtest_name = "all_gather_perf"
+        nccl2.test.test_definition.cmd_args.subtest_name = "all_reduce_perf"
+
+        groups = TestRunsGrouper(trs=[nccl1, nccl2], group_by=["subtest_name"]).groups()
+
+        assert len(groups) == 2
+        assert groups[0].name == "subtest_name=all_gather_perf"
+        assert groups[1].name == "subtest_name=all_reduce_perf"
+        assert groups[0].items[0].name == "0.0"
+        assert groups[1].items[0].name == "1.0"
+
+    def test_group_by_two_fields(self, nccl_tr: TestRun) -> None:
+        nccl_tr.test.test_definition.cmd_args.subtest_name = ["all_gather_perf", "all_reduce_perf"]
+        nccl_tr.test.test_definition.extra_env_vars["NCCL_IB_SPLIT_DATA_ON_QPS"] = ["0", "1"]
+        trs: list[TestRun] = [nccl_tr.apply_params_set(combination) for combination in nccl_tr.all_combinations]
+
+        groups = TestRunsGrouper(
+            trs=trs,
+            group_by=["subtest_name", "extra_env_vars.NCCL_IB_SPLIT_DATA_ON_QPS"],
+        ).groups()
+
+        assert len(groups) == 4
+        assert all(len(group.items) == 1 for group in groups)
+        assert groups[0].name == "subtest_name=all_gather_perf NCCL_IB_SPLIT_DATA_ON_QPS=0"
+        assert groups[1].name == "subtest_name=all_gather_perf NCCL_IB_SPLIT_DATA_ON_QPS=1"
+        assert groups[2].name == "subtest_name=all_reduce_perf NCCL_IB_SPLIT_DATA_ON_QPS=0"
+        assert groups[3].name == "subtest_name=all_reduce_perf NCCL_IB_SPLIT_DATA_ON_QPS=1"
+
+    def test_multiple_trs_in_a_group(self, nccl_tr: TestRun) -> None:
+        nccl_tr.test.test_definition.cmd_args.subtest_name = ["all_gather_perf", "all_reduce_perf"]
+        nccl_tr.test.test_definition.extra_env_vars["NCCL_IB_SPLIT_DATA_ON_QPS"] = ["0", "1"]
+        trs: list[TestRun] = [nccl_tr.apply_params_set(combination) for combination in nccl_tr.all_combinations]
+
+        groups = TestRunsGrouper(trs=trs, group_by=["subtest_name"]).groups()
+
+        assert len(groups) == 2
+
+        assert groups[0].name == "subtest_name=all_gather_perf"
+        assert len(groups[0].items) == 2
+        assert groups[0].items[0].name == "NCCL_IB_SPLIT_DATA_ON_QPS=0"
+        assert groups[0].items[1].name == "NCCL_IB_SPLIT_DATA_ON_QPS=1"
+
+        assert groups[1].name == "subtest_name=all_reduce_perf"
+        assert len(groups[1].items) == 2
+        assert groups[1].items[0].name == "NCCL_IB_SPLIT_DATA_ON_QPS=0"
+        assert groups[1].items[1].name == "NCCL_IB_SPLIT_DATA_ON_QPS=1"
+
+
+class TestDiffTrs:
+    def test_diff_cmd_args_field(self, nccl_tr: TestRun) -> None:
+        nccl1 = copy.deepcopy(nccl_tr)
+        nccl2 = copy.deepcopy(nccl_tr)
+        nccl1.test.test_definition.cmd_args.subtest_name = "all_gather_perf"
+        nccl2.test.test_definition.cmd_args.subtest_name = "all_reduce_perf"
+
+        diff = diff_test_runs([nccl1, nccl2])
+
+        assert diff == {"subtest_name": ["all_gather_perf", "all_reduce_perf"]}
+
+    def test_diff_num_nodes(self, nccl_tr: TestRun) -> None:
+        nccl1 = copy.deepcopy(nccl_tr)
+        nccl2 = copy.deepcopy(nccl_tr)
+        nccl1.num_nodes = 1
+        nccl2.num_nodes = 2
+
+        diff = diff_test_runs([nccl1, nccl2])
+        assert diff == {"NUM_NODES": [1, 2]}
+
+    def test_diff_extra_env_vars(self, nccl_tr: TestRun) -> None:
+        nccl1 = copy.deepcopy(nccl_tr)
+        nccl2 = copy.deepcopy(nccl_tr)
+        nccl1.test.test_definition.extra_env_vars["NCCL_IB_SPLIT_DATA_ON_QPS"] = "0"
+        nccl2.test.test_definition.extra_env_vars["NCCL_IB_SPLIT_DATA_ON_QPS"] = "1"
+
+        diff = diff_test_runs([nccl1, nccl2])
+        assert diff == {"extra_env_vars.NCCL_IB_SPLIT_DATA_ON_QPS": ["0", "1"]}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,6 +41,7 @@ from cloudai.workloads.jax_toolbox import (
 )
 from cloudai.workloads.megatron_run import MegatronRunSlurmCommandGenStrategy, MegatronRunTestDefinition
 from cloudai.workloads.nccl_test import (
+    NcclComparissonReport,
     NCCLTestDefinition,
     NcclTestGradingStrategy,
     NcclTestKubernetesJsonGenStrategy,
@@ -203,12 +204,18 @@ def test_definitions():
 
 def test_scenario_reports():
     scenario_reports = Registry().scenario_reports
-    assert list(scenario_reports.keys()) == ["per_test", "status", "tarball", "nixl_bench_summary"]
-    assert list(scenario_reports.values()) == [PerTestReporter, StatusReporter, TarballReporter, NIXLBenchSummaryReport]
+    assert list(scenario_reports.keys()) == ["per_test", "status", "tarball", "nixl_bench_summary", "nccl_comparisson"]
+    assert list(scenario_reports.values()) == [
+        PerTestReporter,
+        StatusReporter,
+        TarballReporter,
+        NIXLBenchSummaryReport,
+        NcclComparissonReport,
+    ]
 
 
 def test_report_configs():
     configs = Registry().report_configs
-    assert list(configs.keys()) == ["per_test", "status", "tarball", "nixl_bench_summary"]
+    assert list(configs.keys()) == ["per_test", "status", "tarball", "nixl_bench_summary", "nccl_comparisson"]
     for name, rep_config in configs.items():
         assert rep_config.enable is True, f"Report {name} is not enabled by default"


### PR DESCRIPTION
## Summary
Add new report `NcclComparissonReport` that creates comparison charts and tables for NCCL workloads from the same test scenario.

## Test Plan
1. CI (extended)
2. Manual runs on a bunch of NCCL results.

Example charts:
<img width="1622" height="513" alt="image" src="https://github.com/user-attachments/assets/e0684d07-ba3a-4e9f-b1c1-e2f1aca8e7ff" />

Table:
<img width="1679" height="877" alt="image" src="https://github.com/user-attachments/assets/2cd53210-9dd0-4570-b23f-cde501bfe8c0" />


## Additional Notes
Reports are grouped based on `group_by` configuration that defaults to `subtest_name` to split by a benchmark. Grouping can be done based on any `cmd_args` or `extra_env_vars` fields, multiple fields are supported. `group_by` list can be empty, in this case all results will be put into a single chart (per metrics, e.g. one for Latency, one for BW) and table.

Right now configuration is possible only via System TOML. This is initial support for such types of reports, this work is in progress and changes will be made.