### PR TITLE
Amanley/reward overrides

### DIFF
--- a/doc/USER_GUIDE.rst
+++ b/doc/USER_GUIDE.rst
@@ -206,6 +206,17 @@ action, typically seeded by ``random_seed``.
 
 Custom agents may extend the ``BaseAgentConfig`` and offer more parameters to configure.
 
+Metric errors and report strategies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Report generation strategies signal a failed or missing metric by returning the singleton ``METRIC_ERROR`` from
+``cloudai.core`` (type ``MetricErrorSentinel``; ``float(METRIC_ERROR)`` is ``-1.0`` for numeric use). The declared
+return type of ``ReportGenerationStrategy.get_metric`` is ``MetricValue`` (``float | MetricErrorSentinel``).
+
+When branching on success vs failure, use **identity** (``value is METRIC_ERROR`` or
+``value is test_run.get_metric_error_value()``), not equality to ``-1.0``, so a legitimate metric of ``-1.0`` is not
+treated as an error. The gym observation path uses that identity check before applying ``agent_config.rewards.metric_failure``.
+
 Configuring HTTP Data Repository
 --------------------------------
 

--- a/doc/USER_GUIDE.rst
+++ b/doc/USER_GUIDE.rst
@@ -213,8 +213,7 @@ Report generation strategies signal a failed or missing metric by returning the 
 ``cloudai.core`` (type ``MetricErrorSentinel``; ``float(METRIC_ERROR)`` is ``-1.0`` for numeric use). The declared
 return type of ``ReportGenerationStrategy.get_metric`` is ``MetricValue`` (``float | MetricErrorSentinel``).
 
-When branching on success vs failure, use **identity** (``value is METRIC_ERROR`` or
-``value is test_run.get_metric_error_value()``), not equality to ``-1.0``, so a legitimate metric of ``-1.0`` is not
+When branching on success vs failure, use **identity** (``value is METRIC_ERROR``), not equality to ``-1.0``, so a legitimate metric of ``-1.0`` is not
 treated as an error. The gym observation path uses that identity check before applying ``agent_config.rewards.metric_failure``.
 
 Configuring HTTP Data Repository

--- a/doc/USER_GUIDE.rst
+++ b/doc/USER_GUIDE.rst
@@ -176,9 +176,9 @@ For DSE workloads, you can pass agent configuration via ``agent_config`` in the 
 
   - ``constraint_failure``: reward returned when ``TestDefinition.constraint_check`` fails on a step. If omitted
     or unset, the environment uses ``-1.0``.
-  - ``metric_failure``: value written into the observation vector when a metric is missing or equals the
-    canonical error sentinel (``METRIC_ERROR``, ``-1.0``). If omitted or unset, observations use ``-1.0`` for that
-    slot.
+  - ``metric_failure``: value written into the observation vector when a metric is missing or is the
+    canonical error sentinel ``METRIC_ERROR`` (a distinct object from numeric metrics, so a valid ``-1.0``
+    result is not mistaken for an error). If omitted or unset, observations use ``-1.0`` for that slot.
 
 Example:
 

--- a/doc/USER_GUIDE.rst
+++ b/doc/USER_GUIDE.rst
@@ -171,6 +171,14 @@ For DSE workloads, you can pass agent configuration via ``agent_config`` in the 
 
 - ``random_seed``: controls deterministic random behavior in agents.
 - ``start_action``: controls the very first action strategy (``"random"`` or ``"first"``).
+- ``rewards`` (optional): nested table mapped to ``RewardOverrides``. When present, ``CloudAIGymEnv`` uses it for
+  constraint failures and for substituting failed-metric values in observations.
+
+  - ``constraint_failure``: reward returned when ``TestDefinition.constraint_check`` fails on a step. If omitted
+    or unset, the environment uses ``-1.0``.
+  - ``metric_failure``: value written into the observation vector when a metric is missing or equals the
+    canonical error sentinel (``METRIC_ERROR``, ``-1.0``). If omitted or unset, observations use ``-1.0`` for that
+    slot.
 
 Example:
 
@@ -187,6 +195,10 @@ Example:
      [Tests.agent_config]
      random_seed = 123
      start_action = "first"
+
+       [Tests.agent_config.rewards]
+       constraint_failure = -5.0
+       metric_failure = 0.0
 
 When an agent honors ``start_action = "first"``, it should start from ``CloudAIGymEnv.first_sweep`` (the sweep
 is built from first values of each sweep parameter). ``start_action = "random"`` means starting from a random

--- a/src/cloudai/_core/report_generation_strategy.py
+++ b/src/cloudai/_core/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/_core/report_generation_strategy.py
+++ b/src/cloudai/_core/report_generation_strategy.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 from .system import System
-from .test_scenario import MetricValue, TestRun
+from .test_scenario import METRIC_ERROR, MetricValue, TestRun
 
 
 class ReportGenerationStrategy(ABC):
@@ -31,7 +31,7 @@ class ReportGenerationStrategy(ABC):
         self.test_run = tr
 
     def get_metric(self, metric: str) -> MetricValue:
-        return 0.0
+        return METRIC_ERROR
 
     @abstractmethod
     def can_handle_directory(self) -> bool: ...

--- a/src/cloudai/_core/report_generation_strategy.py
+++ b/src/cloudai/_core/report_generation_strategy.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from typing import ClassVar
 
 from .system import System
-from .test_scenario import TestRun
+from .test_scenario import MetricValue, TestRun
 
 
 class ReportGenerationStrategy(ABC):
@@ -30,7 +30,7 @@ class ReportGenerationStrategy(ABC):
         self.system = system
         self.test_run = tr
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         return 0.0
 
     @abstractmethod

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -20,7 +20,7 @@ import copy
 import itertools
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Type, TypeAlias, Union
 
 from ..util import flatten_dict
 from .system import System
@@ -30,13 +30,14 @@ if TYPE_CHECKING:
     from ..models.workload import TestDefinition
     from .report_generation_strategy import ReportGenerationStrategy
 
-class _MetricErrorSentinel:
+
+class MetricErrorSentinel:
     """Singleton returned by report strategies on failure; use ``v is METRIC_ERROR`` to detect errors."""
 
     __slots__ = ()
-    _instance: _MetricErrorSentinel | None = None
+    _instance: MetricErrorSentinel | None = None
 
-    def __new__(cls) -> _MetricErrorSentinel:
+    def __new__(cls) -> MetricErrorSentinel:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
@@ -48,7 +49,9 @@ class _MetricErrorSentinel:
         return -1.0
 
 
-METRIC_ERROR = _MetricErrorSentinel()
+METRIC_ERROR = MetricErrorSentinel()
+
+MetricValue: TypeAlias = float | MetricErrorSentinel
 
 
 class TestDependency:
@@ -120,11 +123,15 @@ class TestRun:
 
         return None
 
-    def get_metric_error_value(self) -> _MetricErrorSentinel:
-        """Same object strategies return on metric failure; use ``value is tr.get_metric_error_value()`` for checks."""
+    def get_metric_error_value(self) -> MetricErrorSentinel:
+        """
+        Return the singleton metric-error token (``METRIC_ERROR``).
+
+        Use ``value is test_run.get_metric_error_value()`` so a numeric ``-1.0`` is not treated as an error.
+        """
         return METRIC_ERROR
 
-    def get_metric_value(self, system: System, metric: str) -> float | _MetricErrorSentinel:
+    def get_metric_value(self, system: System, metric: str) -> MetricValue:
         report = self.metric_reporter
         if report is None:
             return METRIC_ERROR

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -123,14 +123,6 @@ class TestRun:
 
         return None
 
-    def get_metric_error_value(self) -> MetricErrorSentinel:
-        """
-        Return the singleton metric-error token (``METRIC_ERROR``).
-
-        Use ``value is test_run.get_metric_error_value()`` so a numeric ``-1.0`` is not treated as an error.
-        """
-        return METRIC_ERROR
-
     def get_metric_value(self, system: System, metric: str) -> MetricValue:
         report = self.metric_reporter
         if report is None:

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -30,7 +30,25 @@ if TYPE_CHECKING:
     from ..models.workload import TestDefinition
     from .report_generation_strategy import ReportGenerationStrategy
 
-METRIC_ERROR: float = -1.0
+class _MetricErrorSentinel:
+    """Singleton returned by report strategies on failure; use ``v is METRIC_ERROR`` to detect errors."""
+
+    __slots__ = ()
+    _instance: _MetricErrorSentinel | None = None
+
+    def __new__(cls) -> _MetricErrorSentinel:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "METRIC_ERROR"
+
+    def __float__(self) -> float:
+        return -1.0
+
+
+METRIC_ERROR = _MetricErrorSentinel()
 
 
 class TestDependency:
@@ -102,11 +120,11 @@ class TestRun:
 
         return None
 
-    def get_metric_error_value(self) -> float:
-        """Numeric sentinel for missing or failed metrics."""
+    def get_metric_error_value(self) -> _MetricErrorSentinel:
+        """Same object strategies return on metric failure; use ``value is tr.get_metric_error_value()`` for checks."""
         return METRIC_ERROR
 
-    def get_metric_value(self, system: System, metric: str) -> float:
+    def get_metric_value(self, system: System, metric: str) -> float | _MetricErrorSentinel:
         report = self.metric_reporter
         if report is None:
             return METRIC_ERROR

--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
     from ..models.workload import TestDefinition
     from .report_generation_strategy import ReportGenerationStrategy
 
-
-METRIC_ERROR = -1.0
+METRIC_ERROR: float = -1.0
 
 
 class TestDependency:
@@ -102,6 +101,10 @@ class TestRun:
                 return r
 
         return None
+
+    def get_metric_error_value(self) -> float:
+        """Numeric sentinel for missing or failed metrics."""
+        return METRIC_ERROR
 
     def get_metric_value(self, system: System, metric: str) -> float:
         report = self.metric_reporter

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -143,9 +143,13 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
             err = 1
             continue
 
-        env = CloudAIGymEnv(test_run=test_run, runner=runner.runner)
         agent_config_data = test_run.test.agent_config or {}
         agent_config = agent_class.get_config_class()(**agent_config_data)
+        env = CloudAIGymEnv(
+            test_run=test_run,
+            runner=runner.runner,
+            rewards=agent_config.rewards,
+        )
         if agent_config.start_action == "first":
             logging.info(f"Using deterministic first sweep for the chosen agent: {env.first_sweep}.")
 
@@ -158,11 +162,7 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
             step, action = result
             env.test_run.step = step
             logging.info(f"Running step {step} (of {agent.max_steps}) with action {action}")
-            observation, reward, *_ = (
-                env.step(action, agent_config.constraint_reward_override)
-                if agent_config.constraint_reward_override != -1.0
-                else env.step(action)
-            )
+            observation, reward, *_ = env.step(action)
             feedback = {"trial_index": step, "value": reward}
             agent.update_policy(feedback)
             logging.info(f"Step {step}: Observation: {[round(obs, 4) for obs in observation]}, Reward: {reward:.4f}")

--- a/src/cloudai/configurator/base_agent.py
+++ b/src/cloudai/configurator/base_agent.py
@@ -17,9 +17,24 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .base_gym import BaseGym
+
+
+class RewardOverrides(BaseModel):
+    """Optional reward and observation overrides for the agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    constraint_failure: float | None = Field(
+        default=None,
+        description="Reward when a constraint check fails; None uses the environment default (-1.0).",
+    )
+    metric_failure: float | None = Field(
+        default=None,
+        description="Observation value when a metric is missing or failed; None uses -1.0.",
+    )
 
 
 class BaseAgentConfig(BaseModel):
@@ -29,7 +44,10 @@ class BaseAgentConfig(BaseModel):
 
     random_seed: int = 42
     start_action: Literal["random", "first"] = "random"
-    constraint_reward_override: float = -1.0
+    rewards: RewardOverrides | None = Field(
+        default=None,
+        description="Reward and observation overrides for the agent.",
+    )
 
 
 class BaseAgent(ABC):

--- a/src/cloudai/configurator/base_agent.py
+++ b/src/cloudai/configurator/base_agent.py
@@ -27,13 +27,13 @@ class RewardOverrides(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    constraint_failure: float | None = Field(
-        default=None,
-        description="Reward when a constraint check fails; None uses the environment default (-1.0).",
+    constraint_failure: float = Field(
+        default=-1.0,
+        description="Reward when a constraint check fails.",
     )
-    metric_failure: float | None = Field(
-        default=None,
-        description="Observation value when a metric is missing or failed; None uses -1.0.",
+    metric_failure: float = Field(
+        default=-1.0,
+        description="Observation value when a metric is missing or failed.",
     )
 
 
@@ -44,8 +44,8 @@ class BaseAgentConfig(BaseModel):
 
     random_seed: int = 42
     start_action: Literal["random", "first"] = "random"
-    rewards: RewardOverrides | None = Field(
-        default=None,
+    rewards: RewardOverrides = Field(
+        default_factory=RewardOverrides,
         description="Reward and observation overrides for the agent.",
     )
 

--- a/src/cloudai/configurator/base_gym.py
+++ b/src/cloudai/configurator/base_gym.py
@@ -67,13 +67,12 @@ class BaseGym(ABC):
         pass
 
     @abstractmethod
-    def step(self, action: Any, constraint_check_reward: float = -1.0) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
-            constraint_check_reward (float): Reward returned upon constraint check failure.
 
         Returns:
             Tuple: A tuple containing:

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -211,15 +211,11 @@ class CloudAIGymEnv(BaseGym):
         if not all_metrics:
             raise ValueError("No agent metrics defined for the test run")
 
-        obs_replace = -1.0
-        if self.rewards is not None and self.rewards.metric_failure is not None:
-            obs_replace = self.rewards.metric_failure
-
         observation = []
         for metric in all_metrics:
             v = self.test_run.get_metric_value(self.runner.system, metric)
             if v is METRIC_ERROR:
-                v = obs_replace
+                v = self.rewards.metric_failure
             observation.append(v)
         return observation
 

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -21,9 +21,10 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from cloudai.core import METRIC_ERROR, BaseRunner, Registry, TestRun
+from cloudai.core import BaseRunner, Registry, TestRun
 from cloudai.util.lazy_imports import lazy
 
+from .base_agent import RewardOverrides
 from .base_gym import BaseGym
 
 
@@ -44,17 +45,24 @@ class CloudAIGymEnv(BaseGym):
     Uses the TestRun object and actual runner methods to execute jobs.
     """
 
-    def __init__(self, test_run: TestRun, runner: BaseRunner):
+    def __init__(
+        self,
+        test_run: TestRun,
+        runner: BaseRunner,
+        rewards: RewardOverrides | None = None,
+    ):
         """
         Initialize the Gym environment using the TestRun object.
 
         Args:
             test_run (TestRun): A test run object that encapsulates cmd_args, extra_cmd_args, etc.
             runner (BaseRunner): The runner object to execute jobs.
+            rewards: Optional reward / observation overrides from agent config.
         """
         self.test_run = test_run
         self.original_test_run = copy.deepcopy(test_run)  # Preserve clean state for DSE
         self.runner = runner
+        self.rewards = rewards
         self.max_steps = test_run.test.agent_steps
         self.reward_function = Registry().get_reward_function(test_run.test.agent_reward_function)
         self.trajectory: dict[int, list[TrajectoryEntry]] = {}
@@ -101,13 +109,12 @@ class CloudAIGymEnv(BaseGym):
         info = {}
         return observation, info
 
-    def step(self, action: Any, constraint_check_reward: float = -1.0) -> Tuple[list, float, bool, dict]:
+    def step(self, action: Any) -> Tuple[list, float, bool, dict]:
         """
         Execute one step in the environment.
 
         Args:
             action (Any): Action chosen by the agent.
-            constraint_check_reward (float): Reward returned upon constraint check failure.
 
         Returns:
             Tuple: A tuple containing:
@@ -128,7 +135,12 @@ class CloudAIGymEnv(BaseGym):
 
         if not self.test_run.test.constraint_check(self.test_run, self.runner.system):
             logging.info("Constraint check failed. Skipping step.")
-            return [-1.0], constraint_check_reward, True, {}
+            reward = (
+                self.rewards.constraint_failure
+                if self.rewards and self.rewards.constraint_failure is not None
+                else -1.0
+            )
+            return [-1.0], reward, True, {}
 
         new_tr = copy.deepcopy(self.test_run)
         new_tr.output_path = self.runner.get_job_output_path(new_tr)
@@ -209,11 +221,15 @@ class CloudAIGymEnv(BaseGym):
         if not all_metrics:
             raise ValueError("No agent metrics defined for the test run")
 
+        obs_replace = -1.0
+        if self.rewards is not None and self.rewards.metric_failure is not None:
+            obs_replace = self.rewards.metric_failure
+
         observation = []
         for metric in all_metrics:
             v = self.test_run.get_metric_value(self.runner.system, metric)
-            if v == METRIC_ERROR:
-                v = -1.0
+            if v == self.test_run.get_metric_error_value():
+                v = obs_replace
             observation.append(v)
         return observation
 

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -21,7 +21,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from cloudai.core import BaseRunner, Registry, TestRun
+from cloudai.core import METRIC_ERROR, BaseRunner, Registry, TestRun
 from cloudai.util.lazy_imports import lazy
 
 from .base_agent import RewardOverrides
@@ -45,19 +45,14 @@ class CloudAIGymEnv(BaseGym):
     Uses the TestRun object and actual runner methods to execute jobs.
     """
 
-    def __init__(
-        self,
-        test_run: TestRun,
-        runner: BaseRunner,
-        rewards: RewardOverrides | None = None,
-    ):
+    def __init__(self, test_run: TestRun, runner: BaseRunner, rewards: RewardOverrides):
         """
         Initialize the Gym environment using the TestRun object.
 
         Args:
             test_run (TestRun): A test run object that encapsulates cmd_args, extra_cmd_args, etc.
             runner (BaseRunner): The runner object to execute jobs.
-            rewards: Optional reward / observation overrides from agent config.
+            rewards: Reward / observation overrides from agent config.
         """
         self.test_run = test_run
         self.original_test_run = copy.deepcopy(test_run)  # Preserve clean state for DSE
@@ -135,12 +130,7 @@ class CloudAIGymEnv(BaseGym):
 
         if not self.test_run.test.constraint_check(self.test_run, self.runner.system):
             logging.info("Constraint check failed. Skipping step.")
-            reward = (
-                self.rewards.constraint_failure
-                if self.rewards and self.rewards.constraint_failure is not None
-                else -1.0
-            )
-            return [-1.0], reward, True, {}
+            return [-1.0], self.rewards.constraint_failure, True, {}
 
         new_tr = copy.deepcopy(self.test_run)
         new_tr.output_path = self.runner.get_job_output_path(new_tr)
@@ -225,11 +215,10 @@ class CloudAIGymEnv(BaseGym):
         if self.rewards is not None and self.rewards.metric_failure is not None:
             obs_replace = self.rewards.metric_failure
 
-        err = self.test_run.get_metric_error_value()
         observation = []
         for metric in all_metrics:
             v = self.test_run.get_metric_value(self.runner.system, metric)
-            if v is err:
+            if v is METRIC_ERROR:
                 v = obs_replace
             observation.append(v)
         return observation

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -225,10 +225,11 @@ class CloudAIGymEnv(BaseGym):
         if self.rewards is not None and self.rewards.metric_failure is not None:
             obs_replace = self.rewards.metric_failure
 
+        err = self.test_run.get_metric_error_value()
         observation = []
         for metric in all_metrics:
             v = self.test_run.get_metric_value(self.runner.system, metric)
-            if v == self.test_run.get_metric_error_value():
+            if v is err:
                 v = obs_replace
             observation.append(v)
         return observation

--- a/src/cloudai/core.py
+++ b/src/cloudai/core.py
@@ -39,7 +39,7 @@ from ._core.registry import Registry
 from ._core.report_generation_strategy import ReportGenerationStrategy
 from ._core.runner import Runner
 from ._core.system import System
-from ._core.test_scenario import METRIC_ERROR, TestDependency, TestRun, TestScenario
+from ._core.test_scenario import METRIC_ERROR, MetricErrorSentinel, MetricValue, TestDependency, TestRun, TestScenario
 from .configurator.base_agent import BaseAgent, BaseAgentConfig, RewardOverrides
 from .configurator.cloudai_gym import CloudAIGymEnv
 from .configurator.grid_search import GridSearchAgent
@@ -72,6 +72,8 @@ __all__ = [
     "JobIdRetrievalError",
     "JobStatusResult",
     "JsonGenStrategy",
+    "MetricErrorSentinel",
+    "MetricValue",
     "MissingTestError",
     "NsysConfiguration",
     "Parser",

--- a/src/cloudai/core.py
+++ b/src/cloudai/core.py
@@ -40,7 +40,7 @@ from ._core.report_generation_strategy import ReportGenerationStrategy
 from ._core.runner import Runner
 from ._core.system import System
 from ._core.test_scenario import METRIC_ERROR, TestDependency, TestRun, TestScenario
-from .configurator.base_agent import BaseAgent, BaseAgentConfig
+from .configurator.base_agent import BaseAgent, BaseAgentConfig, RewardOverrides
 from .configurator.cloudai_gym import CloudAIGymEnv
 from .configurator.grid_search import GridSearchAgent
 from .models.workload import CmdArgs, NsysConfiguration, PredictorConfig, TestDefinition
@@ -81,6 +81,7 @@ __all__ = [
     "Registry",
     "ReportGenerationStrategy",
     "Reporter",
+    "RewardOverrides",
     "Runner",
     "StatusReporter",
     "System",

--- a/src/cloudai/systems/slurm/single_sbatch_runner.py
+++ b/src/cloudai/systems/slurm/single_sbatch_runner.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Generator, Optional, cast
 
 from cloudai.configurator import CloudAIGymEnv, TrajectoryEntry
-from cloudai.core import BaseJob, JobIdRetrievalError, System, TestRun, TestScenario
+from cloudai.core import BaseJob, JobIdRetrievalError, Registry, System, TestRun, TestScenario
 from cloudai.util import CommandShell, format_time_limit, parse_time_limit
 
 from .slurm_command_gen_strategy import SlurmCommandGenStrategy
@@ -200,6 +200,7 @@ class SingleSbatchRunner(SlurmRunner):
         self.on_job_completion(job)
 
     def handle_dse(self):
+        registry = Registry()
         for tr in self.test_scenario.test_runs:
             if not tr.is_dse_job:
                 continue
@@ -209,7 +210,13 @@ class SingleSbatchRunner(SlurmRunner):
                 next_tr.step = idx
                 next_tr.output_path = self.get_job_output_path(next_tr)
 
-                gym = CloudAIGymEnv(next_tr, self)
+                rewards = None
+                agent_class = registry.agents_map.get(next_tr.test.agent)
+                if agent_class is not None:
+                    agent_config = agent_class.get_config_class()(**(next_tr.test.agent_config or {}))
+                    rewards = agent_config.rewards
+
+                gym = CloudAIGymEnv(next_tr, self, rewards=rewards)
                 observation = gym.get_observation({})
                 reward = gym.compute_reward(observation)
                 gym.write_trajectory(

--- a/src/cloudai/systems/slurm/single_sbatch_runner.py
+++ b/src/cloudai/systems/slurm/single_sbatch_runner.py
@@ -211,10 +211,10 @@ class SingleSbatchRunner(SlurmRunner):
                 next_tr.output_path = self.get_job_output_path(next_tr)
 
                 rewards = None
-                agent_class = registry.agents_map.get(next_tr.test.agent)
-                if agent_class is not None:
-                    agent_config = agent_class.get_config_class()(**(next_tr.test.agent_config or {}))
-                    rewards = agent_config.rewards
+                agent_class = registry.agents_map[next_tr.test.agent]
+                agent_config_data = next_tr.test.agent_config or {}
+                agent_config = agent_class.get_config_class()(**agent_config_data)
+                rewards = agent_config.rewards
 
                 gym = CloudAIGymEnv(next_tr, self, rewards=rewards)
                 observation = gym.get_observation({})

--- a/src/cloudai/workloads/ai_dynamo/report_generation_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/report_generation_strategy.py
@@ -19,14 +19,14 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 from cloudai.util.lazy_imports import lazy
 
 
 class AIDynamoReportGenerationStrategy(ReportGenerationStrategy):
     """Strategy for generating reports from AI Dynamo run directories."""
 
-    def extract_metric_from_csv(self, csv_file: Path, metric_name: str, metric_type: str) -> float:
+    def extract_metric_from_csv(self, csv_file: Path, metric_name: str, metric_type: str) -> MetricValue:
         df = lazy.pd.read_csv(csv_file)
 
         if "Metric" not in df.columns or metric_type not in df.columns:
@@ -42,7 +42,7 @@ class AIDynamoReportGenerationStrategy(ReportGenerationStrategy):
             return METRIC_ERROR
         return float(series.iloc[0])
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         logging.info(f"Getting metric: {metric}")
         benchmark_name = "genai_perf"
         metric_name = metric

--- a/src/cloudai/workloads/aiconfig/report_generation_strategy.py
+++ b/src/cloudai/workloads/aiconfig/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/aiconfig/report_generation_strategy.py
+++ b/src/cloudai/workloads/aiconfig/report_generation_strategy.py
@@ -20,7 +20,7 @@ import json
 import logging
 from typing import ClassVar, Optional
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 
 from .aiconfigurator import AiconfiguratorTestDefinition
 
@@ -85,7 +85,7 @@ class AiconfiguratorReportGenerationStrategy(ReportGenerationStrategy):
         except Exception as e:
             logging.error(f"Failed to write summary: {e}")
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         data = self._load_results()
         if not data:
             return METRIC_ERROR

--- a/src/cloudai/workloads/common/llm_serving.py
+++ b/src/cloudai/workloads/common/llm_serving.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/common/llm_serving.py
+++ b/src/cloudai/workloads/common/llm_serving.py
@@ -25,7 +25,7 @@ from rich.console import Console
 from rich.table import Table
 from typing_extensions import Self
 
-from cloudai.core import METRIC_ERROR, DockerImage, HFModel, Installable, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, DockerImage, HFModel, Installable, MetricValue, ReportGenerationStrategy
 from cloudai.models.workload import CmdArgs, TestDefinition
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
@@ -251,7 +251,7 @@ class LLMServingReportGenerationStrategy(ReportGenerationStrategy, Generic[TestD
 
         return len(gpu_ids) * num_nodes
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         if metric not in self.metrics:
             return METRIC_ERROR
 

--- a/src/cloudai/workloads/common/llm_serving.py
+++ b/src/cloudai/workloads/common/llm_serving.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/megatron_bridge/report_generation_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/report_generation_strategy.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from statistics import mean, median, pstdev
 from typing import ClassVar
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 
 from .megatron_bridge import extract_mbridge_metrics
 
@@ -101,7 +101,7 @@ class MegatronBridgeReportGenerationStrategy(ReportGenerationStrategy):
             f.write(f"  max: {tflops_stats['max']}\n")
             f.write(f"  std: {tflops_stats['std']}\n")
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         if metric not in {"default", "step-time", "tflops-per-gpu"}:
             return METRIC_ERROR
         log_file, step_times_s, gpu_tflops = self._get_extracted_data()

--- a/src/cloudai/workloads/megatron_run/report_generation_strategy.py
+++ b/src/cloudai/workloads/megatron_run/report_generation_strategy.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from statistics import mean, median, pstdev
 from typing import ClassVar
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 
 CHECKPOINT_REGEX = re.compile(r"(save|load)-checkpoint\s.*:\s\((\d+\.\d+),\s(\d+\.\d+)\)")
 
@@ -166,7 +166,7 @@ class MegatronRunReportGenerationStrategy(ReportGenerationStrategy):
             writer.writerow(["iteration_time_ms", iter_avg, iter_median, iter_min, iter_max, iter_std])
             writer.writerow(["tflops_per_gpu", tflops_avg, tflops_median, tflops_min, tflops_max, tflops_std])
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         if metric not in {"default", "iteration-time", "tflops-per-gpu"}:
             return METRIC_ERROR
         log_file, iter_times_ms, gpu_tflops = self._get_extracted_data()

--- a/src/cloudai/workloads/nccl_test/performance_report_generation_strategy.py
+++ b/src/cloudai/workloads/nccl_test/performance_report_generation_strategy.py
@@ -22,7 +22,7 @@ from io import TextIOWrapper
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, List, Tuple
 
-from cloudai.core import METRIC_ERROR, System, TestRun
+from cloudai.core import METRIC_ERROR, MetricValue, System, TestRun
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.tool.csv_report_tool import CSVReportTool
 from cloudai.report_generator.util import add_human_readable_sizes
@@ -181,7 +181,7 @@ class NcclTestPerformanceReportGenerationStrategy(NcclTestReportGenerationStrate
 
         report_tool.finalize_report(Path("cloudai_nccl_test_bokeh_report.html"))
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         df: pd.DataFrame = self._extract_data()
         if df.empty:
             return METRIC_ERROR

--- a/src/cloudai/workloads/nemo_run/report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_run/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/nemo_run/report_generation_strategy.py
+++ b/src/cloudai/workloads/nemo_run/report_generation_strategy.py
@@ -22,7 +22,7 @@ from functools import cache
 from pathlib import Path
 from typing import ClassVar, List
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.util.lazy_imports import lazy
 
@@ -101,7 +101,7 @@ class NeMoRunReportGenerationStrategy(ReportGenerationStrategy):
 
         self.generate_bokeh_report(step_timings)
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         logging.debug(f"Getting metric {metric} from {self.results_file.absolute()}")
         step_timings = extract_timings(self.results_file)
         if not step_timings:

--- a/src/cloudai/workloads/nixl_bench/report_generation_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/nixl_bench/report_generation_strategy.py
+++ b/src/cloudai/workloads/nixl_bench/report_generation_strategy.py
@@ -20,7 +20,7 @@ import logging
 from pathlib import Path
 from typing import ClassVar
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.util.lazy_imports import lazy
 from cloudai.workloads.common.nixl import extract_nixlbench_data
@@ -47,7 +47,7 @@ class NIXLBenchReportGenerationStrategy(ReportGenerationStrategy):
         df = extract_nixlbench_data(self.results_file)
         df.to_csv(self.test_run.output_path / "nixlbench.csv", index=False)
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         logging.debug(f"Getting metric {metric} from {self.results_file.absolute()}")
         df = extract_nixlbench_data(self.results_file)
         if df.empty or metric not in {"default", "latency"}:

--- a/src/cloudai/workloads/nixl_ep/report_generation_strategy.py
+++ b/src/cloudai/workloads/nixl_ep/report_generation_strategy.py
@@ -23,7 +23,7 @@ from typing import ClassVar
 from rich.console import Console
 from rich.table import Table
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 
 from .log_parsing import parse_nixl_ep_bandwidth_samples, parse_nixl_ep_completed_phases
 from .nixl_ep import GENERATED_PLAN_FILE_NAME
@@ -145,7 +145,7 @@ class NixlEPReportGenerationStrategy(ReportGenerationStrategy):
         table = self._build_table(title, plan, node_logs, completed_by_node, samples_by_node, has_combined, has_kineto)
         console.print(table)
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         if metric not in self.metrics:
             return METRIC_ERROR
         samples = [s for path in self._node_logs() for s in parse_nixl_ep_bandwidth_samples(path)]

--- a/src/cloudai/workloads/nixl_ep/report_generation_strategy.py
+++ b/src/cloudai/workloads/nixl_ep/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/nixl_ep/report_generation_strategy.py
+++ b/src/cloudai/workloads/nixl_ep/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/ucc_test/report_generation_strategy.py
+++ b/src/cloudai/workloads/ucc_test/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/ucc_test/report_generation_strategy.py
+++ b/src/cloudai/workloads/ucc_test/report_generation_strategy.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional
 if TYPE_CHECKING:
     import pandas as pd
 
-from cloudai.core import METRIC_ERROR, ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 from cloudai.report_generator.tool.bokeh_report_tool import BokehReportTool
 from cloudai.report_generator.util import add_human_readable_sizes
 from cloudai.util.lazy_imports import lazy
@@ -128,7 +128,7 @@ class UCCTestReportGenerationStrategy(ReportGenerationStrategy):
 
         report_tool.finalize_report(Path("cloudai_ucc_test_bokeh_report.html"))
 
-    def get_metric(self, metric: str) -> float:
+    def get_metric(self, metric: str) -> MetricValue:
         """
         Calculate the metric value from the UCC test output.
 

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -83,7 +83,7 @@ def setup_env(slurm_system: SlurmSystem, nemorun: NeMoRunTestDefinition) -> tupl
 
 def test_observation_space(setup_env: tuple[TestRun, BaseRunner]):
     test_run, runner = setup_env
-    env = CloudAIGymEnv(test_run=test_run, runner=runner)
+    env = CloudAIGymEnv(test_run=test_run, runner=runner, rewards=RewardOverrides())
     observation_space = env.define_observation_space()
 
     expected_observation_space = [0.0]
@@ -125,7 +125,7 @@ def test_observation_space(setup_env: tuple[TestRun, BaseRunner]):
 )
 def test_compute_reward(reward_function, test_cases, base_tr: TestRun):
     base_tr.test.agent_reward_function = reward_function
-    env = CloudAIGymEnv(test_run=base_tr, runner=MagicMock())
+    env = CloudAIGymEnv(test_run=base_tr, runner=MagicMock(), rewards=RewardOverrides())
 
     for input_value, expected_reward in test_cases:
         reward = env.compute_reward(input_value)
@@ -136,7 +136,7 @@ def test_compute_reward_invalid(base_tr: TestRun):
     base_tr.test.agent_reward_function = "nonexistent"
 
     with pytest.raises(KeyError) as exc_info:
-        CloudAIGymEnv(test_run=base_tr, runner=MagicMock())
+        CloudAIGymEnv(test_run=base_tr, runner=MagicMock(), rewards=RewardOverrides())
 
     assert "Reward function 'nonexistent' not found" in str(exc_info.value)
     assert (
@@ -148,7 +148,7 @@ def test_compute_reward_invalid(base_tr: TestRun):
 def test_tr_output_path(setup_env: tuple[TestRun, BaseRunner]):
     test_run, runner = setup_env
     test_run.test.cmd_args.data.global_batch_size = 8  # avoid constraint check failure
-    env = CloudAIGymEnv(test_run=test_run, runner=runner)
+    env = CloudAIGymEnv(test_run=test_run, runner=runner, rewards=RewardOverrides())
     agent = GridSearchAgent(env, GridSearchAgent.get_config_class()())
 
     _, action = agent.select_action()
@@ -161,11 +161,11 @@ def test_tr_output_path(setup_env: tuple[TestRun, BaseRunner]):
 @pytest.mark.parametrize(
     "rewards, expected_reward",
     [
-        pytest.param(None, -1.0, id="default_penalty"),
+        pytest.param(RewardOverrides(), -1.0, id="default_penalty"),
         pytest.param(RewardOverrides(constraint_failure=-2.5), -2.5, id="custom_penalty"),
     ],
 )
-def test_constraint_failure(nemorun: NeMoRunTestDefinition, rewards: RewardOverrides | None, expected_reward: float):
+def test_constraint_failure(nemorun: NeMoRunTestDefinition, rewards: RewardOverrides, expected_reward: float):
     tdef = nemorun.model_copy(deep=True)
     tdef.cmd_args.data.global_batch_size = 8
     tdef.agent_metrics = ["default"]
@@ -368,7 +368,7 @@ def test_get_cached_trajectory_result(
     runner.testrun_to_job_map = {}
     runner.get_job_output_path.return_value = tmp_path / "scenario" / base_tr.name / "0" / "7"
 
-    env = CloudAIGymEnv(test_run=base_tr, runner=runner)
+    env = CloudAIGymEnv(test_run=base_tr, runner=runner, rewards=RewardOverrides())
     env.test_run.current_iteration = current_iteration
     env.trajectory = trajectory
 

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 
 from cloudai.configurator import CloudAIGymEnv, GridSearchAgent, TrajectoryEntry
-from cloudai.core import BaseRunner, Runner, TestRun, TestScenario
+from cloudai.core import BaseRunner, RewardOverrides, Runner, TestRun, TestScenario
 from cloudai.systems.slurm import SlurmSystem
 from cloudai.util import flatten_dict
 from cloudai.workloads.nemo_run import (
@@ -159,13 +159,13 @@ def test_tr_output_path(setup_env: tuple[TestRun, BaseRunner]):
 
 
 @pytest.mark.parametrize(
-    "step_kwargs, expected_reward",
+    "rewards, expected_reward",
     [
-        pytest.param({}, -1.0, id="default_penalty"),
-        pytest.param({"constraint_check_reward": -2.5}, -2.5, id="custom_penalty"),
+        pytest.param(None, -1.0, id="default_penalty"),
+        pytest.param(RewardOverrides(constraint_failure=-2.5), -2.5, id="custom_penalty"),
     ],
 )
-def test_constraint_failure(nemorun: NeMoRunTestDefinition, step_kwargs: dict, expected_reward: float):
+def test_constraint_failure(nemorun: NeMoRunTestDefinition, rewards: RewardOverrides | None, expected_reward: float):
     tdef = nemorun.model_copy(deep=True)
     tdef.cmd_args.data.global_batch_size = 8
     tdef.agent_metrics = ["default"]
@@ -178,10 +178,10 @@ def test_constraint_failure(nemorun: NeMoRunTestDefinition, step_kwargs: dict, e
     )
     runner = MagicMock(spec=BaseRunner)
     runner.system = MagicMock()
-    env = CloudAIGymEnv(test_run=test_run, runner=runner)
+    env = CloudAIGymEnv(test_run=test_run, runner=runner, rewards=rewards)
 
     bad = {"trainer.strategy.context_parallel_size": 3}  # induce constraint failure
-    obs, reward, done, info = env.step(bad, **step_kwargs)
+    obs, reward, done, info = env.step(bad)
 
     assert obs == [-1.0]
     assert reward == expected_reward

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -27,6 +27,7 @@ from cloudai.core import (
     BaseAgent,
     BaseAgentConfig,
     Registry,
+    RewardOverrides,
     Runner,
     TestDependency,
     TestRun,
@@ -207,3 +208,8 @@ def test_dse_run_cache(base_tr: TestRun, tmp_path, caplog: pytest.LogCaptureFixt
     pd.testing.assert_frame_equal(actual_trajectory, expected_trajectory)
 
     assert [tr.step for tr in reporter.trs] == [1, 3]
+
+
+def test_rewards_nested() -> None:
+    cfg = BaseAgentConfig.model_validate({"rewards": {"constraint_failure": -2.5, "metric_failure": 0.0}})
+    assert cfg.rewards == RewardOverrides(constraint_failure=-2.5, metric_failure=0.0)

--- a/tests/workloads/megatron_run/test_report_gen_strategy.py
+++ b/tests/workloads/megatron_run/test_report_gen_strategy.py
@@ -137,6 +137,8 @@ def test_megatron_run_get_metric_iteration_time(slurm_system: SlurmSystem, megat
     # Expected: avg of [15800.0, 15639.0, 15448.5]
     expected_avg = (15800.0 + 15639.0 + 15448.5) / 3
     metric = strategy.get_metric("iteration-time")
+    assert metric is not METRIC_ERROR
+    assert isinstance(metric, float)
     assert abs(metric - expected_avg) < 0.1
 
 
@@ -145,6 +147,8 @@ def test_megatron_run_get_metric_default(slurm_system: SlurmSystem, megatron_run
     # Default should return iteration-time
     expected_avg = (15800.0 + 15639.0 + 15448.5) / 3
     metric = strategy.get_metric("default")
+    assert metric is not METRIC_ERROR
+    assert isinstance(metric, float)
     assert abs(metric - expected_avg) < 0.1
 
 
@@ -153,19 +157,21 @@ def test_megatron_run_get_metric_tflops(slurm_system: SlurmSystem, megatron_run_
     # Expected: avg of [490.0, 494.6, 500.6]
     expected_avg = (490.0 + 494.6 + 500.6) / 3
     metric = strategy.get_metric("tflops-per-gpu")
+    assert metric is not METRIC_ERROR
+    assert isinstance(metric, float)
     assert abs(metric - expected_avg) < 0.1
 
 
 def test_megatron_run_get_metric_invalid(slurm_system: SlurmSystem, megatron_run_tr: TestRun) -> None:
     strategy = MegatronRunReportGenerationStrategy(slurm_system, megatron_run_tr)
     metric = strategy.get_metric("invalid-metric")
-    assert metric == METRIC_ERROR
+    assert metric is METRIC_ERROR
 
 
 def test_megatron_run_get_metric_no_data(slurm_system: SlurmSystem, megatron_run_tr_no_data: TestRun) -> None:
     strategy = MegatronRunReportGenerationStrategy(slurm_system, megatron_run_tr_no_data)
     metric = strategy.get_metric("iteration-time")
-    assert metric == METRIC_ERROR
+    assert metric is METRIC_ERROR
 
 
 def test_megatron_run_metrics_class_var() -> None:

--- a/tests/workloads/megatron_run/test_report_gen_strategy.py
+++ b/tests/workloads/megatron_run/test_report_gen_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/workloads/megatron_run/test_report_gen_strategy.py
+++ b/tests/workloads/megatron_run/test_report_gen_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Summary
Refines the agent config overrides for rewards. Originally only constraint check failures' reward was possible to override, now metric errors can be modified. Also, leaves room for future overrides.

New TOML flags:
```toml
[Tests.agent_config.rewards]
constraint_failure = -5.0
metric_failure = 0.0
```

## Test Plan
Added new tests.
```bash
uv run python -m pytest \
  tests/test_handlers.py::test_rewards_nested \
  tests/test_cloudaigym.py::test_constraint_failure \
  -v
```

Keeps similar behavior as #865, but improves the interface.

> Note: Overrides only take effect in DSE mode!