### PR TITLE
Configure reports via scenario config

### DIFF
--- a/doc/reporting.md
+++ b/doc/reporting.md
@@ -10,6 +10,13 @@ Per-test reports are linked to a particular workload type (e.g. `NcclTest`). All
 To list all available reports, one can use `cloudai list-reports` command. Use verbose output to also print report configurations.
 
 
+## Notes and general flow
+1. All reports should be registered via `Registry()` (`.add_report()` or `.add_scenario_report()`).
+1. Scenario reports are configurable via system config (Slurm-only for now) and scenario config.
+1. Configuration in a scenario config has the highest priority. Next, system config is checked. Then it defaults to report config from the registry.
+1. Then report is generated (or not) according to this final config.
+
+
 ## Enable, disable and configure reports
 **NOTE** Only scenario-level reports can be configured today.
 

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -26,6 +26,7 @@ from .system import System
 from .test_template_strategy import TestTemplateStrategy
 
 if TYPE_CHECKING:
+    from ..models.scenario import ReportConfig
     from .report_generation_strategy import ReportGenerationStrategy
     from .test import Test
 
@@ -184,7 +185,13 @@ class TestScenario:
 
     __test__ = False
 
-    def __init__(self, name: str, test_runs: List[TestRun], job_status_check: bool = True) -> None:
+    def __init__(
+        self,
+        name: str,
+        test_runs: List[TestRun],
+        job_status_check: bool = True,
+        reports: dict[str, ReportConfig] | None = None,
+    ) -> None:
         """
         Initialize a TestScenario instance.
 
@@ -192,10 +199,12 @@ class TestScenario:
             name (str): Name of the test scenario.
             test_runs (List[TestRun]): List of tests in the scenario with custom run options.
             job_status_check (bool): Flag indicating whether to check the job status or not.
+            reports (Optional[dict[str, ReportConfig]]): Reports to be generated for the scenario.
         """
         self.name = name
         self.test_runs = test_runs
         self.job_status_check = job_status_check
+        self.reports = reports or {}
 
     def __repr__(self) -> str:
         """

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -157,7 +157,9 @@ def generate_reports(system: System, test_scenario: TestScenario, result_dir: Pa
         logging.debug(f"Generating report '{name}' ({reporter_class.__name__})")
 
         cfg = registry.report_configs.get(name, ReportConfig(enable=False))
-        if isinstance(system, SlurmSystem) and system.reports and name in system.reports:
+        if scenario_cfg := test_scenario.reports.get(name):
+            cfg = scenario_cfg
+        elif isinstance(system, SlurmSystem) and system.reports and name in system.reports:
             cfg = system.reports[name]
         logging.debug(f"Report '{name}' config is: {cfg.model_dump_json(indent=None)}")
 

--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -155,6 +155,7 @@ class TestScenarioModel(BaseModel):
     tests: list[TestRunModel] = Field(alias="Tests", min_length=1)
     pre_test: Optional[str] = None
     post_test: Optional[str] = None
+    reports: dict[str, ReportConfig] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def check_no_self_dependency(self):
@@ -187,6 +188,11 @@ class TestScenarioModel(BaseModel):
                     raise ValueError(f"Dependency section '{dep.id}' not found for test '{tr.id}'.")
 
         return self
+
+    @field_validator("reports", mode="before")
+    @classmethod
+    def parse_reports(cls, value: dict[str, Any] | None) -> dict[str, ReportConfig] | None:
+        return parse_reports_spec(value)
 
 
 class TestRunDetails(BaseModel):

--- a/src/cloudai/test_scenario_parser.py
+++ b/src/cloudai/test_scenario_parser.py
@@ -167,6 +167,7 @@ class TestScenarioParser:
             name=ts_model.name,
             test_runs=list(test_runs_by_id.values()),
             job_status_check=ts_model.job_status_check,
+            reports=ts_model.reports,
         )
 
     def _create_test_run(

--- a/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
+++ b/src/cloudai/workloads/nccl_test/nccl_comparisson_report.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 class NcclComparissonReportConfig(ReportConfig):
     """Configuration for NCCL comparisson report."""
 
+    enable: bool = True
     group_by: list[str] = Field(default_factory=lambda: ["subtest_name"])
 
 


### PR DESCRIPTION
## Summary
Configure reports via scenario config. Previously scenario-level reports could only be configured via Slurm System config. But with NCCL comparison report, it makes more sense to control it via Scenario:
```toml
[reports.nccl_comparisson]
group_by = ["subtest_name"]
```

## Test Plan
1. CI (extended).
2. Manual runs for (re)generating reports with different configs.

## Additional Notes
—