### PR TITLE
Support the TRT-LLM backend in AI Dynamo

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -64,6 +64,7 @@ function log()
 
 _is_vllm() { [[ "${dynamo_args["backend"]}" == "vllm" ]]; }
 _is_sglang() { [[ "${dynamo_args["backend"]}" == "sglang" ]]; }
+_is_trtllm() { [[ "${dynamo_args["backend"]}" == "trtllm" ]]; }
 
 _csv_len() { grep -oE '[^,]+' <<< "$1" | wc -l; }
 
@@ -167,6 +168,18 @@ _apply_sglang_section_args() {
   unset 'decode_args["--model"]'
 }
 
+_apply_trtllm_section_args() {
+  if [[ -n "${dynamo_args["prefill-engine-config"]:-}" ]]; then
+    [[ -f "${dynamo_args["prefill-engine-config"]}" ]] || log "WARN: prefill-engine-config not found: ${dynamo_args["prefill-engine-config"]}"
+    prefill_args["--engine-config"]="${dynamo_args["prefill-engine-config"]}"
+  fi
+
+  if [[ -n "${dynamo_args["decode-engine-config"]:-}" ]]; then
+    [[ -f "${dynamo_args["decode-engine-config"]}" ]] || log "WARN: decode-engine-config not found: ${dynamo_args["decode-engine-config"]}"
+    decode_args["--engine-config"]="${dynamo_args["decode-engine-config"]}"
+  fi
+}
+
 _apply_genai_perf_section_args() {
   genai_perf_args["--model"]="${dynamo_args["model"]}"
   genai_perf_args["--url"]="${dynamo_args["url"]}"
@@ -256,6 +269,8 @@ _patch_section_args() {
 
   if _is_sglang; then
     _apply_sglang_section_args
+  elif _is_trtllm; then
+    _apply_trtllm_section_args
   fi
 
   _apply_genai_perf_section_args

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -105,6 +105,24 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                     f'--dynamo-deepep-config "{deepep_path!s}"',
                 ]
             )
+        elif td.cmd_args.dynamo.backend == "trtllm":
+            prefill_engine_config = getattr(td.cmd_args.dynamo, "prefill_engine_config", None)
+            decode_engine_config = getattr(td.cmd_args.dynamo, "decode_engine_config", None)
+
+            if not prefill_engine_config:
+                raise ValueError("prefill_engine_config is required for trtllm backend")
+            if not decode_engine_config:
+                raise ValueError("decode_engine_config is required for trtllm backend")
+
+            prefill_engine_config = Path(prefill_engine_config).absolute()
+            decode_engine_config = Path(decode_engine_config).absolute()
+
+            args.extend(
+                [
+                    f'--dynamo-prefill-engine-config "{prefill_engine_config!s}"',
+                    f'--dynamo-decode-engine-config "{decode_engine_config!s}"',
+                ]
+            )
 
         args.extend(self._get_toml_args(td.cmd_args.dynamo.prefill_worker, "--prefill-"))
         args.extend(self._get_toml_args(td.cmd_args.dynamo.decode_worker, "--decode-"))


### PR DESCRIPTION
## Summary
Support the TRT-LLM backend in AI Dynamo

[RM4578536](https://redmine.mellanox.com/issues/4578536)

https://github.com/ai-dynamo/dynamo/blob/main/components/backends/trtllm/multinode/multinode-examples.md

## Test Plan
1. CI passes
2. Run on EOS

You need to download model weights with this python script
```
from huggingface_hub import snapshot_download

repo_id = "nvidia/DeepSeek-R1-FP4"  
target  = "/path/to/model"

snapshot_download(
    repo_id=repo_id,
    revision="main",                 # optional
    local_dir=target,
    local_dir_use_symlinks=False,    # write real files, not symlinks
    allow_patterns=[
        "config.json",
        "generation_config.json",
        "tokenizer.json",
        "tokenizer_config.json",
        "model.safetensors.index.json",
        "model-*.safetensors",
        "configuration_*.py",
        "modeling_*.py",
        "README.md",
        "LICENSE",
        "figures/**",
        "checksums.blake3"
    ]
```

Take https://github.com/Mellanox/cloudaix/pull/334

**VLLM - LLAMA**
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml 
```

**SGLang - DSR1**
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_ai_DSR1.toml 
```

**TRTLLM - LLAMA**
```
$ python cloudaix.py run --system-config conf/common/system/eos.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b_trtllm.toml
```
