### PR TITLE
Single sbatch + NIXL + ETCD issues

### DIFF
--- a/src/cloudai/workloads/common/nixl.py
+++ b/src/cloudai/workloads/common/nixl.py
@@ -79,13 +79,18 @@ class NIXLCmdGenBase(SlurmCommandGenStrategy):
         return cmd
 
     def gen_kill_and_wait_cmd(self, pid_var: str, timeout: int = 60) -> list[str]:
-        return [
+        cmd = [
             f"kill -TERM ${pid_var}\n",
-            f"timeout {timeout} wait ${pid_var} || {{\n",
+            "timeout",
+            str(timeout),
+            "bash",
+            "-c",
+            f'"while kill -0 ${pid_var} 2>/dev/null; do sleep 1; done" || {{\n',
             f'  echo "Failed to kill ETCD (pid=${pid_var}) within {timeout} seconds";\n',
             "  exit 1\n",
-            "}\n",
+            "}",
         ]
+        return cmd
 
     def gen_nixlbench_srun_commands(self, test_cmd: list[str], backend: str) -> list[list[str]]:
         prefix_part = self.gen_srun_prefix(with_num_nodes=False)

--- a/tests/ref_data/nixl-kvbench.sbatch
+++ b/tests/ref_data/nixl-kvbench.sbatch
@@ -26,7 +26,7 @@ srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mo
 sleep 15
 srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=1 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS"
 kill -TERM $etcd_pid
- timeout 60 wait $etcd_pid || {
+ timeout 60 bash -c "while kill -0 $etcd_pid 2>/dev/null; do sleep 1; done" || {
    echo "Failed to kill ETCD (pid=$etcd_pid) within 60 seconds";
    exit 1
  }

--- a/tests/ref_data/nixl-perftest.sbatch
+++ b/tests/ref_data/nixl-perftest.sbatch
@@ -25,7 +25,7 @@ timeout 60 bash -c "until curl -s $NIXL_ETCD_ENDPOINTS/health > /dev/null 2>&1; 
  }
 srun --export=ALL --mpi=pmix -N1 --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap bash -c "source __OUTPUT_DIR__/output/env_vars.sh;  python /workspace/nixl/benchmark/kvbench/main.py sequential-ct-perftest __OUTPUT_DIR__/output/matrices/metadata.yaml --json-output-path=__OUTPUT_DIR__/output/results.json "
 kill -TERM $etcd_pid
- timeout 60 wait $etcd_pid || {
+ timeout 60 bash -c "while kill -0 $etcd_pid 2>/dev/null; do sleep 1; done" || {
    echo "Failed to kill ETCD (pid=$etcd_pid) within 60 seconds";
    exit 1
  }

--- a/tests/ref_data/nixl_bench.sbatch
+++ b/tests/ref_data/nixl_bench.sbatch
@@ -26,7 +26,7 @@ srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-moun
 sleep 15
 srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=1 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ./nixlbench --etcd-endpoints http://$NIXL_ETCD_ENDPOINTS --backend UCX"
 kill -TERM $etcd_pid
- timeout 60 wait $etcd_pid || {
+ timeout 60 bash -c "while kill -0 $etcd_pid 2>/dev/null; do sleep 1; done" || {
    echo "Failed to kill ETCD (pid=$etcd_pid) within 60 seconds";
    exit 1
  }

--- a/tests/workloads/nixl_bench/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/nixl_bench/test_command_gen_strategy_slurm.py
@@ -137,3 +137,19 @@ def test_gen_srun_command(nixl_bench_tr: TestRun, slurm_system: SlurmSystem):
         "  exit 1\n",
         "}",
     ]
+
+
+def test_gen_kill_and_wait_cmd(nixl_bench_tr: TestRun, slurm_system: SlurmSystem) -> None:
+    strategy = NIXLBenchSlurmCommandGenStrategy(slurm_system, nixl_bench_tr)
+    cmd = strategy.gen_kill_and_wait_cmd("PID", timeout=120)
+    assert cmd == [
+        "kill -TERM $PID\n",
+        "timeout",
+        "120",
+        "bash",
+        "-c",
+        '"while kill -0 $PID 2>/dev/null; do sleep 1; done" || {\n',
+        '  echo "Failed to kill ETCD (pid=$PID) within 120 seconds";\n',
+        "  exit 1\n",
+        "}",
+    ]


### PR DESCRIPTION
## Summary
Fixes CLOUDAI-18. Now the ETCD process is gracefully terminated. 

* It was: 

    1. `SIGKILL` sent to the srun process and killed instantly (local srun process, not the actual one on the compute node). 
    2. It takes a few moments until slurm detects it and starts to kill the actuall ETCD process on the compute node. 
    3. However our wait mechanism didn't work because the local srun process was already dead (pid doesn't exist)

* Now: 

    1. `SIGTERM` is sent. So that the local `srun` process sends the signal to the slurm scheduler
    2. Slurm scheduler starts killing the etcd on the compute node (local `srun` is still alive - pid exists - our wait works)
    3. After slurm finishes killing ETCD, it kills the local `srun` and our wait mechanism releases

## Test Plan
Reproduced the issue according to the description in the base redmine ticket. After that applied the fix and executed a few times - no failures spotted.

## Additional Notes

