### PR TITLE
Continuously fetch logs for NCCL over k8s

### DIFF
--- a/src/cloudai/systems/kubernetes/kubernetes_system.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_system.py
@@ -168,11 +168,11 @@ class KubernetesSystem(System):
             conditions = status.get("conditions", [])
             logging.debug(f"MPIJob '{job.name}': {conditions=} {status=}")
 
+            self.store_logs_for_job(job.name, job.test_run.output_path)
+
             # Consider an empty conditions list as running
             if not conditions:
                 return True
-
-            self.store_logs_for_job(job.name, job.test_run.output_path)
 
             for condition in conditions:
                 if condition["type"] == "Succeeded" and condition["status"] == "True":


### PR DESCRIPTION
## Summary
Continuously fetch logs for NCCL over k8s to avoid cases when launcher is already removed but logs were not yet collected.

Addresses [internal issue](https://redmine.mellanox.com/issues/4852431).

## Test Plan
1. CI
2. Manual runs.

## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
