### PR TITLE
feat: add DockerURL type to fix cache_docker_images_locally=false

### DIFF
--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -21,6 +21,8 @@ from typing import Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 
+from cloudai._core.types import DockerURL
+
 
 class Installable(ABC):
     """Installable object."""
@@ -73,11 +75,20 @@ class DockerImage(Installable):
         return f"{img_name}__{tag}.sqsh"
 
     @property
-    def installed_path(self) -> Union[str, Path]:
-        """Return the cached path or URL of the docker image."""
+    def installed_path(self) -> Union[DockerURL, Path]:
+        """
+        Return the cached path or URL of the docker image.
+
+        Returns:
+            Path: Local .sqsh file path (when cached locally)
+            DockerURL: Registry URL (when not cached, pyxis pulls from registry)
+
+        Downstream code should check isinstance(result, Path) vs isinstance(result, DockerURL)
+        to determine how to handle the value. Do NOT call Path().absolute() on DockerURL.
+        """
         if self._installed_path:
             return self._installed_path.absolute() if isinstance(self._installed_path, Path) else self._installed_path
-        return self.url
+        return DockerURL(self.url)
 
     @installed_path.setter
     def installed_path(self, value: Union[str, Path]) -> None:

--- a/src/cloudai/_core/types.py
+++ b/src/cloudai/_core/types.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom types for CloudAI."""
+
+
+class DockerURL(str):
+    """
+    Docker registry URL - not a filesystem path.
+
+    This type distinguishes docker registry URLs from local filesystem paths.
+    Downstream code should check isinstance(value, DockerURL) to determine
+    if the value is a URL (pass directly to pyxis) vs a Path (local .sqsh file).
+
+    Examples:
+        - "nvcr.io/nvidian/nemo:26.04.rc2"
+        - "docker://nvcr.io/nvidian/nemo:26.04.rc2"
+        - "docker.io/library/ubuntu:22.04"
+    """
+
+    pass

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -269,7 +269,10 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                         "(docker_image.installed_path is empty). Please run `cloudai install` first, or provide "
                         "a valid local .sqsh path in cmd_args.container_image."
                     )
-                return str(Path(installed).absolute())
+                if isinstance(installed, Path):
+                    return str(installed.absolute())
+                # DockerURL - pass directly to pyxis (it will pull from registry)
+                return str(installed)
 
             ci = str(args.container_image).strip()
             if ci.startswith("/") or ci.startswith("."):

--- a/tests/test_cache_docker_images_locally_false.py
+++ b/tests/test_cache_docker_images_locally_false.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test case: cache_docker_images_locally = false with DockerURL type.
+
+When cache_docker_images_locally=false in system TOML:
+1. cloudai install doesn't set DockerImage._installed_path
+2. DockerImage.installed_path returns DockerURL(self.url)
+3. slurm_command_gen_strategy.py checks isinstance(installed, Path) vs DockerURL
+4. DockerURL is passed directly to pyxis (it pulls from registry)
+
+The fix uses a custom DockerURL type to distinguish URLs from Paths.
+"""
+
+from pathlib import Path
+
+from cloudai._core.installables import DockerImage
+from cloudai._core.types import DockerURL
+
+
+class TestCacheDockerImagesLocallyFalse:
+    """Test cases for cache_docker_images_locally=false with DockerURL type."""
+
+    def test_installed_path_returns_docker_url_when_not_cached(self):
+        """When _installed_path is None, installed_path returns a DockerURL."""
+        docker_url = "nvcr.io/nvidian/nemo:26.04.rc2"
+        img = DockerImage(url=docker_url)
+        
+        assert img._installed_path is None, "Precondition: _installed_path should be None"
+        
+        result = img.installed_path
+        
+        # Returns DockerURL type (not plain str)
+        assert isinstance(result, DockerURL), f"Expected DockerURL, got {type(result)}"
+        assert result == docker_url
+
+    def test_installed_path_returns_path_when_cached(self):
+        """When _installed_path is set, installed_path returns a Path."""
+        docker_url = "nvcr.io/nvidian/nemo:26.04.rc2"
+        sqsh_path = Path("/install/nvcr.io_nvidian__nemo__26.04.rc2.sqsh")
+        
+        img = DockerImage(url=docker_url)
+        img.installed_path = sqsh_path
+        
+        result = img.installed_path
+        
+        # Returns Path type (not DockerURL)
+        assert isinstance(result, Path), f"Expected Path, got {type(result)}"
+        assert result == sqsh_path.absolute()
+
+    def test_docker_url_is_subclass_of_str(self):
+        """DockerURL is a str subclass, so it works with string operations."""
+        url = DockerURL("nvcr.io/nvidian/nemo:26.04.rc2")
+        
+        assert isinstance(url, str)
+        assert isinstance(url, DockerURL)
+        assert "nvcr.io" in url
+        assert url.startswith("nvcr.io")
+
+    def test_type_check_distinguishes_url_from_path(self):
+        """isinstance() can distinguish DockerURL from Path."""
+        docker_url = "nvcr.io/nvidian/nemo:26.04.rc2"
+        img = DockerImage(url=docker_url)
+        
+        # Not cached - returns DockerURL
+        result_uncached = img.installed_path
+        assert isinstance(result_uncached, DockerURL)
+        assert not isinstance(result_uncached, Path)
+        
+        # Cached - returns Path
+        img.installed_path = Path("/install/image.sqsh")
+        result_cached = img.installed_path
+        assert isinstance(result_cached, Path)
+        assert not isinstance(result_cached, DockerURL)
+
+    def test_container_path_resolution_logic(self):
+        """
+        Test the correct container path resolution logic.
+        
+        This is what slurm_command_gen_strategy.py should do:
+        - Path: call .absolute() and convert to str
+        - DockerURL: pass directly as str
+        """
+        def resolve_container_path(installed) -> str:
+            if isinstance(installed, Path):
+                return str(installed.absolute())
+            # DockerURL - pass directly to pyxis
+            return str(installed)
+        
+        # DockerURL case
+        url_result = resolve_container_path(DockerURL("nvcr.io/nvidian/nemo:26.04.rc2"))
+        assert url_result == "nvcr.io/nvidian/nemo:26.04.rc2"
+        assert not url_result.startswith("/")  # Not mangled into a local path
+        
+        # Path case
+        path_result = resolve_container_path(Path("/install/image.sqsh"))
+        assert path_result == "/install/image.sqsh"
+
+    def test_cache_filename_generation(self):
+        """Verify cache filename is correctly generated from docker URL."""
+        docker_url = "nvcr.io/nvidian/nemo:26.04.rc2"
+        img = DockerImage(url=docker_url)
+        
+        expected = "nvcr.io_nvidian__nemo__26.04.rc2.sqsh"
+        assert img.cache_filename == expected


### PR DESCRIPTION
## Summary

This PR fixes container path resolution when `cache_docker_images_locally=false` is set in the system TOML configuration.

**Problem:**
When `cache_docker_images_locally=false`, the `DockerImage.installed_path` property returns the raw Docker URL (e.g., `nvcr.io/nvidian/nemo:26.04.rc2`). Downstream code in `slurm_command_gen_strategy.py` then calls `Path(url).absolute()` on this URL, which incorrectly converts it to a bogus local filesystem path like `/current/working/dir/nvcr.io/nvidian/nemo:26.04.rc2`. Pyxis then fails with "No such file or directory" because this path doesn't exist.

**Solution:**
- Introduce a `DockerURL(str)` type in `_core/types.py` to semantically distinguish Docker registry URLs from filesystem paths
- Update `DockerImage.installed_path` to return `DockerURL` when the image is not cached locally
- Update `slurm_command_gen_strategy.py` to check `isinstance(installed, Path)` before calling `.absolute()`, passing `DockerURL` values directly to pyxis

This allows pyxis to correctly receive the Docker URL and pull the image from the registry at runtime.

**Related Issue:** #850

## Test Plan

**Testing Environment:**
- EOS cluster with Slurm scheduler
- Container: `nvcr.io/nvidian/nemo:26.04.rc2`
- System config: `cache_docker_images_locally` not set (defaults to `false`)

**Steps:**
1. Ran unit tests locally:
   ```bash
   uv run python -m pytest tests/test_cache_docker_images_locally_false.py -v
   ```
   Output: 6 passed

2. Deployed to EOS and ran Megatron-Bridge workload:
   ```bash
   cloudaix run --system-config eos.toml --test-scenario qwen3_235b_...toml
   ```

3. Verified sbatch script contains correct container image:
   ```
   --container-image nvcr.io/nvidian/nemo:26.04.rc2
   ```
   (URL passed directly, not mangled into a local path)

4. Verified pyxis successfully imported the image:
   ```
   pyxis: imported docker image: nvcr.io/nvidian/nemo:26.04.rc2
   ```

5. Training started successfully:
   ```
   Starting training loop at iteration 0
   [2026-03-25 18:32:28] iteration 1/10 | lm loss: 1.275077E+01 | elapsed: 83974ms
   [2026-03-25 18:32:53] iteration 2/10 | lm loss: 1.275050E+01 | elapsed: 24361ms
   ```

## Additional Notes

- The `DockerURL` type is a simple `str` subclass, maintaining full backward compatibility with string operations
- The type check uses `isinstance(installed, Path)` which is more robust than string pattern matching
- This fix only affects the Megatron-Bridge workload's command generation; other workloads may need similar updates if they use `docker_image.installed_path`
- Future consideration: The related issue #850 discusses broader design concerns with `[[git_repos]]` and `mount_as` creating version mismatches