### PR TITLE
Parsing: fix system config detection

### DIFF
--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -551,7 +551,7 @@ def load_tomls_by_type(tomls: List[Path]) -> dict[str, List[Path]]:
                 files["hook"].append(toml_file)
             continue
 
-        if "scheduler =" in content:
+        if "\nscheduler =" in content:
             files["system"].append(toml_file)
         elif "test_template_name =" in content and "[[Tests]]" not in content:
             files["test"].append(toml_file)

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -554,8 +554,11 @@ def load_tomls_by_type(tomls: List[Path]) -> dict[str, List[Path]]:
         try:
             toml_content = toml.loads(content)
         except toml.TomlDecodeError:
+            files["unknown"].append(toml_file)
             continue
+
         if not isinstance(toml_content, dict):
+            files["unknown"].append(toml_file)
             continue
 
         if "scheduler" in toml_content:

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -551,7 +551,14 @@ def load_tomls_by_type(tomls: List[Path]) -> dict[str, List[Path]]:
                 files["hook"].append(toml_file)
             continue
 
-        if "\nscheduler =" in content:
+        try:
+            toml_content = toml.loads(content)
+        except toml.TomlDecodeError:
+            continue
+        if not isinstance(toml_content, dict):
+            continue
+
+        if "scheduler" in toml_content:
             files["system"].append(toml_file)
         elif "test_template_name =" in content and "[[Tests]]" not in content:
             files["test"].append(toml_file)

--- a/tests/test_toml_files.py
+++ b/tests/test_toml_files.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_toml_files.py
+++ b/tests/test_toml_files.py
@@ -26,6 +26,21 @@ from cloudai.models.scenario import TestScenarioModel
 TOML_FILES = list(Path("conf").glob("**/*.toml"))
 
 
+def get_all_systems() -> list[Path]:
+    result = []
+
+    for p in TOML_FILES:
+        try:
+            toml_content = toml.loads(p.read_text())
+        except toml.TomlDecodeError:
+            continue
+
+        if isinstance(toml_content, dict) and "scheduler" in toml_content:
+            result.append(p)
+
+    return result
+
+
 @pytest.mark.parametrize("toml_file", TOML_FILES, ids=lambda x: str(x))
 def test_toml_files(toml_file: Path):
     """
@@ -38,7 +53,7 @@ def test_toml_files(toml_file: Path):
         assert toml.load(f) is not None
 
 
-ALL_SYSTEMS = [p for p in Path("conf/").glob("**/*.toml") if "scheduler =" in p.read_text()]
+ALL_SYSTEMS = get_all_systems()
 
 
 @pytest.mark.parametrize("system_file", ALL_SYSTEMS, ids=lambda x: str(x))


### PR DESCRIPTION
## Summary
`scheduler =` pattern was detected in a config with `something_scheduler =` being part of cmd args

## Test Plan
- Automated CI
- Manual run of `verify-configs` on CloudAIx repo

## Additional Notes
- Internal [ticket](https://redmine.mellanox.com/issues/4989418)
