### PR TITLE
Append trajectory row on cache hits

### DIFF
--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -123,8 +123,17 @@ class CloudAIGymEnv(BaseGym):
         cached_result = self.get_cached_trajectory_result(action)
         if cached_result is not None:
             logging.info(
-                "Retrieved cached result from trajectory with reward %s. Skipping step.",
+                "Retrieved cached result from trajectory with reward %s (from step %s). Skipping execution.",
                 cached_result.reward,
+                cached_result.step,
+            )
+            self.write_trajectory(
+                TrajectoryEntry(
+                    step=self.test_run.step,
+                    action=action,
+                    reward=cached_result.reward,
+                    observation=cached_result.observation,
+                )
             )
             return cached_result.observation, cached_result.reward, False, {}
 

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -379,9 +379,7 @@ def test_get_cached_trajectory_result(
         assert actual.step == expected_step
 
 
-def test_cached_step_appends_trajectory_row(
-    nemorun: NeMoRunTestDefinition, tmp_path: Path
-) -> None:
+def test_cached_step_appends_trajectory_row(nemorun: NeMoRunTestDefinition, tmp_path: Path) -> None:
     """Cache hits must still append a row to trajectory.csv so the visible step list matches agent_steps."""
     tdef = nemorun.model_copy(deep=True)
     tdef.cmd_args.data.global_batch_size = 8
@@ -406,6 +404,7 @@ def test_cached_step_appends_trajectory_row(
     env.test_run.step = 5
     obs, reward, done, _info = env.step(cached_action)
 
+    runner.run.assert_not_called()
     assert reward == 0.42
     assert obs == [0.84]
     assert done is False

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -377,3 +377,46 @@ def test_get_cached_trajectory_result(
         assert expected_step is None
     else:
         assert actual.step == expected_step
+
+
+def test_cached_step_appends_trajectory_row(
+    nemorun: NeMoRunTestDefinition, tmp_path: Path
+) -> None:
+    """Cache hits must still append a row to trajectory.csv so the visible step list matches agent_steps."""
+    tdef = nemorun.model_copy(deep=True)
+    tdef.cmd_args.data.global_batch_size = 8
+    tdef.agent_metrics = ["default"]
+    test_run = TestRun(
+        name="cache_tr",
+        test=tdef,
+        num_nodes=1,
+        nodes=[],
+        reports={NeMoRunReportGenerationStrategy},
+    )
+
+    runner = MagicMock(spec=BaseRunner)
+    runner.scenario_root = tmp_path / "scenario"
+    runner.system = MagicMock()
+
+    env = CloudAIGymEnv(test_run=test_run, runner=runner, rewards=RewardOverrides())
+    cached_action = {"trainer.max_steps": 1000}
+    env.test_run.current_iteration = 0
+    env.trajectory = {0: [TrajectoryEntry(step=1, action=cached_action, reward=0.42, observation=[0.84])]}
+
+    env.test_run.step = 5
+    obs, reward, done, _info = env.step(cached_action)
+
+    assert reward == 0.42
+    assert obs == [0.84]
+    assert done is False
+    rows = env.trajectory[0]
+    assert len(rows) == 2
+    assert rows[-1].step == 5
+    assert rows[-1].reward == 0.42
+    assert rows[-1].action == cached_action
+
+    csv_path = env.trajectory_file_path
+    assert csv_path.exists()
+    contents = csv_path.read_text().strip().splitlines()
+    assert contents[0] == "step,action,reward,observation"
+    assert contents[-1].startswith("5,")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -202,6 +202,7 @@ def test_dse_run_cache(base_tr: TestRun, tmp_path, caplog: pytest.LogCaptureFixt
     expected_trajectory = pd.DataFrame(
         data=[
             [1, "{'candidate': 1}", -1.0, "[-1.0]"],
+            [2, "{'candidate': 1}", -1.0, "[-1.0]"],
             [3, "{'candidate': 2}", -1.0, "[-1.0]"],
         ],
         columns=["step", "action", "reward", "observation"],


### PR DESCRIPTION
## Summary

`CloudAIGymEnv.step()` short-circuits when the requested action has already been evaluated, returning the cached reward/observation. Currently this path **does not** append a row to `trajectory.csv` or to `self.current_trajectory`, so the visible trajectory contains only the executed (non-cached) steps even though the agent observed `agent_steps` interactions.

Downstream consequences:
- Step counts in reports / `analysis.json` diverge from the agent's actual interaction count.
- The CSV row index is no longer a stable proxy for "agent step", breaking offline analysis tools that assume one row per call to `step()`.
- Any future offline-RL / behavior-cloning corpus built from `trajectory.csv` is missing transitions.

This PR writes a `TrajectoryEntry` for cache hits using the **current** step index, reusing the cached reward and observation. The log line is also expanded to record the originating step the cached result was taken from.

## Changes

- `src/cloudai/configurator/cloudai_gym.py`: append a `TrajectoryEntry` in the cache-hit branch of `step()`; log the source step.
- `tests/test_cloudaigym.py`: add `test_cached_step_appends_trajectory_row` that primes `env.trajectory`, invokes `step()`, and asserts a new row appears in both the in-memory trajectory and `trajectory.csv`.

## Test plan

- [x] `pytest tests/test_cloudaigym.py` — 27 passed locally.
- [x] `ruff check` on the touched files — clean.
- [ ] CI green.