### PR TITLE
Report results dir to users as early as possible

### DIFF
--- a/src/cloudai/_core/base_runner.py
+++ b/src/cloudai/_core/base_runner.py
@@ -104,8 +104,8 @@ class BaseRunner(ABC):
         Args:
             tr (TestRun): The test to be started.
         """
-        logging.info(f"Starting test: {tr.name}")
         tr.output_path = self.get_job_output_path(tr)
+        logging.info(f"Starting test: {tr.name} (results at: {tr.output_path})")
         self.on_job_submit(tr)
         try:
             job = self._submit_test(tr)
@@ -126,7 +126,7 @@ class BaseRunner(ABC):
             tr (TestRun): The test to start after a delay.
             delay (int): Delay in seconds before starting the test.
         """
-        logging.info(f"Delayed start for test {tr.name} by {delay} seconds.")
+        logging.debug(f"Delayed start for test {tr.name} by {delay} seconds.")
         await asyncio.sleep(delay)
         await self.submit_test(tr)
 

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -189,8 +189,6 @@ def generate_reports(system: System, test_scenario: TestScenario, result_dir: Pa
 def handle_non_dse_job(runner: Runner, args: argparse.Namespace) -> None:
     asyncio.run(runner.run())
 
-    logging.info(f"All test scenario results stored at: {runner.runner.scenario_root}")
-
     if args.mode == "run":
         generate_reports(runner.runner.system, runner.runner.test_scenario, runner.runner.scenario_root)
 
@@ -294,6 +292,7 @@ def handle_dry_run_and_run(args: argparse.Namespace) -> int:
 
     runner = Runner(args.mode, system, test_scenario)
     register_signal_handlers(runner.cancel_on_signal)
+    logging.info(f"Scenario results will be stored at: {runner.runner.scenario_root}")
 
     has_dse = any(tr.is_dse_job for tr in test_scenario.test_runs)
     if args.single_sbatch or not has_dse:  # in this mode cases are unrolled using grid search


### PR DESCRIPTION
## Summary
Report results dir to users as early as possible, show less relevant log lines in debug mode only. Previously, results dir was reported only at the end of a scenario run, so users would need to manually search output folder for relevant files.

Now it can look like this:
```bash
...
[INFO] Initializing Runner [DRY-RUN] mode
[INFO] Creating SlurmRunner
[INFO] Scenario results will be stored at: results/megatron_run_2025-11-24_16-00-42
[INFO] Starting test: megatron-run.save (results at: results/megatron_run_2025-11-24_16-00-42/megatron-run.save/0)
...
```

## Test Plan
1. CI
2. Manual runs

## Additional Notes
—