### PR TITLE
Handle CancelledError gracefully during job cleanup

### DIFF
--- a/src/cloudai/_core/runner.py
+++ b/src/cloudai/_core/runner.py
@@ -85,6 +85,10 @@ class Runner:
         try:
             await self.runner.run()
             logging.debug("All jobs finished successfully.")
+        except asyncio.CancelledError:
+            logging.info("Runner cancelled, performing cleanup...")
+            await self.runner.shutdown()
+            return
         except JobFailureError as exc:
             logging.debug(f"Runner failed JobFailure exception: {exc}", exc_info=True)
 


### PR DESCRIPTION
## Summary
Handle CancelledError gracefully during job cleanup

[RM4582475](https://redmine.mellanox.com/issues/4582475)

## Test Plan
1. CI passes
2. Run on CW

**No cancellation - works**
```
$ python cloudaix.py run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 5115247
```
https://drive.google.com/drive/folders/1OsyHZhXdBkm39CGqaPLzlgM2PWAwrblB?usp=sharing

**Cancel manually - works without stack trace**
```
$ python cloudaix.py run --system-config conf/common/system/cw.toml --tests-dir conf/staging/ai_dynamo/test --test-scenario conf/staging/ai_dynamo/test_scenario/deepseek_r1_distill_llama_8b.toml
[INFO] System Name: Coreweave
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: deepseek_r1_distill_llama_8b
[INFO] Checking if test templates are installed.
[INFO] Test Scenario: deepseek_r1_distill_llama_8b

Section Name: Tests.1
  Test Name: vllm
  Description: vllm
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Starting test: Tests.1
[INFO] Running test: Tests.1
[INFO] Submitted slurm job: 5115246
^C[INFO] Signal 2 received, shutting down...
[INFO] Terminating all jobs...
[INFO] Terminating job 5115246 for test Tests.1
[INFO] All jobs have been killed.
[INFO] Runner cancelled, performing cleanup...
[INFO] Terminating all jobs...
[INFO] Terminating job 5115246 for test Tests.1
[INFO] All jobs have been killed.
[INFO] All test scenario results stored at: results/deepseek_r1_distill_llama_8b_2025-08-18_07-59-39
[WARNING] Skipping 'results/deepseek_r1_distill_llama_8b_2025-08-18_07-59-39/Tests.1/0', can't handle with strategy=AIDynamoReportGenerationStrategy.
[INFO] Generated scenario report at results/deepseek_r1_distill_llama_8b_2025-08-18_07-59-39/deepseek_r1_distill_llama_8b.html
[INFO] All jobs are complete.
```