### PR TITLE
Add debug logging for system config parsing errors

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -403,12 +403,14 @@ def verify_system_configs(system_tomls: List[Path]) -> int:
             try:
                 with _ensure_kube_config_exists(system_toml, content):
                     Parser.parse_system(system_toml)
-            except Exception:
+            except Exception as e:
+                logging.debug(f"Failed to parse system config {system_toml}: {e}", exc_info=True)
                 nfailed += 1
         else:
             try:
                 Parser.parse_system(system_toml)
-            except Exception:
+            except Exception as e:
+                logging.debug(f"Failed to parse system config {system_toml}: {e}", exc_info=True)
                 nfailed += 1
 
     if nfailed:


### PR DESCRIPTION
## Summary
Add debug logging for system config parsing errors

[RM4540392](https://redmine.mellanox.com/issues/4540392)

## Test Plan
1. CI passes
2. Ran on IL-1 by Ofir 
```
(cloudai) ofirmi@mtl-isr1-slurm-gw:/hpc/local/work/ofirmi/cloudai$ cloudai verify-configs conf
[INFO] Found 2 hook TOMLs (always verified)
[WARNING] Test configuration directory not provided, using all found test TOMLs in the specified directory.
[ERROR] Failed to parse system definition: /hpc/local/work/ofirmi/cloudai/conf/common/system/kubernetes_cluster.toml
[ERROR] Error: Invalid kube-config. /labhome/ofirmi/.kube/config file is empty
[ERROR] 1 out of 4 system configurations have issues.
[INFO] Checked tests: 41, all passed
[INFO] Checked scenarios: 31, all passed
[ERROR] 1 out of 78 configuration files have issues.
```