### PR TITLE
Refactor GPU count to use _gpus_per_node in vllm and env validation

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -277,7 +277,7 @@ _compute_worker_allocation_sglang() {
 _compute_worker_allocation_vllm() {
   local tp_arg_name="--${dynamo_args["tp-arg-name"]}"
   local pp_arg_name="--${dynamo_args["pp-arg-name"]}"
-  local num_gpus=$(echo "${CUDA_VISIBLE_DEVICES:-}" | tr ',' '\n' | grep -c .)
+  local num_gpus="$(_gpus_per_node)"
 
   if [[ $num_gpus -eq 0 ]]; then
     log "ERROR: No GPUs found in CUDA_VISIBLE_DEVICES"
@@ -569,8 +569,7 @@ validate_environment() {
   fi
 
   # GPU count sanity
-  local num_gpus
-  num_gpus=$(echo "${CUDA_VISIBLE_DEVICES}" | tr ',' '\n' | grep -c . || true)
+  local num_gpus="$(_gpus_per_node)"
   if [[ "$num_gpus" -le 0 ]]; then
     log "ERROR: Parsed zero GPUs from CUDA_VISIBLE_DEVICES='${CUDA_VISIBLE_DEVICES}'"
     exit 1


### PR DESCRIPTION
## Summary
Refactor GPU count to use _gpus_per_node in vllm and env validation

Follow-up PR for https://github.com/NVIDIA/cloudai/pull/653
Comment https://github.com/NVIDIA/cloudai/pull/653#discussion_r2279537492

## Test Plan
1. CI passes
2. Run on EOS

**VLLM**
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml 

[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 3453750
[INFO] Job completed: Tests.1 (iteration 1 of 1)
```
https://drive.google.com/drive/folders/1To8hLD7h9aGyVvEboXV3Qm44TGgEo6Ko?usp=drive_link