### PR TITLE
Installables: submodules fix

### DIFF
--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -136,10 +136,10 @@ class GitRepo(Installable, BaseModel):
         if not has_submodules:
             return True, ""
 
-        submodules_initialized = (line.startswith(" ") for line in output)
-        if self.init_submodules and not all(submodules_initialized):
+        status_prefixes = [line[0] for line in output]
+        if self.init_submodules and not all(prefix == " " for prefix in status_prefixes):
             return False, "Cloned repo has not all submodules initialized."
-        if not self.init_submodules and any(submodules_initialized):
+        if not self.init_submodules and not all(prefix == "-" for prefix in status_prefixes):
             return False, "Cloned repo has some submodules initialized but requires none to be."
 
         return True, ""

--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -118,6 +119,44 @@ class GitRepo(Installable, BaseModel):
     @property
     def container_mount(self) -> str:
         return self.mount_as or f"/git/{self.repo_name}"
+
+    def check_submodules_state(self, repo_path: Path) -> tuple[bool, str]:
+        """Check if submodules state in the cloned repo matches self.init_submodules."""
+        result = subprocess.run(
+            ["git", "submodule", "status", "--recursive"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return False, f"Failed to get submodule status: {result.stderr}"
+        output = [line for line in result.stdout.splitlines() if line.strip()]
+
+        has_submodules = bool(output)
+        if not has_submodules:
+            return True, ""
+
+        submodules_initialized = (line.startswith(" ") for line in output)
+        if self.init_submodules and not all(submodules_initialized):
+            return False, "Cloned repo has not all submodules initialized."
+        if not self.init_submodules and any(submodules_initialized):
+            return False, "Cloned repo has some submodules initialized but requires none to be."
+
+        return True, ""
+
+    def ensure_submodules_state(self, repo_path: Path) -> tuple[bool, str]:
+        """Ensure submodules state in the cloned repo matches self.init_submodules (install or deinstall them)."""
+        submodules_are_ok, _ = self.check_submodules_state(repo_path)
+        if submodules_are_ok:
+            return True, ""
+
+        cmd = ["update", "--init", "--recursive"] if self.init_submodules else ["deinit", "--all", "--force"]
+        result = subprocess.run(["git", "submodule", *cmd], cwd=str(repo_path), capture_output=True, text=True)
+        if result.returncode != 0:
+            action = "initialize" if self.init_submodules else "deinitialize"
+            return False, f"Failed to {action} submodules: {result.stderr}"
+
+        return True, ""
 
 
 @dataclass

--- a/src/cloudai/_core/installables.py
+++ b/src/cloudai/_core/installables.py
@@ -146,9 +146,11 @@ class GitRepo(Installable, BaseModel):
 
     def ensure_submodules_state(self, repo_path: Path) -> tuple[bool, str]:
         """Ensure submodules state in the cloned repo matches self.init_submodules (install or deinstall them)."""
-        submodules_are_ok, _ = self.check_submodules_state(repo_path)
+        submodules_are_ok, submodules_are_ok_msg = self.check_submodules_state(repo_path)
         if submodules_are_ok:
             return True, ""
+        if not submodules_are_ok and "Failed to get submodule status" in submodules_are_ok_msg:
+            return False, submodules_are_ok_msg
 
         cmd = ["update", "--init", "--recursive"] if self.init_submodules else ["deinit", "--all", "--force"]
         result = subprocess.run(["git", "submodule", *cmd], cwd=str(repo_path), capture_output=True, text=True)

--- a/src/cloudai/systems/kubernetes/kubernetes_installer.py
+++ b/src/cloudai/systems/kubernetes/kubernetes_installer.py
@@ -116,6 +116,9 @@ class KubernetesInstaller(BaseInstaller):
                 verify_res = self._verify_commit(item.commit, repo_path)
                 if not verify_res.success:
                     return verify_res
+                verify_submodules, msg_submodules = item.check_submodules_state(repo_path)
+                if not verify_submodules:
+                    return InstallStatusResult(False, msg_submodules)
                 item.installed_path = repo_path
                 return InstallStatusResult(True)
             return InstallStatusResult(False, f"Git repository {item.url} not cloned")
@@ -156,10 +159,9 @@ class KubernetesInstaller(BaseInstaller):
             verify_res = self._verify_commit(item.commit, repo_path)
             if not verify_res.success:
                 return verify_res
-            if item.init_submodules:
-                res = self._init_submodules(repo_path)
-                if not res.success:
-                    return res
+            submodules_res, submodules_msg = item.ensure_submodules_state(repo_path)
+            if not submodules_res:
+                return InstallStatusResult(False, submodules_msg)
             item.installed_path = repo_path
             msg = f"Git repository already exists at {repo_path}."
             logging.debug(msg)
@@ -184,13 +186,12 @@ class KubernetesInstaller(BaseInstaller):
                 rmtree(repo_path)
             return res
 
-        if item.init_submodules:
-            res = self._init_submodules(repo_path)
-            if not res.success:
-                logging.error(f"Submodule init failed, removing cloned repository at {repo_path}")
-                if repo_path.exists():
-                    rmtree(repo_path)
-                return res
+        submodules_res, submodules_msg = item.ensure_submodules_state(repo_path)
+        if not submodules_res:
+            logging.error(f"Submodule setup failed with `{submodules_msg}`, removing cloned repository at {repo_path}")
+            if repo_path.exists():
+                rmtree(repo_path)
+            return InstallStatusResult(False, submodules_msg)
 
         return InstallStatusResult(True)
 
@@ -254,14 +255,6 @@ class KubernetesInstaller(BaseInstaller):
         result = subprocess.run(checkout_cmd, cwd=str(path), capture_output=True, text=True)
         if result.returncode != 0:
             return InstallStatusResult(False, f"Failed to checkout commit {commit_hash}: {result.stderr}")
-        return InstallStatusResult(True)
-
-    def _init_submodules(self, path: Path) -> InstallStatusResult:
-        logging.debug(f"Initializing submodules in {path}")
-        submodule_cmd = ["git", "submodule", "update", "--init", "--recursive"]
-        result = subprocess.run(submodule_cmd, cwd=str(path), capture_output=True, text=True)
-        if result.returncode != 0:
-            return InstallStatusResult(False, f"Failed to initialize submodules: {result.stderr}")
         return InstallStatusResult(True)
 
     def _verify_commit(self, ref: str, path: Path) -> InstallStatusResult:

--- a/src/cloudai/systems/slurm/slurm_installer.py
+++ b/src/cloudai/systems/slurm/slurm_installer.py
@@ -209,10 +209,9 @@ class SlurmInstaller(BaseInstaller):
             verify_res = self._verify_commit(item.commit, repo_path)
             if not verify_res.success:
                 return verify_res
-            if item.init_submodules:
-                res = self._init_submodules(repo_path)
-                if not res.success:
-                    return res
+            submodules_res, submodules_msg = item.ensure_submodules_state(repo_path)
+            if not submodules_res:
+                return InstallStatusResult(False, submodules_msg)
             item.installed_path = repo_path
             msg = f"Git repository already exists at {repo_path}."
             logging.debug(msg)
@@ -237,13 +236,12 @@ class SlurmInstaller(BaseInstaller):
                 rmtree(repo_path)
             return res
 
-        if item.init_submodules:
-            res = self._init_submodules(repo_path)
-            if not res.success:
-                logging.error(f"Submodule init failed, removing cloned repository at {repo_path}")
-                if repo_path.exists():
-                    rmtree(repo_path)
-                return res
+        submodules_res, submodules_msg = item.ensure_submodules_state(repo_path)
+        if not submodules_res:
+            logging.error(f"Submodule setup failed with `{submodules_msg}`, removing cloned repository at {repo_path}")
+            if repo_path.exists():
+                rmtree(repo_path)
+            return InstallStatusResult(False, submodules_msg)
 
         return InstallStatusResult(True)
 
@@ -307,14 +305,6 @@ class SlurmInstaller(BaseInstaller):
         result = subprocess.run(checkout_cmd, cwd=str(path), capture_output=True, text=True)
         if result.returncode != 0:
             return InstallStatusResult(False, f"Failed to checkout commit {commit_hash}: {result.stderr}")
-        return InstallStatusResult(True)
-
-    def _init_submodules(self, path: Path) -> InstallStatusResult:
-        logging.debug(f"Initializing submodules in {path}")
-        submodule_cmd = ["git", "submodule", "update", "--init", "--recursive"]
-        result = subprocess.run(submodule_cmd, cwd=str(path), capture_output=True, text=True)
-        if result.returncode != 0:
-            return InstallStatusResult(False, f"Failed to initialize submodules: {result.stderr}")
         return InstallStatusResult(True)
 
     def _verify_commit(self, ref: str, path: Path) -> InstallStatusResult:
@@ -450,6 +440,11 @@ class SlurmInstaller(BaseInstaller):
         verify_res = self._verify_commit(item.commit, repo_path)
         if not verify_res.success:
             return verify_res
+
+        verify_submodules, msg_submodules = item.check_submodules_state(repo_path)
+        if not verify_submodules:
+            return InstallStatusResult(False, msg_submodules)
+
         item.installed_path = repo_path
         return InstallStatusResult(True)
 

--- a/tests/test_git_repo_installer.py
+++ b/tests/test_git_repo_installer.py
@@ -103,7 +103,8 @@ class TestGitRepoInstaller:
         repo_path = installer.system.install_path / git.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
-        res = installer._install_one_git_repo(git)
+        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")):
+            res = installer._install_one_git_repo(git)
         assert res.success
         assert res.message == f"Git repository already exists at {repo_path}."
         assert git.installed_path == repo_path
@@ -232,29 +233,6 @@ class TestGitRepoInstaller:
             res = installer._verify_commit(ref, repo_path)
         assert res.success
 
-    def test_submodules_initialized(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
-        repo_path = installer.system.install_path / git.repo_name
-        repo_path.mkdir()
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess(args=[], returncode=0)
-            res = installer._init_submodules(repo_path)
-        assert res.success
-        mock_run.assert_called_once_with(
-            ["git", "submodule", "update", "--init", "--recursive"],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
-
-    def test_error_initializing_submodules(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
-        repo_path = installer.system.install_path / git.repo_name
-        repo_path.mkdir()
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = CompletedProcess(args=[], returncode=1, stderr="err")
-            res = installer._init_submodules(repo_path)
-        assert not res.success
-        assert res.message == "Failed to initialize submodules: err"
-
     def test_submodule_failure_cleans_up_repo(
         self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
     ):
@@ -264,17 +242,18 @@ class TestGitRepoInstaller:
             side_effect=lambda url, path: (path.mkdir(parents=True, exist_ok=True), InstallStatusResult(True))[1]
         )
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        installer._init_submodules = Mock(
-            return_value=InstallStatusResult(False, "Failed to initialize submodules: err")
-        )
-        res = installer._install_one_git_repo(git)
+        with patch.object(
+            GitRepo, "ensure_submodules_state", return_value=(False, "Failed to initialize submodules: err")
+        ):
+            res = installer._install_one_git_repo(git)
         assert not res.success
         assert not repo_path.exists()
 
     def test_all_good_flow(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
         installer._clone_repository = Mock(return_value=InstallStatusResult(True))
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        res = installer._install_one_git_repo(git)
+        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")):
+            res = installer._install_one_git_repo(git)
         assert res.success
         assert git.installed_path == installer.system.install_path / git.repo_name
 
@@ -283,19 +262,19 @@ class TestGitRepoInstaller:
     ):
         installer._clone_repository = Mock(return_value=InstallStatusResult(True))
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        installer._init_submodules = Mock(return_value=InstallStatusResult(True))
-        res = installer._install_one_git_repo(git)
+        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
+            res = installer._install_one_git_repo(git)
         assert res.success
-        installer._init_submodules.assert_not_called()
+        mock_ensure.assert_called_once()
 
     def test_submodules_run_when_requested(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
         git.init_submodules = True
         installer._clone_repository = Mock(return_value=InstallStatusResult(True))
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        installer._init_submodules = Mock(return_value=InstallStatusResult(True))
-        res = installer._install_one_git_repo(git)
+        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
+            res = installer._install_one_git_repo(git)
         assert res.success
-        installer._init_submodules.assert_called_once()
+        mock_ensure.assert_called_once()
 
     def test_existing_repo_inits_submodules_when_requested(
         self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
@@ -304,11 +283,47 @@ class TestGitRepoInstaller:
         repo_path = installer.system.install_path / git.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
-        installer._init_submodules = Mock(return_value=InstallStatusResult(True))
-        res = installer._install_one_git_repo(git)
+        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
+            res = installer._install_one_git_repo(git)
         assert res.success
         assert git.installed_path == repo_path
-        installer._init_submodules.assert_called_once_with(repo_path)
+        mock_ensure.assert_called_once_with(repo_path)
+
+    def test_existing_repo_deinits_submodules_when_not_requested(
+        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+    ):
+        repo_path = installer.system.install_path / git.repo_name
+        repo_path.mkdir()
+        installer._verify_commit = Mock(return_value=InstallStatusResult(True))
+        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
+            res = installer._install_one_git_repo(git)
+
+        assert res.success
+        mock_ensure.assert_called_once_with(repo_path)
+
+    def test_is_installed_checks_submodule_state(
+        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+    ):
+        repo_path = installer.system.install_path / git.repo_name
+        repo_path.mkdir()
+        installer._verify_commit = Mock(return_value=InstallStatusResult(True))
+        with patch.object(GitRepo, "check_submodules_state", return_value=(True, "")) as mock_check:
+            res = installer.is_installed_one(git)
+
+        assert res.success
+        mock_check.assert_called_once_with(repo_path)
+
+    def test_is_installed_fails_when_submodule_state_does_not_match(
+        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+    ):
+        repo_path = installer.system.install_path / git.repo_name
+        repo_path.mkdir()
+        installer._verify_commit = Mock(return_value=InstallStatusResult(True))
+        with patch.object(GitRepo, "check_submodules_state", return_value=(False, "Submodule state does not match")):
+            res = installer.is_installed_one(git)
+
+        assert not res.success
+        assert "Submodule state does not match" in res.message
 
     def test_uninstall_no_repo(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
         res = installer._uninstall_git_repo(git)

--- a/tests/test_git_repo_installer.py
+++ b/tests/test_git_repo_installer.py
@@ -16,8 +16,8 @@
 
 from pathlib import Path
 from subprocess import CompletedProcess
-from typing import Any, Union
-from unittest.mock import Mock, patch
+from typing import Any, Iterator, Union
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -94,8 +94,31 @@ def installer(
 
 
 @pytest.fixture
-def git() -> GitRepo:
+def git_unmocked() -> GitRepo:
     return GitRepo(url="./git_url", commit="commit_hash")
+
+
+@pytest.fixture
+def check_submodules_state_mock() -> MagicMock:
+    return MagicMock(return_value=(True, ""))
+
+
+@pytest.fixture
+def ensure_submodules_state_mock() -> MagicMock:
+    return MagicMock(return_value=(True, ""))
+
+
+@pytest.fixture
+def git(
+    git_unmocked: GitRepo,
+    check_submodules_state_mock: MagicMock,
+    ensure_submodules_state_mock: MagicMock,
+) -> Iterator[GitRepo]:
+    with (
+        patch.object(GitRepo, "check_submodules_state", check_submodules_state_mock),
+        patch.object(GitRepo, "ensure_submodules_state", ensure_submodules_state_mock),
+    ):
+        yield git_unmocked
 
 
 class TestGitRepoInstaller:
@@ -103,8 +126,7 @@ class TestGitRepoInstaller:
         repo_path = installer.system.install_path / git.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")):
-            res = installer._install_one_git_repo(git)
+        res = installer._install_one_git_repo(git)
         assert res.success
         assert res.message == f"Git repository already exists at {repo_path}."
         assert git.installed_path == repo_path
@@ -234,10 +256,10 @@ class TestGitRepoInstaller:
         assert res.success
 
     def test_submodule_failure_cleans_up_repo(
-        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+        self, installer: Union[KubernetesInstaller, SlurmInstaller], git_unmocked: GitRepo
     ):
-        git.init_submodules = True
-        repo_path = installer.system.install_path / git.repo_name
+        git_unmocked.init_submodules = True
+        repo_path = installer.system.install_path / git_unmocked.repo_name
         installer._clone_repository = Mock(
             side_effect=lambda url, path: (path.mkdir(parents=True, exist_ok=True), InstallStatusResult(True))[1]
         )
@@ -245,82 +267,93 @@ class TestGitRepoInstaller:
         with patch.object(
             GitRepo, "ensure_submodules_state", return_value=(False, "Failed to initialize submodules: err")
         ):
-            res = installer._install_one_git_repo(git)
+            res = installer._install_one_git_repo(git_unmocked)
         assert not res.success
         assert not repo_path.exists()
 
     def test_all_good_flow(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
         installer._clone_repository = Mock(return_value=InstallStatusResult(True))
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")):
-            res = installer._install_one_git_repo(git)
+        res = installer._install_one_git_repo(git)
         assert res.success
         assert git.installed_path == installer.system.install_path / git.repo_name
 
     def test_submodules_skipped_when_not_requested(
-        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+        self,
+        installer: Union[KubernetesInstaller, SlurmInstaller],
+        git: GitRepo,
+        ensure_submodules_state_mock: MagicMock,
     ):
         installer._clone_repository = Mock(return_value=InstallStatusResult(True))
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
-            res = installer._install_one_git_repo(git)
+        res = installer._install_one_git_repo(git)
         assert res.success
-        mock_ensure.assert_called_once()
+        ensure_submodules_state_mock.assert_called_once()
 
-    def test_submodules_run_when_requested(self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo):
+    def test_submodules_run_when_requested(
+        self,
+        installer: Union[KubernetesInstaller, SlurmInstaller],
+        git: GitRepo,
+        ensure_submodules_state_mock: MagicMock,
+    ):
         git.init_submodules = True
         installer._clone_repository = Mock(return_value=InstallStatusResult(True))
         installer._checkout_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
-            res = installer._install_one_git_repo(git)
+        res = installer._install_one_git_repo(git)
         assert res.success
-        mock_ensure.assert_called_once()
+        ensure_submodules_state_mock.assert_called_once()
 
     def test_existing_repo_inits_submodules_when_requested(
-        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+        self,
+        installer: Union[KubernetesInstaller, SlurmInstaller],
+        git: GitRepo,
+        ensure_submodules_state_mock: MagicMock,
     ):
         git.init_submodules = True
         repo_path = installer.system.install_path / git.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
-            res = installer._install_one_git_repo(git)
+        res = installer._install_one_git_repo(git)
         assert res.success
         assert git.installed_path == repo_path
-        mock_ensure.assert_called_once_with(repo_path)
+        ensure_submodules_state_mock.assert_called_once_with(repo_path)
 
     def test_existing_repo_deinits_submodules_when_not_requested(
-        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+        self,
+        installer: Union[KubernetesInstaller, SlurmInstaller],
+        git: GitRepo,
+        ensure_submodules_state_mock: MagicMock,
     ):
         repo_path = installer.system.install_path / git.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "ensure_submodules_state", return_value=(True, "")) as mock_ensure:
-            res = installer._install_one_git_repo(git)
+        res = installer._install_one_git_repo(git)
 
         assert res.success
-        mock_ensure.assert_called_once_with(repo_path)
+        ensure_submodules_state_mock.assert_called_once_with(repo_path)
 
     def test_is_installed_checks_submodule_state(
-        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+        self,
+        installer: Union[KubernetesInstaller, SlurmInstaller],
+        git: GitRepo,
+        check_submodules_state_mock: MagicMock,
     ):
         repo_path = installer.system.install_path / git.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
-        with patch.object(GitRepo, "check_submodules_state", return_value=(True, "")) as mock_check:
-            res = installer.is_installed_one(git)
+        res = installer.is_installed_one(git)
 
         assert res.success
-        mock_check.assert_called_once_with(repo_path)
+        check_submodules_state_mock.assert_called_once_with(repo_path)
 
     def test_is_installed_fails_when_submodule_state_does_not_match(
-        self, installer: Union[KubernetesInstaller, SlurmInstaller], git: GitRepo
+        self, installer: Union[KubernetesInstaller, SlurmInstaller], git_unmocked: GitRepo
     ):
-        repo_path = installer.system.install_path / git.repo_name
+        repo_path = installer.system.install_path / git_unmocked.repo_name
         repo_path.mkdir()
         installer._verify_commit = Mock(return_value=InstallStatusResult(True))
         with patch.object(GitRepo, "check_submodules_state", return_value=(False, "Submodule state does not match")):
-            res = installer.is_installed_one(git)
+            res = installer.is_installed_one(git_unmocked)
 
         assert not res.success
         assert "Submodule state does not match" in res.message

--- a/tests/test_installables.py
+++ b/tests/test_installables.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from cloudai.core import GitRepo
+
+
+@pytest.fixture
+def git() -> GitRepo:
+    return GitRepo(url="./git_url", commit="commit_hash")
+
+
+class TestGitRepoSubmodules:
+    @pytest.mark.parametrize("init_submodules", [True, False])
+    def test_check_submodules_state_no_submodules(self, git: GitRepo, init_submodules: bool):
+        git.init_submodules = init_submodules
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+            result, message = git.check_submodules_state(Path("/repo"))
+
+        assert result is True
+        assert message == ""
+
+    @pytest.mark.parametrize(
+        ("init_submodules", "stdout", "expected_result", "expected_message"),
+        [
+            (True, " 0123456789abcdef path/to/submodule\n", True, ""),
+            (True, "-0123456789abcdef path/to/submodule\n", False, "Cloned repo has not all submodules initialized."),
+            (False, "-0123456789abcdef path/to/submodule\n", True, ""),
+            (
+                False,
+                " 0123456789abcdef path/to/submodule\n",
+                False,
+                "Cloned repo has some submodules initialized but requires none to be.",
+            ),
+        ],
+    )
+    def test_check_submodules_state(
+        self,
+        git: GitRepo,
+        init_submodules: bool,
+        stdout: str,
+        expected_result: bool,
+        expected_message: str,
+    ):
+        git.init_submodules = init_submodules
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+            result, message = git.check_submodules_state(Path("/repo"))
+
+        assert result is expected_result
+        assert message == expected_message
+
+    def test_check_submodules_state_status_failure(self, git: GitRepo):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+            result, message = git.check_submodules_state(Path("/repo"))
+
+        assert result is False
+        assert message == "Failed to get submodule status: err"
+
+    @pytest.mark.parametrize(
+        ("init_submodules", "stdout", "expected_command"),
+        [
+            (True, "-0123456789abcdef path/to/submodule\n", ["git", "submodule", "update", "--init", "--recursive"]),
+            (False, " 0123456789abcdef path/to/submodule\n", ["git", "submodule", "deinit", "--all", "--force"]),
+        ],
+    )
+    def test_ensure_submodules_state_reconciles(
+        self, git: GitRepo, init_submodules: bool, stdout: str, expected_command: list[str]
+    ):
+        git.init_submodules = init_submodules
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=""),
+                CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ]
+            result, message = git.ensure_submodules_state(Path("/repo"))
+
+        assert result is True
+        assert message == ""
+        assert mock_run.call_args_list[1].args[0] == expected_command
+
+    @pytest.mark.parametrize("init_submodules", [True, False])
+    def test_ensure_submodules_state_noop_when_matching(self, git: GitRepo, init_submodules: bool):
+        git.init_submodules = init_submodules
+        stdout = " 0123456789abcdef path/to/submodule\n" if init_submodules else "-0123456789abcdef path/to/submodule\n"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+            result, message = git.ensure_submodules_state(Path("/repo"))
+
+        assert result is True
+        assert message == ""
+        assert mock_run.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("init_submodules", "stdout", "expected_message"),
+        [
+            (True, "-0123456789abcdef path/to/submodule\n", "Failed to initialize submodules: err"),
+            (False, " 0123456789abcdef path/to/submodule\n", "Failed to deinitialize submodules: err"),
+        ],
+    )
+    def test_ensure_submodules_state_reconcile_failure(
+        self,
+        git: GitRepo,
+        init_submodules: bool,
+        stdout: str,
+        expected_message: str,
+    ):
+        git.init_submodules = init_submodules
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=""),
+                CompletedProcess(args=[], returncode=1, stdout="", stderr="err"),
+            ]
+            result, message = git.ensure_submodules_state(Path("/repo"))
+
+        assert result is False
+        assert message == expected_message

--- a/tests/test_installables.py
+++ b/tests/test_installables.py
@@ -45,10 +45,24 @@ class TestGitRepoSubmodules:
         [
             (True, " 0123456789abcdef path/to/submodule\n", True, ""),
             (True, "-0123456789abcdef path/to/submodule\n", False, "Cloned repo has not all submodules initialized."),
+            (True, "+0123456789abcdef path/to/submodule\n", False, "Cloned repo has not all submodules initialized."),
+            (True, "U0123456789abcdef path/to/submodule\n", False, "Cloned repo has not all submodules initialized."),
             (False, "-0123456789abcdef path/to/submodule\n", True, ""),
             (
                 False,
                 " 0123456789abcdef path/to/submodule\n",
+                False,
+                "Cloned repo has some submodules initialized but requires none to be.",
+            ),
+            (
+                False,
+                "+0123456789abcdef path/to/submodule\n",
+                False,
+                "Cloned repo has some submodules initialized but requires none to be.",
+            ),
+            (
+                False,
+                "U0123456789abcdef path/to/submodule\n",
                 False,
                 "Cloned repo has some submodules initialized but requires none to be.",
             ),
@@ -84,6 +98,8 @@ class TestGitRepoSubmodules:
         [
             (True, "-0123456789abcdef path/to/submodule\n", ["git", "submodule", "update", "--init", "--recursive"]),
             (False, " 0123456789abcdef path/to/submodule\n", ["git", "submodule", "deinit", "--all", "--force"]),
+            (False, "+0123456789abcdef path/to/submodule\n", ["git", "submodule", "deinit", "--all", "--force"]),
+            (False, "U0123456789abcdef path/to/submodule\n", ["git", "submodule", "deinit", "--all", "--force"]),
         ],
     )
     def test_ensure_submodules_state_reconciles(
@@ -120,6 +136,8 @@ class TestGitRepoSubmodules:
         [
             (True, "-0123456789abcdef path/to/submodule\n", "Failed to initialize submodules: err"),
             (False, " 0123456789abcdef path/to/submodule\n", "Failed to deinitialize submodules: err"),
+            (False, "+0123456789abcdef path/to/submodule\n", "Failed to deinitialize submodules: err"),
+            (False, "U0123456789abcdef path/to/submodule\n", "Failed to deinitialize submodules: err"),
         ],
     )
     def test_ensure_submodules_state_reconcile_failure(

--- a/tests/test_installables.py
+++ b/tests/test_installables.py
@@ -158,3 +158,12 @@ class TestGitRepoSubmodules:
 
         assert result is False
         assert message == expected_message
+
+    def test_ensure_submodules_state_status_fails(self, git: GitRepo):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [CompletedProcess(args=[], returncode=1, stdout="bla", stderr="bla")]
+            result, message = git.ensure_submodules_state(Path("/repo"))
+
+        assert result is False
+        assert "bla" in message
+        assert mock_run.call_count == 1


### PR DESCRIPTION
## Summary
Issue:

1. Install a git repo with `init_submodules = false`
2. Change `init_submodules` to `true`
3. Run the workload - submodules aren't installed

## Test Plan
- Automated CI
- Manual `cloudai install/run` runs on EOS

## Additional Notes
-