### PR TITLE
Removing VBOOST 

### DIFF
--- a/conf/common/test/dse_nemo_run_llama3_8b_fp8.toml
+++ b/conf/common/test/dse_nemo_run_llama3_8b_fp8.toml
@@ -47,7 +47,6 @@ num_layers = 32
     grad_reduce_in_fp32 = true
 
 [extra_env_vars]
-ENABLE_VBOOST = "1"
 ENABLE_NUMA_CONTROL = "1"
 NCCL_P2P_NET_CHUNKSIZE = "2097152"
 TORCHX_MAX_RETRIES = "0"


### PR DESCRIPTION
## Summary
Vboost as a feature requires sudo access to the nodes. The public facing configuration cannot make this assumption regarding sudo access and hence needs to be removed.

## Test Plan
-CI/CD
- Real system

## Additional Notes

