### PR TITLE
Ensure reports order

### DIFF
--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -223,6 +223,16 @@ class Registry(metaclass=Singleton):
         self.scenario_reports[name] = report
         self.report_configs[name] = config
 
+    def ordered_scenario_reports(self) -> list[tuple[str, type[Reporter]]]:
+        def report_order(k: str) -> int:
+            return {
+                "per_test": 0,  # first
+                "status": 2,
+                "tarball": 3,  # last
+            }.get(k, 1)
+
+        return sorted(self.scenario_reports.items(), key=lambda kv: report_order(kv[0]))
+
     def add_reward_function(self, name: str, value: RewardFunction) -> None:
         if name in self.reward_functions_map:
             raise ValueError(f"Duplicating implementation for '{name}', use 'update()' for replacement.")

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -169,8 +169,7 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
 def generate_reports(system: System, test_scenario: TestScenario, result_dir: Path) -> None:
     registry = Registry()
 
-    # Ensure "status" report goes last for better readability
-    for name, reporter_class in sorted(registry.scenario_reports.items(), key=lambda x: (x[0] == "status", x[0])):
+    for name, reporter_class in registry.ordered_scenario_reports():
         logging.debug(f"Generating report '{name}' ({reporter_class.__name__})")
 
         cfg = registry.report_configs.get(name, ReportConfig(enable=False))

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -288,3 +288,10 @@ class TestSlurmReportItem:
         meta = SlurmReportItem.get_metadata(run_dir, slurm_system.output_path)
         assert meta is not None
         assert meta.slurm.node_list == slurm_metadata.slurm.node_list
+
+
+def test_report_order() -> None:
+    reports = Registry().ordered_scenario_reports()
+    assert reports[0][0] == "per_test"
+    assert reports[-2][0] == "status"
+    assert reports[-1][0] == "tarball"


### PR DESCRIPTION
## Summary
Order should be: `[per_test, ..., status, tarball]`.

## Test Plan
1. CI (extended)
2. Manual runs

## Additional Notes
—