### PR TITLE
Add Qwen Recipe (VER)

### DIFF
--- a/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
+++ b/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
@@ -32,6 +32,7 @@ from nemo.collections.llm.gpt.data.mock import MockDataModule
 from nemo.collections.llm.gpt.model.llama import Llama3Config70B, Llama31Config405B, LlamaModel
 from nemo.collections.llm.gpt.model.nemotron import Nemotron4Config15B, Nemotron4Config340B, NemotronModel
 from nemo.collections.llm.recipes.nemotron3_8b import pretrain_recipe as nemotron3_8b_recipe
+from nemo.collections.llm.recipes.qwen3_30b_a3b import pretrain_recipe as qwen3_30b_a3b_pretrain_recipe
 from nemo.collections.llm.recipes.tp_overlap_configs.userbuffers import (
     BulkOverlapCfg,
     PipelineOverlapCfg,
@@ -43,6 +44,7 @@ from nemo.lightning import AutoResume, NeMoLogger
 from nemo.lightning.pytorch.callbacks.flops_callback import FLOPsMeasurementCallback
 from nemo.lightning.pytorch.callbacks.garbage_collection import GarbageCollectionCallback
 from nemo.lightning.pytorch.callbacks.megatron_comm_overlap import MegatronCommOverlapCallback
+from nemo.lightning.pytorch.callbacks.moe_token_drop import MegatronTokenDropCallback
 from nemo.lightning.pytorch.callbacks.nsys import NsysCallback
 from nemo.lightning.pytorch.optim import CosineAnnealingScheduler
 from nemo.utils.exp_manager import TimingCallback
@@ -1206,7 +1208,46 @@ def cloudai_nemotron4_340b_recipe() -> run.Partial:
 
     return recipe
 
+# Qwen3 30B Recipe
+@run.cli.factory(target=llm.pretrain)
+def cloudai_qwen3_30b_a3b_recipe() -> run.Partial:
+    recipe = qwen3_30b_a3b_pretrain_recipe()
 
+    # CloudAI adjustments using upstream performance settings
+    recipe.log = default_log()
+
+    if not hasattr(recipe.trainer, "callbacks") or recipe.trainer.callbacks is None:
+        recipe.trainer.callbacks = []
+
+    # FLOPs measurement (modeled after DeepSeek integration)
+    recipe.trainer.callbacks.append(
+        run.Config(
+            FLOPsMeasurementCallback,
+            model_config=recipe.model.config,
+            data_config=recipe.data,
+            model_name="qwen3",
+        )
+    )
+
+    recipe.trainer.callbacks.append(run.Config(MegatronTokenDropCallback))
+    recipe.trainer.callbacks.append(run.Config(MegatronCommOverlapCallback, tp_comm_overlap=True))
+
+    recipe.model.config.cross_entropy_fusion_impl = "te"
+    recipe.model.config.cross_entropy_loss_fusion = True
+    recipe.model.config.apply_rope_fusion = True
+    recipe.model.config.moe_permute_fusion = True
+    recipe.model.config.bias_dropout_fusion = True
+    recipe.model.config.bias_activation_fusion = True
+
+    recipe.model.config.recompute_granularity = None
+    recipe.model.config.recompute_method = None
+    recipe.model.config.recompute_num_layers = None
+
+    if os.getenv("CLOUDAI_GPU_TYPE") in ("gb200", "b200"):
+        set_enable_cuda_graphs_params(recipe)
+
+    return recipe
+    
 if __name__ == "__main__":
     mode = os.getenv("CLOUDAI_NEMO_TASK")
 
@@ -1218,6 +1259,7 @@ if __name__ == "__main__":
         "cloudai_nemotron4_15b_recipe",
         "cloudai_nemotron4_340b_recipe",
         "cloudai_deepseek_v3_recipe",
+        "cloudai_qwen3_30b_a3b_recipe",
     ]
 
     recipe_name = os.getenv("CLOUDAI_NEMO_RECIPE")

--- a/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
+++ b/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
@@ -1214,13 +1214,11 @@ def cloudai_nemotron4_340b_recipe() -> run.Partial:
 def cloudai_qwen3_30b_a3b_recipe() -> run.Partial:
     recipe = qwen3_30b_a3b_pretrain_recipe()
 
-    # CloudAI adjustments using upstream performance settings
     recipe.log = default_log()
 
     if not hasattr(recipe.trainer, "callbacks") or recipe.trainer.callbacks is None:
         recipe.trainer.callbacks = []
 
-    # FLOPs measurement (modeled after DeepSeek integration)
     recipe.trainer.callbacks.append(
         run.Config(
             FLOPsMeasurementCallback,

--- a/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
+++ b/src/cloudai/workloads/nemo_run/cloudai_nemorun.py
@@ -1208,6 +1208,7 @@ def cloudai_nemotron4_340b_recipe() -> run.Partial:
 
     return recipe
 
+
 # Qwen3 30B Recipe
 @run.cli.factory(target=llm.pretrain)
 def cloudai_qwen3_30b_a3b_recipe() -> run.Partial:
@@ -1247,7 +1248,8 @@ def cloudai_qwen3_30b_a3b_recipe() -> run.Partial:
         set_enable_cuda_graphs_params(recipe)
 
     return recipe
-    
+
+
 if __name__ == "__main__":
     mode = os.getenv("CLOUDAI_NEMO_TASK")
 

--- a/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nemo_run/slurm_command_gen_strategy.py
@@ -98,6 +98,7 @@ class NeMoRunSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             "cloudai_nemotron3_8b_recipe",
             "cloudai_nemotron4_15b_recipe",
             "cloudai_nemotron4_340b_recipe",
+            "cloudai_qwen3_30b_a3b_recipe",
         ]
 
         if recipe_name not in supported_recipes:


### PR DESCRIPTION
## Summary
We deprecated Llama3_8b for Gb200 systems VER testing. As a replacement, we add Qwen3_30b model for GB200. This PR adds support for Qwen3_30b model using existing Nemo-Run mechanisms.

## Test Plan
-CI/CD
- Real Gb200 internal cluster. Logs here.

