### PR TITLE
Get rid of strict validation for configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
           # this checks that all TOMLs are valid, Test Scenarios are checked _only_ the tests in the specified directory
           cloudai verify-configs --tests-dir conf/common/test conf/common
-          cloudai verify-configs --strict --tests-dir conf/release/spcx/l40s/test conf/release/spcx/l40s
+          cloudai verify-configs --tests-dir conf/release/spcx/l40s/test conf/release/spcx/l40s
 
           # set monitor_interval to 1 to speed up the test
           sed -i '/scheduler =/a monitor_interval = 1' conf/common/system/example_slurm_cluster.toml

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -117,9 +117,6 @@ class CloudAICLI:
                 tests_dir=False,
             )
             p.add_argument("configs_dir", help="Path to a file or the directory containing the TOML files.", type=Path)
-            p.add_argument(
-                "--strict", help="Warn about unknown keys in Test TOML files.", action="store_true", default=False
-            )
 
         if "list" in self.DEFAULT_MODES:
             p = self.add_command("list", "List registered items.", handle_list_registered_items)

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -410,16 +410,15 @@ def verify_system_configs(system_tomls: List[Path]) -> int:
     return nfailed
 
 
-def verify_test_configs(test_tomls: List[Path], strict: bool) -> int:
+def verify_test_configs(test_tomls: List[Path]) -> int:
     nfailed = 0
     tp = TestParser([], None)  # type: ignore
-    logging.info(f"Strict test verification: {strict}")
     for test_toml in test_tomls:
         logging.debug(f"Verifying Test: {test_toml}...")
         try:
             with test_toml.open() as fh:
                 tp.current_file = test_toml
-                tp.load_test_definition(toml.load(fh), strict)
+                tp.load_test_definition(toml.load(fh))
         except Exception:
             nfailed += 1
 
@@ -432,11 +431,7 @@ def verify_test_configs(test_tomls: List[Path], strict: bool) -> int:
 
 
 def verify_test_scenarios(
-    scenario_tomls: List[Path],
-    test_tomls: list[Path],
-    hook_tomls: List[Path],
-    hook_test_tomls: list[Path],
-    strict: bool = False,
+    scenario_tomls: List[Path], test_tomls: list[Path], hook_tomls: List[Path], hook_test_tomls: list[Path]
 ) -> int:
     system = Mock(spec=System)
     nfailed = 0
@@ -446,7 +441,7 @@ def verify_test_scenarios(
             tests = Parser.parse_tests(test_tomls, system)
             hook_tests = Parser.parse_tests(hook_test_tomls, system)
             hooks = Parser.parse_hooks(hook_tomls, system, {t.name: t for t in hook_tests})
-            Parser.parse_test_scenario(scenario_file, system, {t.name: t for t in tests}, hooks, strict)
+            Parser.parse_test_scenario(scenario_file, system, {t.name: t for t in tests}, hooks)
         except Exception:
             nfailed += 1
 
@@ -482,9 +477,9 @@ def handle_verify_all_configs(args: argparse.Namespace) -> int:
     if files["system"]:
         nfailed += verify_system_configs(files["system"])
     if files["test"]:
-        nfailed += verify_test_configs(files["test"], args.strict)
+        nfailed += verify_test_configs(files["test"])
     if files["scenario"]:
-        nfailed += verify_test_scenarios(files["scenario"], test_tomls, files["hook"], files["hook_test"], args.strict)
+        nfailed += verify_test_scenarios(files["scenario"], test_tomls, files["hook"], files["hook_test"])
     if files["unknown"]:
         logging.error(f"Unknown configuration files: {[str(f) for f in files['unknown']]}")
         nfailed += len(files["unknown"])

--- a/src/cloudai/parser.py
+++ b/src/cloudai/parser.py
@@ -146,12 +146,11 @@ class Parser:
         system: System,
         test_mapping: Dict[str, Test],
         hook_mapping: Optional[Dict[str, TestScenario]] = None,
-        strict: bool = False,
     ) -> TestScenario:
         if hook_mapping is None:
             hook_mapping = {}
 
-        test_scenario_parser = TestScenarioParser(test_scenario_path, system, test_mapping, hook_mapping, strict)
+        test_scenario_parser = TestScenarioParser(test_scenario_path, system, test_mapping, hook_mapping)
         test_scenario = test_scenario_parser.parse()
         return test_scenario
 

--- a/src/cloudai/test_parser.py
+++ b/src/cloudai/test_parser.py
@@ -86,7 +86,7 @@ class TestParser:
                 extras |= TestParser.model_extras(m.__dict__[field], prefix=f"{prefix}.{field}")
         return extras | set([f"{prefix}.{k}" for k in m.model_extra])
 
-    def load_test_definition(self, data: dict, strict: bool = False) -> TestDefinition:
+    def load_test_definition(self, data: dict) -> TestDefinition:
         test_template_name = data.get("test_template_name")
         registry = Registry()
         if not test_template_name or test_template_name not in registry.test_definitions_map:
@@ -102,12 +102,6 @@ class TestParser:
                 err_msg = format_validation_error(err)
                 logging.error(err_msg)
             raise TestConfigParsingError("Failed to parse test spec") from e
-
-        if strict and self.model_extras(test_def.cmd_args):
-            logging.error(f"Strict check failed for test spec: '{self.current_file}'")
-            for field in self.model_extras(test_def.cmd_args):
-                logging.error(f"Unexpected field '{field}' in test spec.")
-            raise TestConfigParsingError("Failed to parse test spec using strict mode")
 
         return test_def
 
@@ -166,7 +160,7 @@ class TestParser:
         )
         return obj
 
-    def _parse_data(self, data: Dict[str, Any], strict: bool = False) -> Test:
+    def _parse_data(self, data: Dict[str, Any]) -> Test:
         """
         Parse data for a Test object.
 
@@ -177,6 +171,6 @@ class TestParser:
         Returns:
             Test: Parsed Test object.
         """
-        test_def = self.load_test_definition(data, strict)
+        test_def = self.load_test_definition(data)
         test_template = self._get_test_template(test_def.test_template_name, test_def)
         return Test(test_definition=test_def, test_template=test_template)

--- a/src/cloudai/test_scenario_parser.py
+++ b/src/cloudai/test_scenario_parser.py
@@ -83,18 +83,12 @@ class TestScenarioParser:
     __test__ = False
 
     def __init__(
-        self,
-        file_path: Path,
-        system: System,
-        test_mapping: Dict[str, Test],
-        hook_mapping: Dict[str, TestScenario],
-        strict: bool = False,
+        self, file_path: Path, system: System, test_mapping: Dict[str, Test], hook_mapping: Dict[str, TestScenario]
     ) -> None:
         self.file_path = file_path
         self.system = system
         self.test_mapping = test_mapping
         self.hook_mapping = hook_mapping
-        self.strict = strict
 
     def parse(self) -> TestScenario:
         """
@@ -239,9 +233,9 @@ class TestScenarioParser:
             test_defined = test.test_definition.model_dump(by_alias=True)
             tc_defined = test_info.tdef_model_dump(by_alias=True)
             merged_data = deep_merge(test_defined, tc_defined)
-            test.test_definition = tp.load_test_definition(merged_data, self.strict)
+            test.test_definition = tp.load_test_definition(merged_data)
         elif test_info.test_template_name:  # test fully defined in the scenario
-            test = tp._parse_data(test_info.tdef_model_dump(by_alias=True), self.strict)
+            test = tp._parse_data(test_info.tdef_model_dump(by_alias=True))
         else:
             # this should never happen, because we check for this in the modelvalidator
             raise ValueError(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,7 +220,6 @@ class TestCLIDefaultModes:
             log_level="INFO",
             mode="verify-configs",
             tests_dir=Path.cwd(),
-            strict=False,
             **{"configs_dir": Path("configs_dir")},
         )
 
@@ -230,7 +229,6 @@ class TestCLIDefaultModes:
             log_level="INFO",
             mode="verify-configs",
             tests_dir=None,
-            strict=False,
             **{"configs_dir": Path("configs_dir")},
         )
 

--- a/tests/test_test_definitions.py
+++ b/tests/test_test_definitions.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 from cloudai._core.test import Test
 from cloudai._core.test_scenario import TestRun
 from cloudai._core.test_template import TestTemplate
-from cloudai.core import File, NsysConfiguration, Parser, Registry, TestConfigParsingError, TestDefinition, TestParser
+from cloudai.core import File, NsysConfiguration, Parser, Registry, TestDefinition, TestParser
 from cloudai.models.scenario import TestRunDetails
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.workloads.chakra_replay import ChakraReplayCmdArgs, ChakraReplayTestDefinition

--- a/tests/test_test_definitions.py
+++ b/tests/test_test_definitions.py
@@ -257,11 +257,6 @@ class TestLoadTestDefinition:
         assert test_def.cmd_args.unknown["sub"] == "sub"  # type: ignore
         assert test_def.cmd_args.trainer.strategy.nested_unknown == "nested_unknown"  # type: ignore
 
-    def test_load_test_definition_strict(self, test_parser: TestParser, nemorun_with_unknown_field: dict):
-        with pytest.raises(TestConfigParsingError) as exc_info:
-            test_parser.load_test_definition(data=nemorun_with_unknown_field, strict=True)
-        assert "Failed to parse test spec using strict mode" in str(exc_info.value)
-
     def test_load_test_definition_unknown_test(self, test_parser: TestParser):
         with pytest.raises(NotImplementedError) as exc_info:
             test_parser.load_test_definition(data={"test_template_name": "unknown"})


### PR DESCRIPTION
## Summary
Get rid of strict validation for configs as it is not used and only confuses users.

Fixes [internal bug](https://redmine.mellanox.com/issues/4540313).

## Test Plan
1. CI (updated)

## Additional Notes
—