### PR TITLE
Add HF home dir property inside System model

### DIFF
--- a/src/cloudai/_core/base_installer.py
+++ b/src/cloudai/_core/base_installer.py
@@ -142,6 +142,8 @@ class BaseInstaller(ABC):
         """
         if not prepare_output_dir(self.system.install_path):
             return InstallStatusResult(False, f"Error preparing install dir '{self.system.install_path.absolute()}'")
+        elif not prepare_output_dir(self.system.hf_home_path):
+            return InstallStatusResult(False, f"Error preparing hf home dir '{self.system.hf_home_path.absolute()}'")
 
         install_results: dict[Installable, InstallStatusResult] = {}
         for item in self.all_items(items):
@@ -180,6 +182,8 @@ class BaseInstaller(ABC):
 
         if not prepare_output_dir(self.system.install_path):
             return InstallStatusResult(False, f"Error preparing install dir '{self.system.install_path.absolute()}'")
+        elif not prepare_output_dir(self.system.hf_home_path):
+            return InstallStatusResult(False, f"Error preparing hf home dir '{self.system.hf_home_path.absolute()}'")
 
         logging.debug(f"Going to install {len(set(items))} uniq item(s) (total is {len(list(items))})")
 

--- a/src/cloudai/_core/system.py
+++ b/src/cloudai/_core/system.py
@@ -37,6 +37,7 @@ class System(ABC, BaseModel):
     scheduler: str
     install_path: Path
     output_path: Path
+    hf_home_path: Path = Field(default_factory=lambda data: data["install_path"] / "huggingface")
     global_env_vars: dict[str, Any] = Field(default_factory=dict)
     monitor_interval: int = 1
 

--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
@@ -64,7 +64,6 @@ class AIDynamoCmdArgs(CmdArgs):
     """Arguments for AI Dynamo."""
 
     docker_image_url: str
-    huggingface_home_host_path: Path = Path.home() / ".cache/huggingface"
     huggingface_home_container_path: Path = Path("/root/.cache/huggingface")
     dynamo: AIDynamoArgs
     genai_perf: GenAIPerfArgs
@@ -102,13 +101,6 @@ class AIDynamoTestDefinition(TestDefinition):
     @property
     def installables(self) -> list[Installable]:
         return [self.docker_image, self.script, self.dynamo_repo, self.python_executable]
-
-    @property
-    def huggingface_home_host_path(self) -> Path:
-        path = Path(self.cmd_args.huggingface_home_host_path)
-        if not path.is_dir():
-            raise FileNotFoundError(f"HuggingFace home path not found at {path}")
-        return path
 
     @property
     def python_executable(self) -> PythonExecutable:

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -35,7 +35,7 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
 
         mounts = [
             f"{dynamo_repo_path}:{dynamo_repo_path}",
-            f"{td.cmd_args.huggingface_home_host_path}:{td.cmd_args.huggingface_home_container_path}",
+            f"{self.system.hf_home_path.absolute()}:{td.cmd_args.huggingface_home_container_path}",
             f"{td.script.installed_path.absolute()!s}:{td.script.installed_path.absolute()!s}",
         ]
 

--- a/tests/ref_data/ai-dynamo.sbatch
+++ b/tests/ref_data/ai-dynamo.sbatch
@@ -10,9 +10,9 @@
 
 export SLURM_JOB_MASTER_NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 
-srun --export=ALL --mpi=pmix -N2 --container-image=nvcr.io/nvidia/ai-dynamo:24.09 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__:__INSTALL_DIR__,__OUTPUT_DIR__/output/hf_home:/root/.cache/huggingface,__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh:__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh --output=__OUTPUT_DIR__/output/mapping-stdout.txt --error=__OUTPUT_DIR__/output/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."
+srun --export=ALL --mpi=pmix -N2 --container-image=nvcr.io/nvidia/ai-dynamo:24.09 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__:__INSTALL_DIR__,__INSTALL_DIR__/huggingface:/root/.cache/huggingface,__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh:__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh --output=__OUTPUT_DIR__/output/mapping-stdout.txt --error=__OUTPUT_DIR__/output/mapping-stderr.txt bash -c "echo \$(date): \$(hostname):node \${SLURM_NODEID}:rank \${SLURM_PROCID}."
 
-srun --export=ALL --mpi=pmix -N2 --container-image=nvcr.io/nvidia/ai-dynamo:24.09 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__:__INSTALL_DIR__,__OUTPUT_DIR__/output/hf_home:/root/.cache/huggingface,__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh:__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
+srun --export=ALL --mpi=pmix -N2 --container-image=nvcr.io/nvidia/ai-dynamo:24.09 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__:__INSTALL_DIR__,__INSTALL_DIR__/huggingface:/root/.cache/huggingface,__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh:__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 num_retries=${DYNAMO_NUM_RETRY_ON_FAILURE:-0}
 for try in $(seq 0 $num_retries); do
@@ -23,7 +23,7 @@ for try in $(seq 0 $num_retries); do
   --mpi=pmix \
   -N2 \
   --container-image=nvcr.io/nvidia/ai-dynamo:24.09 \
-  --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__:__INSTALL_DIR__,__OUTPUT_DIR__/output/hf_home:/root/.cache/huggingface,__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh:__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh \
+  --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__:__INSTALL_DIR__,__INSTALL_DIR__/huggingface:/root/.cache/huggingface,__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh:__CLOUDAI_DIR__/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh \
   --nodes=2 \
   --ntasks=2 \
   --ntasks-per-node=1 \

--- a/tests/test_acceptance.py
+++ b/tests/test_acceptance.py
@@ -431,7 +431,6 @@ def test_req(request, slurm_system: SlurmSystem, partial_tr: partial[TestRun]) -
                 ),
                 cmd_args=AIDynamoCmdArgs(
                     docker_image_url="nvcr.io/nvidia/ai-dynamo:24.09",
-                    huggingface_home_host_path=Path.home() / ".cache/huggingface",
                     dynamo=AIDynamoArgs(
                         backend="vllm",
                         prefill_worker=PrefillWorkerArgs(

--- a/tests/test_slurm_system.py
+++ b/tests/test_slurm_system.py
@@ -657,3 +657,23 @@ def test_update(
 
         all_nodes_set = set([node for p in slurm_system.partitions for node in p.slurm_nodes])
         assert all_nodes_set == set(expected_nodes)
+
+
+class TestHfHomePath:
+    @pytest.fixture
+    def system_args(self, tmp_path: Path) -> dict:
+        return {
+            "name": "test_system",
+            "install_path": tmp_path / "install",
+            "output_path": tmp_path / "output",
+            "partitions": [],
+            "default_partition": "main",
+        }
+
+    def test_default(self, system_args: dict):
+        system = SlurmSystem(**system_args)
+        assert system.hf_home_path == system_args["install_path"] / "huggingface"
+
+    def test_custom(self, system_args: dict):
+        system = SlurmSystem(**system_args, hf_home_path=system_args["output_path"] / "custom")
+        assert system.hf_home_path == system_args["output_path"] / "custom"


### PR DESCRIPTION
## Summary
By default, `install_dir/huggingface` is used. Users can override it by specifying custom value.

AI Dynamo uses this value for mapping this folder into a container. Going further, CloudAI can take care about model download using HF CLI.

## Test Plan
1. CI (extended)
2. Manual runs

## Additional Notes
—

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installation validation to verify HuggingFace home directory accessibility before proceeding.

* **Refactor**
  * Unified HuggingFace home path management by centralizing configuration, removing redundant parameters and ensuring consistent model cache directory mounting across installation and container operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->