### PR TITLE
Remove useless options for install/uninstall commands

### DIFF
--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -128,30 +128,18 @@ def main(log_file, log_level):
 
 @main.command()
 @common_options
-@output_dir_opt
-def install(system_cfg: Path, tests_dir: Path, scenario_cfg: Path, output_dir: Path):
+def install(system_cfg: Path, tests_dir: Path, scenario_cfg: Path):
     """Install the necessary components for workloads."""
-    args = argparse.Namespace(
-        system_config=system_cfg,
-        tests_dir=tests_dir,
-        test_scenario=scenario_cfg,
-        output_dir=output_dir,
-        mode="install",
-    )
+    args = argparse.Namespace(system_config=system_cfg, tests_dir=tests_dir, test_scenario=scenario_cfg, mode="install")
     exit(handle_install_and_uninstall(args))
 
 
 @main.command()
 @common_options
-@output_dir_opt
-def uninstall(system_cfg: Path, tests_dir: Path, scenario_cfg: Path, output_dir: Path):
+def uninstall(system_cfg: Path, tests_dir: Path, scenario_cfg: Path):
     """Uninstall the components used by workloads."""
     args = argparse.Namespace(
-        system_config=system_cfg,
-        tests_dir=tests_dir,
-        test_scenario=scenario_cfg,
-        output_dir=output_dir,
-        mode="uninstall",
+        system_config=system_cfg, tests_dir=tests_dir, test_scenario=scenario_cfg, mode="uninstall"
     )
     exit(handle_install_and_uninstall(args))
 

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -59,8 +59,6 @@ def handle_install_and_uninstall(args: argparse.Namespace) -> int:
     parser = Parser(args.system_config)
     system, tests, scenario = parser.parse(args.tests_dir, args.test_scenario)
 
-    if args.output_dir:
-        system.output_path = args.output_dir.absolute()
     system.update()
     logging.info(f"System Name: {system.name}")
     logging.info(f"Scheduler: {system.scheduler}")


### PR DESCRIPTION
## Summary
`--output-dir` is not used for installation/uninstallation, so to make commands less confusing this option is now removed.

Fixes [internal bug](https://redmine.mellanox.com/issues/4641551).

## Test Plan
1. CI
2. Manually run `install` and `uninstall` on EOS.

## Additional Notes
—