### PR TITLE
MBridge: revert metrics parsing

### DIFF
--- a/src/cloudai/workloads/megatron_bridge/__init__.py
+++ b/src/cloudai/workloads/megatron_bridge/__init__.py
@@ -14,12 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .megatron_bridge import GOLDEN_VALUES_FILENAME, MegatronBridgeCmdArgs, MegatronBridgeTestDefinition
+from .megatron_bridge import MegatronBridgeCmdArgs, MegatronBridgeTestDefinition
 from .report_generation_strategy import MegatronBridgeReportGenerationStrategy
 from .slurm_command_gen_strategy import MegatronBridgeSlurmCommandGenStrategy
 
 __all__ = [
-    "GOLDEN_VALUES_FILENAME",
     "MegatronBridgeCmdArgs",
     "MegatronBridgeReportGenerationStrategy",
     "MegatronBridgeSlurmCommandGenStrategy",

--- a/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
+++ b/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
@@ -16,14 +16,13 @@
 
 import logging
 import os
+import re
 from typing import List, Optional, Union, cast
 
 from pydantic import Field, ValidationInfo, field_validator
 
 from cloudai.core import DockerImage, GitRepo, Installable, JobStatusResult, PythonExecutable, System, TestRun
 from cloudai.models.workload import CmdArgs, TestDefinition
-
-GOLDEN_VALUES_FILENAME = "cloudai_megatron_bridge_golden_values.json"
 
 
 class MegatronBridgeCmdArgs(CmdArgs):
@@ -571,9 +570,32 @@ class MegatronBridgeTestDefinition(TestDefinition):
                 error_message=f"Megatron-Bridge launcher log not found in {tr.output_path}.",
             )
 
-        content = log_path.read_text(encoding="utf-8", errors="ignore")
+        log_data = log_path.read_text(encoding="utf-8", errors="ignore")
+        step_times_s, _ = extract_mbridge_metrics(log_data)
+        if not step_times_s:
+            return JobStatusResult(is_successful=False, error_message="\n".join(log_data.splitlines()[-40:]))
 
-        if "Convergence check failed due to missing golden values." in content:
-            return JobStatusResult(is_successful=True)
+        return JobStatusResult(is_successful=True)
 
-        return JobStatusResult(is_successful=False, error_message="\n".join(content.splitlines()[-40:]))
+
+def extract_mbridge_metrics(logs: str) -> tuple[list[float], list[float]]:
+    step_times_s: list[float] = []
+    gpu_tflops: list[float] = []
+    step_line_re = re.compile(
+        r"Step Time\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*s.*?"
+        r"GPU utilization:\s*([0-9]+(?:\.[0-9]+)?)\s*(?:MODEL_)?TFLOP/s/GPU",
+        re.IGNORECASE,
+    )
+    for line in logs.splitlines():
+        m = step_line_re.search(line)
+        if m:
+            try:
+                step_times_s.append(float(m.group(1)))
+                gpu_tflops.append(float(m.group(2)))
+            except (ValueError, TypeError):
+                logging.debug("Failed to parse step metrics line: %s", line.rstrip("\n"))
+
+    if len(step_times_s) > 10:
+        step_times_s = step_times_s[-10:]
+        gpu_tflops = gpu_tflops[-10:]
+    return step_times_s, gpu_tflops

--- a/src/cloudai/workloads/megatron_bridge/report_generation_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/report_generation_strategy.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 from pathlib import Path
 from statistics import mean, median, pstdev
@@ -21,55 +20,37 @@ from typing import ClassVar
 
 from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
 
-from .megatron_bridge import GOLDEN_VALUES_FILENAME
+from .megatron_bridge import extract_mbridge_metrics
 
 
 class MegatronBridgeReportGenerationStrategy(ReportGenerationStrategy):
-    """Parse Megatron-Bridge JSON metrics file for step time and GPU TFLOP/s per GPU."""
+    """Parse Megatron-Bridge logs for step time and GPU TFLOP/s per GPU."""
 
     metrics: ClassVar[list[str]] = ["default", "step-time", "tflops-per-gpu"]
 
+    def get_log_file(self) -> Path | None:
+        log = self.test_run.output_path / "cloudai_megatron_bridge_launcher.log"
+        return log if log.is_file() else None
+
     @property
-    def metrics_file(self) -> Path | None:
-        for path in Path(self.test_run.output_path).rglob(GOLDEN_VALUES_FILENAME):
-            return path
-        return None
+    def results_file(self) -> Path:
+        return self.get_log_file() or (self.test_run.output_path / "cloudai_megatron_bridge_launcher.log")
 
     def can_handle_directory(self) -> bool:
-        return self.metrics_file is not None
-
-    def _extract(self, metrics_file: Path) -> tuple[list[float], list[float]]:
-        try:
-            data: dict[str, dict[str, float]] = json.loads(metrics_file.read_text())
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Corrupted JSON metrics file at {metrics_file}") from e
-
-        data = {k: v for k, v in data.items() if k.isdigit()}
-        steps = sorted(list(map(int, data.keys())))
-
-        try:
-            step_times_s: list[float] = [data[str(step)]["elapsed time per iteration (ms)"] / 1000.0 for step in steps]
-            # despite the metric is named GPU utilization, it's actually TFLOP/s per GPU
-            gpu_tflops: list[float] = [data[str(step)]["GPU utilization"] for step in steps]
-        except (KeyError, AttributeError, TypeError) as e:
-            raise ValueError(f"Cannot parse JSON metrics file at {metrics_file} with {e}") from e
-
-        if len(step_times_s) > 10:
-            step_times_s = step_times_s[-10:]
-            gpu_tflops = gpu_tflops[-10:]
-
-        return step_times_s, gpu_tflops
+        return self.get_log_file() is not None
 
     def _get_extracted_data(self) -> tuple[Path | None, list[float], list[float]]:
-        metrics_file = self.metrics_file
-        if not metrics_file:
+        log_file = self.get_log_file()
+        if not log_file:
             return None, [], []
-        step_times_s, gpu_tflops = self._extract(metrics_file)
-        return metrics_file, step_times_s, gpu_tflops
+
+        log_data = log_file.read_text(encoding="utf-8", errors="ignore")
+        step_times_s, gpu_tflops = extract_mbridge_metrics(log_data)
+        return log_file, step_times_s, gpu_tflops
 
     def generate_report(self) -> None:
-        metrics_file, step_times_s, gpu_tflops = self._get_extracted_data()
-        if not metrics_file:
+        log_file, step_times_s, gpu_tflops = self._get_extracted_data()
+        if not log_file:
             logging.error(
                 "No Megatron-Bridge launcher log file found in: %s",
                 self.test_run.output_path,
@@ -80,9 +61,9 @@ class MegatronBridgeReportGenerationStrategy(ReportGenerationStrategy):
         if not step_times_s:
             with summary_file.open("w") as f:
                 f.write("MegatronBridge report\n")
-                f.write("No metrics were found.\n\n")
+                f.write("No 'Step Time' / 'GPU utilization' lines were found.\n\n")
                 f.write("Searched file:\n")
-                f.write(f"  - {metrics_file}\n")
+                f.write(f"  - {log_file}\n")
             logging.warning("No step metrics found under %s (wrote %s)", self.test_run.output_path, summary_file)
             return
 
@@ -105,7 +86,7 @@ class MegatronBridgeReportGenerationStrategy(ReportGenerationStrategy):
             tflops_stats = {"avg": 0.0, "median": 0.0, "min": 0.0, "max": 0.0, "std": 0.0}
 
         with summary_file.open("w") as f:
-            f.write(f"Source log: {metrics_file}\n\n")
+            f.write(f"Source log: {log_file}\n\n")
             f.write("Step Time (s)\n")
             f.write(f"  avg: {step_stats['avg']}\n")
             f.write(f"  median: {step_stats['median']}\n")
@@ -123,10 +104,10 @@ class MegatronBridgeReportGenerationStrategy(ReportGenerationStrategy):
     def get_metric(self, metric: str) -> float:
         if metric not in {"default", "step-time", "tflops-per-gpu"}:
             return METRIC_ERROR
-        metrics_file, step_times_s, gpu_tflops = self._get_extracted_data()
-        if not metrics_file:
+        log_file, step_times_s, gpu_tflops = self._get_extracted_data()
+        if not log_file:
             logging.error(
-                "No Megatron-Bridge launcher metrics file found in: %s",
+                "No Megatron-Bridge launcher log file found in: %s",
                 self.test_run.output_path,
             )
             return METRIC_ERROR

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -27,7 +27,7 @@ import toml
 from cloudai.models.scenario import TestRunDetails
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
-from .megatron_bridge import GOLDEN_VALUES_FILENAME, MegatronBridgeCmdArgs, MegatronBridgeTestDefinition
+from .megatron_bridge import MegatronBridgeCmdArgs, MegatronBridgeTestDefinition
 
 
 class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
@@ -342,8 +342,6 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             parts.append("-d")
         add_field("num_gpus", "-ng", args.num_gpus)
         add_field("gpus_per_node", "-gn", self.system.gpus_per_node)
-        # Always provide a stable golden values filename so Megatron-Bridge writes parsed metrics to disk.
-        add("--golden_values_path", GOLDEN_VALUES_FILENAME)
         if mounts:
             add("-cm", ",".join(mounts))
 

--- a/tests/ref_data/megatron-bridge.sbatch
+++ b/tests/ref_data/megatron-bridge.sbatch
@@ -19,7 +19,7 @@ if [ "${WANDB_INSTALL_RC}" -ne 0 ]; then
 fi
 
 LAUNCH_RC=0
-NEMORUN_HOME="__OUTPUT_DIR__/output" __INSTALL_DIR__/Run__main-venv/bin/python __INSTALL_DIR__/Megatron-Bridge__main/scripts/performance/setup_experiment.py -p main -t 00:20:00 -i __OUTPUT_DIR__/output/megatron_bridge_image.sqsh -hf dummy_token -ng 8 -gn 8 --golden_values_path cloudai_megatron_bridge_golden_values.json -cm __INSTALL_DIR__/Megatron-Bridge__main:/opt/Megatron-Bridge -cb 'export CUDA_VISIBLE_DEVICES=0,1,2,3' -cb 'export NCCL_DEBUG=INFO' -m qwen3 -mr 30b_a3b --detach false --additional_slurm_params 'gpus-per-node=8;gres=gpu:8' >>"$LOG" 2>&1 || LAUNCH_RC=$?
+NEMORUN_HOME="__OUTPUT_DIR__/output" __INSTALL_DIR__/Run__main-venv/bin/python __INSTALL_DIR__/Megatron-Bridge__main/scripts/performance/setup_experiment.py -p main -t 00:20:00 -i __OUTPUT_DIR__/output/megatron_bridge_image.sqsh -hf dummy_token -ng 8 -gn 8 -cm __INSTALL_DIR__/Megatron-Bridge__main:/opt/Megatron-Bridge -cb 'export CUDA_VISIBLE_DEVICES=0,1,2,3' -cb 'export NCCL_DEBUG=INFO' -m qwen3 -mr 30b_a3b --detach false --additional_slurm_params 'gpus-per-node=8;gres=gpu:8' >>"$LOG" 2>&1 || LAUNCH_RC=$?
 
 
 JOB_ID=""

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -185,14 +185,6 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         assert "--cuda_graph_impl" not in cmd
         assert " -ms " not in cmd
 
-    def test_golden_values_path_is_always_provided(
-        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
-    ) -> None:
-        tr = make_test_run(num_nodes=1)
-        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
-        wrapper_content = self._wrapper_content(cmd_gen)
-        assert "--golden_values_path cloudai_megatron_bridge_golden_values.json" in wrapper_content
-
     def test_container_image_local_path_passed_verbatim(
         self, cmd_gen: MegatronBridgeSlurmCommandGenStrategy, test_run: TestRun
     ) -> None:
@@ -294,30 +286,25 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         ) in wrapper_content
         assert 'exit "${WANDB_INSTALL_RC}"' in wrapper_content
 
-    def test_was_run_successful_detects_launcher_failure_marker(self, make_test_run: Callable[..., TestRun]) -> None:
-        tr = make_test_run()
-        tr.output_path.mkdir(parents=True, exist_ok=True)
-        (tr.output_path / "cloudai_megatron_bridge_launcher.log").write_text(
-            "Job 4818718 finished: FAILED\nException: Experiment failed for test with status: FAILED.\n"
-        )
-        tdef = cast(MegatronBridgeTestDefinition, tr.test)
-        result = tdef.was_run_successful(tr)
-        assert not result.is_successful
-        assert result.error_message is not None
-
-    def test_was_run_successful_accepts_expected_missing_golden_values_failure(
-        self, make_test_run: Callable[..., TestRun]
+    @pytest.mark.parametrize(
+        ("log_content", "expected_is_successful"),
+        (
+            (None, False),
+            ("", False),
+            ("any\bthing", False),
+            ("ain_fp8_mx/0 Step Time : 9.09s GPU utilization: 663.5MODEL_TFLOP/s/GPU", True),
+        ),
+    )
+    def test_was_run_successful(
+        self, make_test_run: Callable[..., TestRun], log_content: str | None, expected_is_successful: bool
     ) -> None:
         tr = make_test_run()
         tr.output_path.mkdir(parents=True, exist_ok=True)
-        (tr.output_path / "cloudai_megatron_bridge_launcher.log").write_text(
-            "Convergence check failed due to missing golden values.\n"
-            "This is expected if it is the first time running this model.\n"
-            "Job 123 finished: FAILED\n"
-        )
+        if log_content is not None:
+            (tr.output_path / "cloudai_megatron_bridge_launcher.log").write_text(log_content)
         tdef = cast(MegatronBridgeTestDefinition, tr.test)
         result = tdef.was_run_successful(tr)
-        assert result.is_successful
+        assert result.is_successful is expected_is_successful
 
     def test_generated_command_file_written(
         self, cmd_gen: MegatronBridgeSlurmCommandGenStrategy, test_run: TestRun

--- a/tests/workloads/megatron_bridge/test_report_gen_strategy.py
+++ b/tests/workloads/megatron_bridge/test_report_gen_strategy.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -22,20 +21,24 @@ import pytest
 
 from cloudai import TestRun
 from cloudai.systems.slurm.slurm_system import SlurmSystem
-from cloudai.workloads.megatron_bridge import GOLDEN_VALUES_FILENAME, MegatronBridgeReportGenerationStrategy
+from cloudai.workloads.megatron_bridge import MegatronBridgeReportGenerationStrategy
 
 
 @pytest.fixture
 def mb_tr(tmp_path: Path) -> TestRun:
     tr = TestRun(name="megatron_bridge", test=Mock(), num_nodes=1, nodes=[], output_path=tmp_path)
-    metrics = {
-        "some_other_data": 1.23,
-        "1": {"elapsed time per iteration (ms)": 1000, "GPU utilization": 1.23},
-        "0": {"elapsed time per iteration (ms)": 1000, "GPU utilization": 1.23},
-    }
-    metrics_folder = tr.output_path / "experiments" / "some_experiment"
-    metrics_folder.mkdir(parents=True)
-    (metrics_folder / GOLDEN_VALUES_FILENAME).write_text(json.dumps(metrics))
+    log_content = "\n".join(
+        [
+            "ain_fp8_mx/0 Step Time : 9.09s GPU utilization: 663.5MODEL_TFLOP/s/GPU",
+            "",
+            "ain_fp8_mx/0  [2025-12-22 15:18:33] iteration       50/      50 | consumed samples:        25600 | "
+            "elapsed time per iteration (ms): 9089.0 | learning rate: 3.000000E-05 | global batch size:   512 | "
+            "lm loss: 8.114214E+00 | load_balancing_loss: 1.000000E+00 | loss scale: 1.0 | grad norm: 0.042 | "
+            "number of skipped iterations:   0 | number of nan iterations:   0 |",
+            "",
+        ]
+    )
+    (tr.output_path / "cloudai_megatron_bridge_launcher.log").write_text(log_content)
     return tr
 
 
@@ -50,23 +53,5 @@ def test_megatron_bridge_extract_and_generate_report(slurm_system: SlurmSystem, 
     report_path = mb_tr.output_path / "report.txt"
     assert report_path.is_file()
     content = report_path.read_text()
-    assert (
-        content
-        == f"""
-Source log: {mb_tr.output_path}/experiments/some_experiment/{GOLDEN_VALUES_FILENAME}
-
-Step Time (s)
-  avg: 1.0
-  median: 1.0
-  min: 1.0
-  max: 1.0
-  std: 0.0
-
-TFLOP/s per GPU
-  avg: 1.23
-  median: 1.23
-  min: 1.23
-  max: 1.23
-  std: 0.0
-""".lstrip()
-    )
+    assert "Step Time" in content
+    assert "TFLOP/s per GPU" in content

--- a/tests/workloads/megatron_bridge/test_report_gen_strategy.py
+++ b/tests/workloads/megatron_bridge/test_report_gen_strategy.py
@@ -31,9 +31,9 @@ def mb_tr(tmp_path: Path) -> TestRun:
         [
             "ain_fp8_mx/0 Step Time : 9.09s GPU utilization: 663.5MODEL_TFLOP/s/GPU",
             "",
-            "ain_fp8_mx/0  [2025-12-22 15:18:33] iteration       50/      50 | consumed samples:        25600 | "
-            "elapsed time per iteration (ms): 9089.0 | learning rate: 3.000000E-05 | global batch size:   512 | "
-            "lm loss: 8.114214E+00 | load_balancing_loss: 1.000000E+00 | loss scale: 1.0 | grad norm: 0.042 | "
+            "ain_fp8_mx/0  [2025-12-22 15:18:33] iteration       50/      50 | consumed samples:        25600 | ",
+            "elapsed time per iteration (ms): 9089.0 | learning rate: 3.000000E-05 | global batch size:   512 | ",
+            "lm loss: 8.114214E+00 | load_balancing_loss: 1.000000E+00 | loss scale: 1.0 | grad norm: 0.042 | ",
             "number of skipped iterations:   0 | number of nan iterations:   0 |",
             "",
         ]


### PR DESCRIPTION
## Summary
The new way of is_run_successful doesn't work in the newest MBridge. Thus reverting to parsing them ourselves which is more reliable (and report-generation accordingly)

Entire code in `/src` is reverted 1:1. Only the test against `is_run_successful` contains new implementation

## Test Plan
- Automated CI
- Manual runs on cw

## Additional Notes

