### PR TITLE
Update Nemo image reference to nvcr.io#nvidia/nemo:25.07 in all toml files

### DIFF
--- a/conf/common/test/dse_nemo_run_llama3_8b_bf16.toml
+++ b/conf/common/test/dse_nemo_run_llama3_8b_bf16.toml
@@ -19,7 +19,7 @@ description = "dse_nemo_run_perf_llama3_8b_bf16"
 test_template_name = "NeMoRun"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
 task = "pretrain"
 recipe_name = "cloudai_llama3_8b_recipe"
 num_layers = 32

--- a/conf/common/test/dse_nemo_run_llama3_8b_fp8.toml
+++ b/conf/common/test/dse_nemo_run_llama3_8b_fp8.toml
@@ -19,7 +19,7 @@ description = "dse_nemo_run_llama3_8b"
 test_template_name = "NeMoRun"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
 task = "pretrain"
 recipe_name = "cloudai_llama3_8b_recipe"
 num_layers = 32

--- a/conf/common/test/nemo_run_llama3_8b.toml
+++ b/conf/common/test/nemo_run_llama3_8b.toml
@@ -19,7 +19,7 @@ description = "nemo_run_llama3_8b"
 test_template_name = "NeMoRun"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
 task = "pretrain"
 recipe_name = "cloudai_llama3_8b_recipe"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_bf16_128_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_bf16_128_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_bf16_128_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_bf16_256_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_bf16_256_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_bf16_256_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_bf16_2_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_bf16_2_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_bf16_2_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_128_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_128_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_128_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_16_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_16_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_16_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_256_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_256_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_256_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_2_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_2_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_2_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_32_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_32_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_32_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_4_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_4_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_4_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_64_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_64_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_64_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_8_node.toml
+++ b/conf/experimental/test/nemo_launcher_nemotron_15b_fp8_8_node.toml
@@ -19,7 +19,7 @@ description = "nemo_launcher_nemotron_15b_fp8_8_node"
 test_template_name = "NeMoLauncher"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
   [cmd_args.training]
   values = "nemotron/nemotron_15b"
 

--- a/conf/release/nemo_acceptance/test/nemo_run_llama3_8b.toml
+++ b/conf/release/nemo_acceptance/test/nemo_run_llama3_8b.toml
@@ -19,7 +19,7 @@ description = "dse_nemo_run_llama3_8b"
 test_template_name = "NeMoRun"
 
 [cmd_args]
-docker_image_url = "nvcr.io/nvidia/nemo:25.04.rc2"
+docker_image_url = "nvcr.io#nvidia/nemo:25.07"
 task = "pretrain"
 recipe_name = "cloudai_llama3_8b_recipe"
 


### PR DESCRIPTION
## Summary
Update Nemo image reference to nvcr.io#nvidia/nemo:25.07 in all toml files

## Test Plan
1. CI passes
2. Ran on CW. Please see https://github.com/Mellanox/cloudaix/pull/352