### PR TITLE
Installables: nested docker image path

### DIFF
--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -54,24 +54,24 @@ class DockerImage(Installable):
     @property
     def cache_filename(self) -> str:
         """Return the cache filename for the docker image."""
-        reference = self.url.split("://", maxsplit=1)[-1]
-        tag = "notag"
-
-        if reference.startswith(("/", ".")):
-            image_name = Path(reference).name
-            if ":" in reference:
-                image_name, tag = image_name.rsplit(":", maxsplit=1)
+        tag, wo_prefix = "notag", self.url
+        is_local = wo_prefix.startswith("/") or wo_prefix.startswith(".")
+        if "://" in wo_prefix:
+            wo_prefix = self.url.split("://", maxsplit=1)[1]
+        if ":" in wo_prefix:
+            tag = wo_prefix.rsplit(":", maxsplit=1)[1]
+        wo_tag = wo_prefix.rsplit(":", maxsplit=1)[0]
+        if is_local:
+            img_name = wo_tag.rsplit("/", maxsplit=1)[1]
         else:
-            # Remote image url
-            parts = reference.replace("#", "/").split("/")
+            parts = wo_tag.split("/")
+            img_name = "_".join(parts[:-1]) + "__" + parts[-1]
 
-            last_part = parts[-1]
-            if ":" in last_part:
-                parts[-1], tag = last_part.rsplit(":", maxsplit=1)
+        # Replace # with _ in img_name to avoid filesystem issues
+        img_name = img_name.replace("#", "_")
 
-            image_name = "_".join(parts[:-1]) + "__" + parts[-1]
-
-        return f"{image_name.replace('#', '_').replace(':', '_')}__{tag}.sqsh"
+        path = f"{img_name}__{tag}.sqsh"
+        return path.replace("/", "_").replace("#", "_").strip("_")
 
     @property
     def installed_path(self) -> Union[str, Path]:

--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -53,31 +53,14 @@ class DockerImage(Installable):
 
     @property
     def cache_filename(self) -> str:
-        """
-        Return the cache filename for the docker image.
-
-        Examples::
-
-            DockerImage("nvcr.io#nvidia/pytorch:24.02-py3").cache_filename
-            # "nvcr.io_nvidia__pytorch__24.02-py3.sqsh"
-
-            DockerImage("registry.example.com:5000#group/project").cache_filename
-            # "registry.example.com_5000_group__project__notag.sqsh"
-
-            DockerImage("/local/cache/image.sqsh").cache_filename
-            # "image.sqsh__notag.sqsh"
-        """
+        """Return the cache filename for the docker image."""
         reference = self.url.split("://", maxsplit=1)[-1]
         tag = "notag"
 
-        if reference.startswith("/") or reference.startswith("."):
-            # Local image file
-            image_ref = reference
+        if reference.startswith(("/", ".")):
+            image_name = Path(reference).name
             if ":" in reference:
-                image_ref, tag = reference.rsplit(":", maxsplit=1)
-
-            # /local/disk/file.sqsh -> file
-            image_name = image_ref.rsplit("/", maxsplit=1)[-1]
+                image_name, tag = image_name.rsplit(":", maxsplit=1)
         else:
             # Remote image url
             parts = reference.replace("#", "/").split("/")

--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -58,17 +58,21 @@ class DockerImage(Installable):
         is_local = wo_prefix.startswith("/") or wo_prefix.startswith(".")
         if "://" in wo_prefix:
             wo_prefix = self.url.split("://", maxsplit=1)[1]
-        if ":" in wo_prefix:
-            tag = wo_prefix.rsplit(":", maxsplit=1)[1]
-        wo_tag = wo_prefix.rsplit(":", maxsplit=1)[0]
         if is_local:
+            if ":" in wo_prefix:
+                tag = wo_prefix.rsplit(":", maxsplit=1)[1]
+                wo_prefix = wo_prefix.rsplit(":", maxsplit=1)[0]
+            wo_tag = wo_prefix
             img_name = wo_tag.rsplit("/", maxsplit=1)[1]
         else:
-            parts = wo_tag.split("/")
+            normalized_url = wo_prefix.replace("#", "/")
+            parts = normalized_url.split("/")
+            if ":" in parts[-1]:
+                parts[-1], tag = parts[-1].rsplit(":", maxsplit=1)
             img_name = "_".join(parts[:-1]) + "__" + parts[-1]
 
-        # Replace # with _ in img_name to avoid filesystem issues
-        img_name = img_name.replace("#", "_")
+        # Normalize separators and registry ports so the cache key is always a filename, not a path.
+        img_name = img_name.replace("#", "_").replace(":", "_")
 
         return f"{img_name}__{tag}.sqsh"
 

--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -53,28 +53,42 @@ class DockerImage(Installable):
 
     @property
     def cache_filename(self) -> str:
-        """Return the cache filename for the docker image."""
-        tag, wo_prefix = "notag", self.url
-        is_local = wo_prefix.startswith("/") or wo_prefix.startswith(".")
-        if "://" in wo_prefix:
-            wo_prefix = self.url.split("://", maxsplit=1)[1]
-        if is_local:
-            if ":" in wo_prefix:
-                tag = wo_prefix.rsplit(":", maxsplit=1)[1]
-                wo_prefix = wo_prefix.rsplit(":", maxsplit=1)[0]
-            wo_tag = wo_prefix
-            img_name = wo_tag.rsplit("/", maxsplit=1)[1]
+        """
+        Return the cache filename for the docker image.
+
+        Examples::
+
+            DockerImage("nvcr.io#nvidia/pytorch:24.02-py3").cache_filename
+            # "nvcr.io_nvidia__pytorch__24.02-py3.sqsh"
+
+            DockerImage("registry.example.com:5000#group/project").cache_filename
+            # "registry.example.com_5000_group__project__notag.sqsh"
+
+            DockerImage("/local/cache/image.sqsh").cache_filename
+            # "image.sqsh__notag.sqsh"
+        """
+        reference = self.url.split("://", maxsplit=1)[-1]
+        tag = "notag"
+
+        if reference.startswith("/") or reference.startswith("."):
+            # Local image file
+            image_ref = reference
+            if ":" in reference:
+                image_ref, tag = reference.rsplit(":", maxsplit=1)
+
+            # /local/disk/file.sqsh -> file
+            image_name = image_ref.rsplit("/", maxsplit=1)[-1]
         else:
-            normalized_url = wo_prefix.replace("#", "/")
-            parts = normalized_url.split("/")
-            if ":" in parts[-1]:
-                parts[-1], tag = parts[-1].rsplit(":", maxsplit=1)
-            img_name = "_".join(parts[:-1]) + "__" + parts[-1]
+            # Remote image url
+            parts = reference.replace("#", "/").split("/")
 
-        # Normalize separators and registry ports so the cache key is always a filename, not a path.
-        img_name = img_name.replace("#", "_").replace(":", "_")
+            last_part = parts[-1]
+            if ":" in last_part:
+                parts[-1], tag = last_part.rsplit(":", maxsplit=1)
 
-        return f"{img_name}__{tag}.sqsh"
+            image_name = "_".join(parts[:-1]) + "__" + parts[-1]
+
+        return f"{image_name.replace('#', '_').replace(':', '_')}__{tag}.sqsh"
 
     @property
     def installed_path(self) -> Union[str, Path]:

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -148,6 +148,9 @@ class TestBaseInstaller:
         ("nvcr.io#nvidia/pytorch:24.02-py3", "nvcr.io_nvidia__pytorch__24.02-py3.sqsh"),
         ("/local/disk/file", "file__notag.sqsh"),
         ("gitlab.com#org/team/image:latest", "gitlab.com_org_team__image__latest.sqsh"),
+        ("registry.example.com:5000#group/project", "registry.example.com_5000_group__project__notag.sqsh"),
+        ("registry.example.com:5000#group/project:latest", "registry.example.com_5000_group__project__latest.sqsh"),
+        ("gitlab-master.nvidia.com:5005#abc/def/g-h.i", "gitlab-master.nvidia.com_5005_abc_def__g-h.i__notag.sqsh"),
     ],
 )
 def test_docker_cache_filename(url: str, expected: str):

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -150,9 +150,10 @@ class TestBaseInstaller:
         ("/local/disk/file:tag", "file__tag.sqsh"),
         ("./local/disk/file:tag", "file__tag.sqsh"),
         ("gitlab.com#org/team/image:latest", "gitlab.com_org_team__image__latest.sqsh"),
-        ("registry.example.com:5000#group/project", "registry.example.com_5000_group__project__notag.sqsh"),
-        ("registry.example.com:5000#group/project:latest", "registry.example.com_5000_group__project__latest.sqsh"),
-        ("gitlab-master.nvidia.com:5005#abc/def/g-h.i", "gitlab-master.nvidia.com_5005_abc_def__g-h.i__notag.sqsh"),
+        ("registry.example.com:5000#group/project", "registry.example.com__5000_group_project.sqsh"),
+        ("registry.example.com:5000#group/project:latest", "registry.example.com:5000_group__project__latest.sqsh"),
+        ("gitlab-master.nvidia.com:5005#abc/def/g-h.i", "gitlab-master.nvidia.com__5005_abc_def_g-h.i.sqsh"),
+        ("nvcr.io/nvidia#nemo:24.07", "nvcr.io__nvidia_nemo__24.07.sqsh"),
     ],
 )
 def test_docker_cache_filename(url: str, expected: str):

--- a/tests/test_base_installer.py
+++ b/tests/test_base_installer.py
@@ -147,6 +147,8 @@ class TestBaseInstaller:
         ("http://fake_url/img", "fake_url__img__notag.sqsh"),
         ("nvcr.io#nvidia/pytorch:24.02-py3", "nvcr.io_nvidia__pytorch__24.02-py3.sqsh"),
         ("/local/disk/file", "file__notag.sqsh"),
+        ("/local/disk/file:tag", "file__tag.sqsh"),
+        ("./local/disk/file:tag", "file__tag.sqsh"),
         ("gitlab.com#org/team/image:latest", "gitlab.com_org_team__image__latest.sqsh"),
         ("registry.example.com:5000#group/project", "registry.example.com_5000_group__project__notag.sqsh"),
         ("registry.example.com:5000#group/project:latest", "registry.example.com_5000_group__project__latest.sqsh"),


### PR DESCRIPTION
## Summary
The generated path or complicated docker image URLs was nested (relatively to install dir) - intermediate dirs were not created thus installation failed

The PR makes sure docker image URLs always resolve into file names, not paths

## Test Plan
- Automated CI
- Manual run with suggested docker image url

## Additional Notes
- Fixes P1 Redmine [ticket](https://redmine.mellanox.com/issues/4958163)
