### PR TITLE
M-bridge Job ID extraction

### DIFF
--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -135,7 +135,8 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             # Parse job id from Megatron-Bridge output (multiple possible formats)
             "",
             'JOB_ID=""',
-            'JOB_ID=$(grep -Eio "Job id[: ]+[0-9]+" "$LOG" | tail -n1 | grep -Eo "[0-9]+" | tail -n1 || true)',
+            'JOB_ID=$(grep -Eio "Job[[:space:]]+id[: ]+[0-9]+" "$LOG" | '
+            'tail -n1 | grep -Eo "[0-9]+" | tail -n1 || true)',
             "",
             # Emit a canonical line for CloudAI to parse
             "",


### PR DESCRIPTION
## Summary
Currently M-Bridge relies on Nemo-Run for slurm execution. While installing Nemo-Run, we point it to main. There has been slight modification in how the Job ID is directed at stdout. We now support the following variations to make it robust to extract the job ID. Without this, it might seems like its a CloudAI Bug.

```
Job id: 694112 (original format)
- Job id: 694112 (NeMo Run format with dash)
Job ID: 694112 (uppercase ID variant)
With varying amounts of whitespace
```


## Test Plan
* CI/CD
* real cluster

## Additional Notes

