### PR TITLE
Make --tests-dir optional

### DIFF
--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -85,7 +85,7 @@ def common_options(f):
     )(f)
     f = click.option(
         "--tests-dir",
-        required=True,
+        required=False,
         type=click.Path(exists=True, resolve_path=True, path_type=Path, file_okay=False, dir_okay=True),
         help="Directory with Test configs.",
     )(f)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,15 @@ def test_version():
     assert "CloudAI, version" in result.output
 
 
+def test_tests_dir_is_optional(tmp_path: Path):
+    system_cfg, scenario_cfg = tmp_path / "system.toml", tmp_path / "scenario.toml"
+    system_cfg.touch()
+    scenario_cfg.touch()
+    runner = CliRunner()
+    result = runner.invoke(main, ["run", "--system-config", str(system_cfg), "--test-scenario", str(scenario_cfg)])
+    assert "Missing option '--tests-dir'" not in result.output
+
+
 @pytest.mark.parametrize(
     "subcommand", ["dry-run", "generate-report", "install", "list", "run", "uninstall", "verify-configs"]
 )


### PR DESCRIPTION
## Summary
Make `--tests-dir` optional, this works for scenarios fully defined in a single file.

Fixes [internal bug](https://redmine.mellanox.com/issues/4640855).

## Test Plan
1. CI (extended).
2. Manually run with different scenarios (dry-run).

## Additional Notes
—
