### PR TITLE
Fix broken duplicate test name detection in TestParser.parse_all()

### DIFF
--- a/src/cloudai/test_parser.py
+++ b/src/cloudai/test_parser.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,11 +63,7 @@ class TestParser:
                 parsed_object = self._parse_data(data)
                 obj_name: str = parsed_object.name
                 if obj_name in seen_names:
-                    raise ValueError(
-                        f"Duplicate test name '{obj_name}' found in:\n"
-                        f"  - {seen_names[obj_name]}\n"
-                        f"  - {f}"
-                    )
+                    raise ValueError(f"Duplicate test name '{obj_name}' found in:\n  - {seen_names[obj_name]}\n  - {f}")
                 seen_names[obj_name] = f
                 objects.append(parsed_object)
         return objects

--- a/src/cloudai/test_parser.py
+++ b/src/cloudai/test_parser.py
@@ -54,6 +54,7 @@ class TestParser:
             List[Any]: List of objects from the configuration files.
         """
         objects: List[Any] = []
+        seen_names: Dict[str, Path] = {}
         for f in self.test_tomls:
             self.current_file = f
             logging.debug(f"Parsing file: {f}")
@@ -61,8 +62,13 @@ class TestParser:
                 data: Dict[str, Any] = toml.load(fh)
                 parsed_object = self._parse_data(data)
                 obj_name: str = parsed_object.name
-                if obj_name in objects:
-                    raise ValueError(f"Duplicate name found: {obj_name}")
+                if obj_name in seen_names:
+                    raise ValueError(
+                        f"Duplicate test name '{obj_name}' found in:\n"
+                        f"  - {seen_names[obj_name]}\n"
+                        f"  - {f}"
+                    )
+                seen_names[obj_name] = f
                 objects.append(parsed_object)
         return objects
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,9 +19,10 @@ from typing import Generator, cast
 from unittest.mock import Mock, patch
 
 import pytest
+import toml
 from pydantic_core import ErrorDetails
 
-from cloudai.core import Parser, Registry, Reporter, format_validation_error
+from cloudai.core import Parser, Registry, Reporter, TestParser, format_validation_error
 from cloudai.models.scenario import ReportConfig, parse_reports_spec
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 
@@ -204,3 +205,73 @@ class TestParseReportsSpec:
         with pytest.raises(ValueError) as exc_info:
             parse_reports_spec({scenario_report: {"enable": "invalid"}})
         assert f"Error validating report configuration '{scenario_report}' as ReportConfig: " in str(exc_info.value)
+
+
+class TestParseAllDuplicateDetection:
+    """Tests for TestParser.parse_all() duplicate name detection.
+
+    Reproduces the scenario where two TOML files (e.g. a DSE config and a
+    single-point copy) share the same ``name`` field. The current check
+    ``if name in objects`` compares a str against a list of Pydantic
+    BaseModel instances, which always evaluates to False.
+    """
+
+    __test__ = True
+
+    @staticmethod
+    def _write_test_toml(path: Path, name: str) -> None:
+        path.write_text(toml.dumps({"name": name, "description": "test"}))
+
+    @staticmethod
+    def _make_fake_parsed(name: str) -> Mock:
+        obj = Mock()
+        obj.name = name
+        return obj
+
+    def test_duplicate_name_across_files_raises(self, tmp_path: Path):
+        """Two files with the same name field should raise ValueError."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        dse_toml = test_dir / "dse_qwen_30b_a3b.toml"
+        single_toml = test_dir / "qwen_30b_a3b.toml"
+        self._write_test_toml(dse_toml, "dse_qwen_30b_a3b")
+        self._write_test_toml(single_toml, "dse_qwen_30b_a3b")
+
+        parser = TestParser([dse_toml, single_toml], None)  # type: ignore
+        fake = self._make_fake_parsed("dse_qwen_30b_a3b")
+
+        with patch.object(parser, "_parse_data", return_value=fake):
+            with pytest.raises(ValueError, match="dse_qwen_30b_a3b"):
+                parser.parse_all()
+
+    def test_unique_names_no_error(self, tmp_path: Path):
+        """Files with distinct names should parse without error."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        toml_a = test_dir / "test_a.toml"
+        toml_b = test_dir / "test_b.toml"
+        self._write_test_toml(toml_a, "test_a")
+        self._write_test_toml(toml_b, "test_b")
+
+        parser = TestParser([toml_a, toml_b], None)  # type: ignore
+
+        with patch.object(
+            parser,
+            "_parse_data",
+            side_effect=[self._make_fake_parsed("test_a"), self._make_fake_parsed("test_b")],
+        ):
+            results = parser.parse_all()
+            assert len(results) == 2
+
+    def test_single_file_no_error(self, tmp_path: Path):
+        """A single file should parse without error."""
+        test_dir = tmp_path / "tests"
+        test_dir.mkdir()
+        toml_a = test_dir / "only_one.toml"
+        self._write_test_toml(toml_a, "only_one")
+
+        parser = TestParser([toml_a], None)  # type: ignore
+
+        with patch.object(parser, "_parse_data", return_value=self._make_fake_parsed("only_one")):
+            results = parser.parse_all()
+            assert len(results) == 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -211,9 +211,9 @@ class TestParseAllDuplicateDetection:
     """Tests for TestParser.parse_all() duplicate name detection.
 
     Reproduces the scenario where two TOML files (e.g. a DSE config and a
-    single-point copy) share the same ``name`` field. The current check
-    ``if name in objects`` compares a str against a list of Pydantic
-    BaseModel instances, which always evaluates to False.
+    single-point copy) share the same ``name`` field. The implementation
+    tracks seen names in a ``dict[str, Path]`` and raises ``ValueError``
+    listing both conflicting file paths when a duplicate is found.
     """
 
     __test__ = True
@@ -241,8 +241,11 @@ class TestParseAllDuplicateDetection:
         fake = self._make_fake_parsed("dse_qwen_30b_a3b")
 
         with patch.object(parser, "_parse_data", return_value=fake):
-            with pytest.raises(ValueError, match="dse_qwen_30b_a3b"):
+            with pytest.raises(ValueError, match="dse_qwen_30b_a3b") as exc_info:
                 parser.parse_all()
+            msg = str(exc_info.value)
+            assert str(dse_toml) in msg
+            assert str(single_toml) in msg
 
     def test_unique_names_no_error(self, tmp_path: Path):
         """Files with distinct names should parse without error."""


### PR DESCRIPTION
## Summary

- Fix the duplicate test name check in `TestParser.parse_all()` which never fires due to a type mismatch (`str in List[BaseModel]` always returns `False`)
- Replace with a `dict[str, Path]` lookup that correctly detects duplicates and reports both conflicting file paths
- Add 3 unit tests covering duplicate detection, unique names, and single-file parsing

## Test plan

- [x] `test_duplicate_name_across_files_raises` — confirms duplicates now raise `ValueError`
- [x] `test_unique_names_no_error` — confirms distinct names parse without error
- [x] `test_single_file_no_error` — confirms single file parses without error
- [x] All 14 tests in `tests/test_parser.py` pass

Fixes https://github.com/NVIDIA/cloudai/issues/874
https://redmine.mellanox.com/issues/4979846