### PR TITLE
Add extra_srun_args on TestRun level

### DIFF
--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -74,6 +74,7 @@ class TestRun:
     pre_test: Optional[TestScenario] = None
     post_test: Optional[TestScenario] = None
     reports: Set[Type[ReportGenerationStrategy]] = field(default_factory=set)
+    extra_srun_args: str | None = None
 
     def __hash__(self) -> int:
         return hash(self.name + self.test.name + str(self.iterations) + str(self.current_iteration))

--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -78,6 +78,7 @@ class TestRunModel(BaseModel):
     ideal_perf: float = 1.0
     time_limit: Optional[str] = None
     dependencies: list[TestRunDependencyModel] = Field(default_factory=list)
+    extra_srun_args: str | None = None
 
     # test definition fields
     name: Optional[str] = None

--- a/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
+++ b/src/cloudai/systems/slurm/slurm_command_gen_strategy.py
@@ -257,6 +257,8 @@ class SlurmCommandGenStrategy(CommandGenStrategy):
 
         if self.system.extra_srun_args:
             srun_command_parts.append(self.system.extra_srun_args)
+        if self.test_run.extra_srun_args:
+            srun_command_parts.append(self.test_run.extra_srun_args)
 
         return srun_command_parts
 

--- a/src/cloudai/test_scenario_parser.py
+++ b/src/cloudai/test_scenario_parser.py
@@ -207,6 +207,7 @@ class TestScenarioParser:
             pre_test=pre_test,
             post_test=post_test,
             reports=get_reporters(test_info, tdef),
+            extra_srun_args=test_info.extra_srun_args,
         )
 
         return tr

--- a/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
+++ b/tests/slurm_command_gen_strategy/test_common_slurm_command_gen_strategy.py
@@ -323,6 +323,12 @@ def test_gen_srun_prefix_with_container_mount_home(
     assert ("--no-container-mount-home" in srun_prefix) is not container_mount_home
 
 
+def test_gen_srun_prefix_tr_extra_srun_args(strategy_fixture: SlurmCommandGenStrategy):
+    strategy_fixture.test_run.extra_srun_args = "--arg val --flag"
+    srun_prefix = strategy_fixture.gen_srun_prefix()
+    assert "--arg val --flag" in srun_prefix  # added as a single element
+
+
 def test_append_distribution_and_hostfile_with_nodes(strategy_fixture: SlurmCommandGenStrategy) -> None:
     strategy_fixture.system.distribution = "block"
     strategy_fixture.system.ntasks_per_node = 2


### PR DESCRIPTION
## Summary
The goal of this change is to provide extra flexibility for cases inside a single scenario. Some workloads requires extra argument for `srun`, but it was available only on System level, meaning, that such cases should run separately using different system configs. Even if the system is 100% the same.

With this change, users can define an extra srun arguments per case:
```toml
[[Tests]]
# ...
srun_extra_args = "--arg V1"

[[Tests]]
# ...
srun_extra_args = "--arg V2"
```

## Test Plan
1. CI (extended)
2. Manual run on EOS.

## Additional Notes
—


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying extra srun arguments at the test-run level, enabling granular control over Slurm command generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->