### PR TITLE
Enable AI Dynamo w/ K8S SPCx (Alpha) - Rel 2B

### DIFF
--- a/src/cloudai/systems/kubernetes/kubernetes_installer.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_installer.py
@@ -55,69 +55,7 @@ class KubernetesInstaller(BaseInstaller):
             logging.error(message)
             return InstallStatusResult(False, message)
 
-        # Check MPIJob-related prerequisites
-        mpi_job_result = self._check_mpi_job_prerequisites()
-        if not mpi_job_result.success:
-            return mpi_job_result
-
         logging.info("All prerequisites are met. Proceeding with installation.")
-        return InstallStatusResult(True)
-
-    def _check_mpi_job_prerequisites(self) -> InstallStatusResult:
-        """
-        Check if the MPIJob CRD is installed and if MPIJob kind is supported in the Kubernetes cluster.
-
-        This ensures that the system is ready for MPI-based operations.
-
-        Returns
-            InstallStatusResult: Result containing the status of the MPIJob prerequisite check and any error message.
-        """
-        # Check if MPIJob CRD is installed
-        try:
-            custom_api = lazy.k8s.client.CustomObjectsApi()
-            custom_api.get_cluster_custom_object(group="kubeflow.org", version="v1", plural="mpijobs", name="mpijobs")
-        except lazy.k8s.client.ApiException as e:
-            if e.status == 404:
-                message = (
-                    "Installation failed during prerequisite checking stage because MPIJob CRD is not installed on "
-                    "this Kubernetes cluster. Please ensure that the MPI Operator is installed and MPIJob kind is "
-                    "supported. You can follow the instructions in the MPI Operator repository to install it: "
-                    "https://github.com/kubeflow/mpi-operator"
-                )
-                logging.error(message)
-                return InstallStatusResult(False, message)
-            else:
-                message = (
-                    f"Installation failed during prerequisite checking stage due to an error while checking for MPIJob "
-                    f"CRD. Original error: {e!r}. Please ensure that the Kubernetes cluster is accessible and the "
-                    f"MPI Operator is correctly installed."
-                )
-                logging.error(message)
-                return InstallStatusResult(False, message)
-
-        # Check if MPIJob kind is supported
-        try:
-            api_resources = lazy.k8s.client.ApiextensionsV1Api().list_custom_resource_definition()
-            mpi_job_supported = any(item.metadata.name == "mpijobs.kubeflow.org" for item in api_resources.items)
-        except lazy.k8s.client.ApiException as e:
-            message = (
-                f"Installation failed during prerequisite checking stage due to an error while checking for MPIJob "
-                f"kind support. Original error: {e!r}. Please ensure that the Kubernetes cluster is accessible and "
-                f"the MPI Operator is correctly installed."
-            )
-            logging.error(message)
-            return InstallStatusResult(False, message)
-
-        if not mpi_job_supported:
-            message = (
-                "Installation failed during prerequisite checking stage because MPIJob kind is not supported on this "
-                "Kubernetes cluster. Please ensure that the MPI Operator is installed and MPIJob kind is supported. "
-                "You can follow the instructions in the MPI Operator repository to install it: "
-                "https://github.com/kubeflow/mpi-operator"
-            )
-            logging.error(message)
-            return InstallStatusResult(False, message)
-
         return InstallStatusResult(True)
 
     def install_one(self, item: Installable) -> InstallStatusResult:


### PR DESCRIPTION
## Summary
Enable AI Dynamo w/ K8S SPCx (Alpha) - Rel 2B

[RM4564191](https://redmine.mellanox.com/issues/4564191)

## Test Plan
1. CI passes
2. TODO: Run on Hera

**Install**
```
cloudai install --system-config ../cloudaix-k8s-spcx/conf/common/system/hera_k8s.toml --tests-dir ../cloudaix-k8s-spcx/conf/staging/ai_dynamo/test/
```