### PR TITLE
Follow-up for PR647 (Support explicit node assignment for prefill and decode workers)

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -176,6 +176,14 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         assert isinstance(prefill_n, int), "prefill_worker.num_nodes must be an integer"
         assert isinstance(decode_n, int), "decode_worker.num_nodes must be an integer"
 
+        if prefill_nodes and decode_nodes:
+            self.test_run.nodes = prefill_nodes.split(",") + decode_nodes.split(",") + self.test_run.nodes
+            self.test_run.num_nodes = len(self.test_run.nodes)
+            prefill_n = len(prefill_nodes.split(","))
+            decode_n = len(decode_nodes.split(","))
+        else:
+            self.test_run.num_nodes = prefill_n + decode_n
+
         total_nodes = prefill_n + decode_n
 
         requested_nodes, node_list = self.system.get_nodes_by_spec(self.test_run.nnodes, self.test_run.nodes)


### PR DESCRIPTION
## Summary
Follow-up for PR647 (Support explicit node assignment for prefill and decode workers)

1. The total number of nodes is automatically calculated from either the `nodes` field of prefill and decode or the `num-node` field of prefill and decode.
2. The number of nodes for prefill and decode is automatically determined by the corresponding `nodes` field.

https://github.com/NVIDIA/cloudai/pull/647

Comments
1. https://github.com/NVIDIA/cloudai/pull/647#issuecomment-3196649397
3. https://github.com/NVIDIA/cloudai/pull/647#issuecomment-3197949051

## Test Plan

Four nodes are allocated.
```
name = "deepseek_r1_distill_llama_8b"

[[Tests]]
id = "Tests.1"
test_name = "vllm"
...
  [Tests.cmd_args]
    [Tests.cmd_args.dynamo]
      [Tests.cmd_args.dynamo.prefill_worker]
      num-nodes = 2
      [Tests.cmd_args.dynamo.decode_worker]
      num-nodes = 2
```

Four nodes are allocated.
```
name = "deepseek_r1_distill_llama_8b"

[[Tests]]
id = "Tests.1"
test_name = "vllm"
...
  [Tests.cmd_args]
    [Tests.cmd_args.dynamo]
      [Tests.cmd_args.dynamo.prefill_worker]
      nodes = "cw-dfw-h100-003-113-026,cw-dfw-h100-003-116-026"
      [Tests.cmd_args.dynamo.decode_worker]
      nodes = "cw-dfw-h100-003-117-012,cw-dfw-h100-003-119-026"
```

I only confirmed the allocation and did not run the experiments to completion in order to save time on share allocation.