### PR TITLE
Constraint failure reward override

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -158,7 +158,11 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
             step, action = result
             env.test_run.step = step
             logging.info(f"Running step {step} (of {agent.max_steps}) with action {action}")
-            observation, reward, *_ = env.step(action)
+            observation, reward, *_ = (
+                env.step(action, agent_config.constraint_reward_override)
+                if agent_config.constraint_reward_override != -1.0
+                else env.step(action)
+            )
             feedback = {"trial_index": step, "value": reward}
             agent.update_policy(feedback)
             logging.info(f"Step {step}: Observation: {[round(obs, 4) for obs in observation]}, Reward: {reward:.4f}")

--- a/src/cloudai/configurator/base_agent.py
+++ b/src/cloudai/configurator/base_agent.py
@@ -29,6 +29,7 @@ class BaseAgentConfig(BaseModel):
 
     random_seed: int = 42
     start_action: Literal["random", "first"] = "random"
+    constraint_reward_override: float = -1.0
 
 
 class BaseAgent(ABC):

--- a/src/cloudai/configurator/base_gym.py
+++ b/src/cloudai/configurator/base_gym.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/configurator/base_gym.py
+++ b/src/cloudai/configurator/base_gym.py
@@ -67,12 +67,13 @@ class BaseGym(ABC):
         pass
 
     @abstractmethod
-    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any, constraint_check_reward: float) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
+            constraint_check_reward (float): Reward returned upon constraint check failure.
 
         Returns:
             Tuple: A tuple containing:

--- a/src/cloudai/configurator/base_gym.py
+++ b/src/cloudai/configurator/base_gym.py
@@ -67,7 +67,7 @@ class BaseGym(ABC):
         pass
 
     @abstractmethod
-    def step(self, action: Any, constraint_check_reward: float) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any, constraint_check_reward: float = -1.0) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -101,12 +101,13 @@ class CloudAIGymEnv(BaseGym):
         info = {}
         return observation, info
 
-    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any, constraint_check_reward: float = -1.0) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
+            constraint_check_reward (float): Reward returned upon constraint check failure.
 
         Returns:
             Tuple: A tuple containing:
@@ -127,7 +128,7 @@ class CloudAIGymEnv(BaseGym):
 
         if not self.test_run.test.constraint_check(self.test_run, self.runner.system):
             logging.info("Constraint check failed. Skipping step.")
-            return [-1.0], -1.0, True, {}
+            return [-1.0], constraint_check_reward, True, {}
 
         new_tr = copy.deepcopy(self.test_run)
         new_tr.output_path = self.runner.get_job_output_path(new_tr)

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -180,7 +180,7 @@ def test_constraint_failure(nemorun: NeMoRunTestDefinition, step_kwargs: dict, e
     runner.system = MagicMock()
     env = CloudAIGymEnv(test_run=test_run, runner=runner)
 
-    bad = {"trainer.strategy.context_parallel_size": 3} # induce constraint failure
+    bad = {"trainer.strategy.context_parallel_size": 3}  # induce constraint failure
     obs, reward, done, info = env.step(bad, **step_kwargs)
 
     assert obs == [-1.0]

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -158,6 +158,37 @@ def test_tr_output_path(setup_env: tuple[TestRun, BaseRunner]):
     assert env.test_run.output_path.name == "42"
 
 
+@pytest.mark.parametrize(
+    "step_kwargs, expected_reward",
+    [
+        pytest.param({}, -1.0, id="default_penalty"),
+        pytest.param({"constraint_check_reward": -2.5}, -2.5, id="custom_penalty"),
+    ],
+)
+def test_constraint_failure(nemorun: NeMoRunTestDefinition, step_kwargs: dict, expected_reward: float):
+    tdef = nemorun.model_copy(deep=True)
+    tdef.cmd_args.data.global_batch_size = 8
+    tdef.agent_metrics = ["default"]
+    test_run = TestRun(
+        name="constraint_fail_tr",
+        test=tdef,
+        num_nodes=1,
+        nodes=[],
+        reports={NeMoRunReportGenerationStrategy},
+    )
+    runner = MagicMock(spec=BaseRunner)
+    runner.system = MagicMock()
+    env = CloudAIGymEnv(test_run=test_run, runner=runner)
+
+    bad = {"trainer.strategy.context_parallel_size": 3} # induce constraint failure
+    obs, reward, done, info = env.step(bad, **step_kwargs)
+
+    assert obs == [-1.0]
+    assert reward == expected_reward
+    assert done is True
+    assert info == {}
+
+
 def test_action_space(nemorun: NeMoRunTestDefinition, setup_env: tuple[TestRun, BaseRunner]):
     tr, _ = setup_env
     nemorun.cmd_args.trainer = Trainer(


### PR DESCRIPTION
## Summary
Adds an agent config flag to override the default -1.0 reward.

## Example TOML Usage
```toml
[agent_config]
constraint_reward_override = 0.01
```

## AIConfigurator Example
To induce a constraint failure, a "dummy" constraint was added.
Default behavior (no override):
```logtalk
[INFO] Running step 3 (of 4) with action {'disagg.p_tp': 2, 'disagg.p_pp': 1, 'disagg.p_dp': 1, 'disagg.p_workers': 8, 'disagg.d_tp': 1, 'disagg.d_pp': 1, 'disagg.d_dp': 1, 'disagg.d_bs': 32, 'disagg.d_workers': 16}
[INFO] Constraint check failed. Skipping step.
[INFO] Step 3: Observation: [-1.0], Reward: -1.0000
```
With override applied:
```logtalk
[INFO] Running step 3 (of 4) with action {'disagg.p_tp': 2, 'disagg.p_pp': 1, 'disagg.p_dp': 1, 'disagg.p_workers': 8, 'disagg.d_tp': 1, 'disagg.d_pp': 1, 'disagg.d_dp': 1, 'disagg.d_bs': 32, 'disagg.d_workers': 16}
[INFO] Constraint check failed. Skipping step.
[INFO] Step 3: Observation: [-1.0], Reward: 0.0100
```

## Test Plan
Added constraint failure test.
```bash
uv run python3 -m pytest tests/test_cloudaigym.py::test_constraint_failure -v
```
This checks that when no override is given the default reward = -1.0.
When a custom override (-2.5) is set, the returned reward = -2.5 
```logtalk
tests/test_cloudaigym.py::test_constraint_failure[default_penalty] PASSED                                                                                                                                                                                                                           [ 50%]
tests/test_cloudaigym.py::test_constraint_failure[custom_penalty] PASSED 
```