### PR TITLE
Fix NameError for K8s batch run

### DIFF
--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -472,9 +472,9 @@ class KubernetesSystem(BaseModel, System):
         api_response = self.batch_v1.delete_namespaced_job(
             name=job_name,
             namespace=self.default_namespace,
-            body=k8s.client.V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
+            body=lazy.k8s.client.V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
         )
-        api_response = cast(k8s.client.V1Job, api_response)
+        api_response = cast("k8s.client.V1Job", api_response)
 
         logging.debug(f"Batch job '{job_name}' deleted with status: {api_response.status}")
 

--- a/tests/test_kubernetes_system.py
+++ b/tests/test_kubernetes_system.py
@@ -16,7 +16,7 @@
 
 from pathlib import Path
 from typing import Dict, List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from kubernetes import client
@@ -179,3 +179,16 @@ def test_check_deployment_conditions(
     k8s_system: KubernetesSystem, conditions: List[Dict[str, str]], expected_result: bool
 ) -> None:
     assert k8s_system._check_deployment_conditions(conditions) == expected_result
+
+
+def test_delete_batch_job(k8s_system: KubernetesSystem):
+    job_name = "test-job"
+
+    with patch.object(k8s_system.batch_v1, "delete_namespaced_job", return_value=Mock()) as mock_delete:
+        k8s_system._delete_batch_job(job_name)
+
+        mock_delete.assert_called_once_with(
+            name=job_name,
+            namespace=k8s_system.default_namespace,
+            body=client.V1DeleteOptions(propagation_policy="Foreground", grace_period_seconds=5),
+        )


### PR DESCRIPTION
## Summary
Fix `NameError` due to conditional import and lazy import implementation.

Fixes #719.

## Test Plan
1. CI (extended).

## Additional Notes
—