### PR TITLE
Rename field model_config to model_cfg in NIXLKVBench workload

### DIFF
--- a/src/cloudai/workloads/nixl_kvbench/nixl_kvbench.py
+++ b/src/cloudai/workloads/nixl_kvbench/nixl_kvbench.py
@@ -33,6 +33,9 @@ class NIXLKVBenchCmdArgs(CmdArgs):
     kvbench_script: str = "/workspace/nixl/benchmark/kvbench/main.py"
     python_executable: str = "python"
 
+    model_cfg: str | list[str] | None = None
+    """Path to model configuration file used by NIXL KVBench."""
+
     backend: str | list[str] | None = None
 
 
@@ -62,7 +65,7 @@ class NIXLKVBenchTestDefinition(TestDefinition):
                 "wait_etcd_for",
                 "docker_image_url",
                 "command",
-            }
+            },
         )
 
     def was_run_successful(self, tr: TestRun) -> JobStatusResult:

--- a/src/cloudai/workloads/nixl_kvbench/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/nixl_kvbench/slurm_command_gen_strategy.py
@@ -66,8 +66,14 @@ class NIXLKVBenchSlurmCommandGenStrategy(NIXLCmdGenBase):
             f"{self.tdef.cmd_args.kvbench_script}",
             self.tdef.cmd_args.command,
         ]
+
         for k, v in self.test_run.test.cmd_args_dict.items():
-            command.append(f"--{k} {v}")
+            if v is None:
+                continue
+
+            key = "model_config" if k == "model_cfg" else k
+
+            command.append(f"--{key} {v}")
 
         command.append("--etcd_endpoints http://$NIXL_ETCD_ENDPOINTS")
 


### PR DESCRIPTION
## Summary
Rename field model_config → model_cfg to avoid conflict with Pydantic's reserved attribute model_config.
This field specifies one or more configuration files defining model parameters for the NIXL KVBench benchmark.

## Test Plan
Tested dry-run mode with new field's name in configuration. 
Commands in `cloudai_sbatch_script.sh` are proper now.
