### PR TITLE
Make agent_reward_function configurable

### DIFF
--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -91,6 +91,7 @@ class TestRunModel(BaseModel):
     agent: Optional[str] = None
     agent_steps: Optional[int] = None
     agent_metrics: list[str] = Field(default=["default"])
+    agent_reward_function: Optional[str] = None
 
     def tdef_model_dump(self, by_alias: bool) -> dict:
         """Return a dictionary with non-None values that correspond to the test definition fields."""
@@ -101,6 +102,7 @@ class TestRunModel(BaseModel):
             "agent": self.agent,
             "agent_steps": self.agent_steps,
             "agent_metrics": self.agent_metrics,
+            "agent_reward_function": self.agent_reward_function,
             "extra_container_mounts": self.extra_container_mounts,
             "extra_env_vars": self.extra_env_vars if self.extra_env_vars else None,
             "cmd_args": self.cmd_args.model_dump(by_alias=by_alias) if self.cmd_args else None,


### PR DESCRIPTION
## Summary
Make agent_reward_function configurable

Taken from https://github.com/karya0/cloudai/commits/aug25/ (https://github.com/karya0/cloudai/commit/e830aa14b7b2bf0a28218756ee9bc547fbb531e3#diff-dfa9eccbd1a274f636a1278a9691b69d9273b2a6b5a956a11febe23aa791e268)

[RM4604577](https://redmine.mellanox.com/issues/4604577)

## Test Plan
1. CI passes
2. Verified by @karya0. This commit is added at Kapil's request.