### PR TITLE
Do not run CommandShell check during object creation

### DIFF
--- a/src/cloudai/systems/slurm/slurm_system.py
+++ b/src/cloudai/systems/slurm/slurm_system.py
@@ -106,7 +106,7 @@ class SlurmSystem(System):
     cache_docker_images_locally: bool = False
     scheduler: str = "slurm"
     monitor_interval: int = 60
-    cmd_shell: CommandShell = Field(default=CommandShell(), exclude=True)
+    cmd_shell: CommandShell = Field(default_factory=CommandShell, exclude=True)
     extra_srun_args: Optional[str] = None
     extra_sbatch_args: list[str] = Field(default_factory=list)
     supports_gpu_directives_cache: Optional[bool] = Field(default=None, exclude=True)

--- a/src/cloudai/util/command_shell.py
+++ b/src/cloudai/util/command_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024, 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,32 +27,14 @@ class CommandShell:
     """
 
     def __init__(self, executable: Path = Path("/bin/bash")):
-        """
-        Initialize the CommandShell with a shell executable.
-
-        Args:
-            executable (Path): The shell executable path. Defaults to Path("/bin/bash").
-
-        Raises:
-            FileNotFoundError: If the specified executable does not exist.
-        """
-        if not executable.exists():
-            raise FileNotFoundError(f"Executable '{executable}' not found.")
+        """Initialize the CommandShell with a shell executable."""
         self.executable = executable
 
     def execute(self, command: str) -> subprocess.Popen:
-        """
-        Execute a shell command and return its process.
+        """Execute a shell command and return its process."""
+        if not self.executable.exists():
+            raise FileNotFoundError(f"Executable '{self.executable}' not found.")
 
-        Args:
-            command (str): The command to be executed.
-
-        Returns:
-            subprocess.Popen: The process object for the executed command.
-
-        Raises:
-            subprocess.CalledProcessError: If command execution fails.
-        """
         process = subprocess.Popen(
             command,
             shell=True,


### PR DESCRIPTION
## Summary
Do not run CommandShell check during object creation. That addresses issue with building documentation on Windows.

## Test Plan
1. CI
2. Docs build on Windows.

## Additional Notes
Re-created as a replacement for #841 .