### PR TITLE
Refactor nodelist validation to check DYNAMO_NODELIST only if both args empty

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
@@ -65,7 +65,6 @@ class AIDynamoCmdArgs(CmdArgs):
     docker_image_url: str
     huggingface_home_host_path: Path = Path.home() / ".cache/huggingface"
     huggingface_home_container_path: Path = Path("/root/.cache/huggingface")
-    hf_model_path: Optional[Path] = None
     dynamo: AIDynamoArgs
     genai_perf: GenAIPerfArgs
     run_script: str = ""

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
@@ -65,6 +65,7 @@ class AIDynamoCmdArgs(CmdArgs):
     docker_image_url: str
     huggingface_home_host_path: Path = Path.home() / ".cache/huggingface"
     huggingface_home_container_path: Path = Path("/root/.cache/huggingface")
+    hf_model_path: Optional[Path] = None
     dynamo: AIDynamoArgs
     genai_perf: GenAIPerfArgs
     run_script: str = ""

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -127,8 +127,8 @@ _apply_sglang_section_args() {
   decode_args["--served-model-name"]=${dynamo_args["model"]}
 
   # model-path must point to HF cache for sglang
-  prefill_args["--model-path"]="${HUGGINGFACE_HOME}"
-  decode_args["--model-path"]="${HUGGINGFACE_HOME}"
+  prefill_args["--model-path"]="${MODEL_PATH}"
+  decode_args["--model-path"]="${MODEL_PATH}"
 
   local self="$(_current_node_name)"
   local gpn="$(_gpus_per_node)"
@@ -191,6 +191,8 @@ _parse_cli_pairs() {
         genai_perf_args["--${key#--genai-perf-}"]="$2" ;;
       --huggingface-home)
         HUGGINGFACE_HOME="$2" ;;
+      --model-path)
+        MODEL_PATH="$2" ;;
       --results-dir)
         RESULTS_DIR="$2" ;;
     esac
@@ -445,9 +447,7 @@ _is_prefill_node() {
 }
 
 _init_runtime_env() {
-  if _is_vllm; then
-    export HF_HOME="${HUGGINGFACE_HOME}"
-  fi
+  export HF_HOME="${HUGGINGFACE_HOME}"
   export NATS_SERVER="nats://${dynamo_args["frontend-node"]}:${dynamo_args["nats-port"]}"
   export ETCD_ENDPOINTS="http://${dynamo_args["frontend-node"]}:${dynamo_args["etcd-port"]}"
   export UCX_LOG_FILE="${RESULTS_DIR}/ucx_log_%h.log"

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -532,10 +532,12 @@ validate_environment() {
     exit 1
   fi
 
-  # If both nodelists are empty then DYNAMO_NODELIST must be provided
-  if [[ -z "${dynamo_args["decode-nodelist"]}" && -z "${dynamo_args["prefill-nodelist"]}" && -z "${DYNAMO_NODELIST:-}" ]]; then
-    log "ERROR: Provide --dynamo-decode-nodelist/--dynamo-prefill-nodelist or set DYNAMO_NODELIST"
-    exit 1
+  # If both nodelists are empty, DYNAMO_NODELIST must be provided
+  if [[ -z "${dynamo_args["decode-nodelist"]}" && -z "${dynamo_args["prefill-nodelist"]}" ]]; then
+    if [[ -z "${DYNAMO_NODELIST:-}" ]]; then
+      log "ERROR: When neither --dynamo-decode-nodelist nor --dynamo-prefill-nodelist is provided, DYNAMO_NODELIST must be set"
+      exit 1
+    fi
   fi
 
   # Directories

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -445,7 +445,9 @@ _is_prefill_node() {
 }
 
 _init_runtime_env() {
-  export HF_HOME="${HUGGINGFACE_HOME}"
+  if _is_vllm; then
+    export HF_HOME="${HUGGINGFACE_HOME}"
+  fi
   export NATS_SERVER="nats://${dynamo_args["frontend-node"]}:${dynamo_args["nats-port"]}"
   export ETCD_ENDPOINTS="http://${dynamo_args["frontend-node"]}:${dynamo_args["etcd-port"]}"
   export UCX_LOG_FILE="${RESULTS_DIR}/ucx_log_%h.log"

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -127,8 +127,8 @@ _apply_sglang_section_args() {
   decode_args["--served-model-name"]=${dynamo_args["model"]}
 
   # model-path must point to HF cache for sglang
-  prefill_args["--model-path"]="${MODEL_PATH}"
-  decode_args["--model-path"]="${MODEL_PATH}"
+  prefill_args["--model-path"]="${HUGGINGFACE_HOME}"
+  decode_args["--model-path"]="${HUGGINGFACE_HOME}"
 
   local self="$(_current_node_name)"
   local gpn="$(_gpus_per_node)"
@@ -191,8 +191,6 @@ _parse_cli_pairs() {
         genai_perf_args["--${key#--genai-perf-}"]="$2" ;;
       --huggingface-home)
         HUGGINGFACE_HOME="$2" ;;
-      --model-path)
-        MODEL_PATH="$2" ;;
       --results-dir)
         RESULTS_DIR="$2" ;;
     esac

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -39,10 +39,6 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             f"{td.script.installed_path.absolute()!s}:{td.script.installed_path.absolute()!s}",
         ]
 
-        if td.cmd_args.hf_model_path:
-            model_path = Path(td.cmd_args.hf_model_path).absolute()
-            mounts.append(f"{model_path}:{model_path}")
-
         if td.cmd_args.dynamo.backend == "sglang":
             deepep_path = (
                 dynamo_repo_path / "components/backends/sglang/configs/deepseek_r1/wideep/deepep.json"
@@ -84,9 +80,6 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                 td.cmd_args.dynamo, "--dynamo-", exclude=["prefill_worker", "decode_worker", "genai_perf"]
             )
         )
-
-        if td.cmd_args.hf_model_path:
-            args.append(f"--model-path {td.cmd_args.hf_model_path}")
 
         # Add backend-specific args
         if td.cmd_args.dynamo.backend == "sglang":


### PR DESCRIPTION
## Summary
Refactor nodelist validation to check DYNAMO_NODELIST only if both args empty

Follow up for [PR641](https://github.com/NVIDIA/cloudai/pull/641) (Support for DeepSeekR1 model with SGLang / AI Dynamo)

**@karya0's comments resolved by this PR**
1. https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278002812
2. https://github.com/NVIDIA/cloudai/pull/641#discussion_r2278004082

Relies on https://github.com/NVIDIA/cloudai/pull/655

## Test Plan
1. CI passes
2. Run on EOS

**VLLM LLAMA8b works**
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml 
[INFO] System Name: EOS
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 3452142
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] All test scenario results stored at: results/deepseek_r1_distill_llama_8b_2025-08-15_04-27-40
[WARNING] gpus_per_node is None, skipping Overall Output Tokens per Second per GPU calculation.
[INFO] Generated scenario report at results/deepseek_r1_distill_llama_8b_2025-08-15_04-27-40/deepseek_r1_distill_llama_8b.html
[INFO] All jobs are complete.
```
https://drive.google.com/drive/folders/10xw8nbidc0iqy65sv7j1daz-4LoeEgfl?usp=drive_link