### PR TITLE
Fix CLI arg for kvbench

### DIFF
--- a/src/cloudai/workloads/nixl_kvbench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_kvbench/slurm_command_gen_strategy.py
@@ -69,6 +69,6 @@ class NIXLKVBenchSlurmCommandGenStrategy(NIXLCmdGenBase):
         for k, v in self.test_run.test.test_definition.cmd_args_dict.items():
             command.append(f"--{k} {v}")
 
-        command.append("--etcd-endpoints http://$NIXL_ETCD_ENDPOINTS")
+        command.append("--etcd_endpoints http://$NIXL_ETCD_ENDPOINTS")
 
         return command

--- a/tests/ref_data/nixl-kvbench.sbatch
+++ b/tests/ref_data/nixl-kvbench.sbatch
@@ -22,7 +22,7 @@ timeout 60 bash -c "until curl -s $NIXL_ETCD_ENDPOINTS/health > /dev/null 2>&1; 
    echo "ETCD ($NIXL_ETCD_ENDPOINTS) was unreachable after 60 seconds";
    exit 1
  }
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=0 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd-endpoints http://$NIXL_ETCD_ENDPOINTS" &
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=0 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS" &
 sleep 15
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=1 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd-endpoints http://$NIXL_ETCD_ENDPOINTS"
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=1 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS"
 kill -9 $etcd_pid

--- a/tests/slurm_command_gen_strategy/test_nixl_kvbench_command_gen.py
+++ b/tests/slurm_command_gen_strategy/test_nixl_kvbench_command_gen.py
@@ -70,5 +70,5 @@ def test_gen_kvbench_ucx(kvbench_tr: TestRun, slurm_system: SlurmSystem):
         "--model_config ./cfg.yaml",
         "--source src",
         "--op_type READ",
-        "--etcd-endpoints http://$NIXL_ETCD_ENDPOINTS",
+        "--etcd_endpoints http://$NIXL_ETCD_ENDPOINTS",
     ]


### PR DESCRIPTION
## Summary
Fix CLI arg for kvbench.

Fixes [internal bug](https://redmine.mellanox.com/issues/4641151).

## Test Plan
1. CI
2. Manual run on EOS with user-provided configs.

## Additional Notes
—