### PR TITLE
[CLI/Core] Polymorphic agent dispatch + TestRun owns trial counter

### DIFF
--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -110,6 +110,11 @@ class TestRun:
         """
         return self.current_iteration + 1 < self.iterations
 
+    def increment_step(self) -> int:
+        """Advance the trial counter and return the new value."""
+        self.step += 1
+        return self.step
+
     @property
     def metric_reporter(self) -> Optional[Type[ReportGenerationStrategy]]:
         if not self.reports:

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -146,18 +146,30 @@ def _has_custom_training_loop(agent: object) -> TypeGuard[CustomTrainingLoopAgen
 
 
 def _run_custom_training_loop(agent: CustomTrainingLoopAgent, agent_type: str) -> int:
-    """Drive an agent's self-contained training loop and return a process-style exit code."""
+    """
+    Drive an agent's self-contained training loop and return a process-style exit code.
+
+    ``shutdown()`` runs inside its own ``try/except`` so a faulty teardown cannot
+    suppress the exit code from ``train()`` nor propagate out of this helper:
+    ``handle_dse_job`` relies on the returned ``rc`` to accumulate ``err |= rc``
+    and continue with the remaining test runs.
+    """
     logging.info(f"Agent {agent_type} drives its own training loop; delegating to agent.train().")
+    rc = 0
     try:
         agent.train()
-        return 0
     except Exception:
         logging.exception(f"Custom training loop failed for agent {agent_type}.")
-        return 1
+        rc = 1
     finally:
         shutdown = getattr(agent, "shutdown", None)
         if callable(shutdown):
-            shutdown()
+            try:
+                shutdown()
+            except Exception:
+                logging.exception(f"Shutdown failed for agent {agent_type}.")
+                rc = 1
+    return rc
 
 
 def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -18,6 +18,7 @@ import argparse
 import copy
 import logging
 import signal
+import traceback
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, List, Optional
@@ -132,43 +133,78 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
         return 1
 
     err = 0
-    for tr in runner.runner.test_scenario.test_runs:
-        test_run = copy.deepcopy(tr)
+    # Recoverable failures return a non-zero rc and are accumulated here; an unexpected exception
+    # (a bug) is a hard-fail. We capture it so reports still generate, then re-raise below.
+    run_error: Exception | None = None
+    try:
+        for tr in runner.runner.test_scenario.test_runs:
+            test_run = copy.deepcopy(tr)
 
-        agent_type = test_run.test.agent
-        agent_class = registry.agents_map.get(agent_type)
-        if agent_class is None:
-            logging.error(
-                f"No agent available for type: {agent_type}. Please make sure {agent_type} "
-                f"is a valid agent type. Available agents: {registry.agents_map.keys()}"
+            agent_type = test_run.test.agent
+            agent_class = registry.agents_map.get(agent_type)
+            if agent_class is None:
+                logging.error(
+                    f"No agent available for type: {agent_type}. Please make sure {agent_type} "
+                    f"is a valid agent type. Available agents: {registry.agents_map.keys()}"
+                )
+                err = 1
+                continue
+
+            agent_config_data = test_run.test.agent_config or {}
+            agent_config = agent_class.get_config_class()(**agent_config_data)
+            env = CloudAIGymEnv(
+                test_run=test_run,
+                runner=runner.runner,
+                rewards=agent_config.rewards,
             )
-            err = 1
-            continue
+            if agent_config.start_action == "first":
+                logging.info(f"Using deterministic first sweep for the chosen agent: {env.first_sweep}.")
 
-        agent_config_data = test_run.test.agent_config or {}
-        agent_config = agent_class.get_config_class()(**agent_config_data)
-        env = CloudAIGymEnv(
-            test_run=test_run,
-            runner=runner.runner,
-            rewards=agent_config.rewards,
-        )
-        if agent_config.start_action == "first":
-            logging.info(f"Using deterministic first sweep for the chosen agent: {env.first_sweep}.")
+            agent = agent_class(env, agent_config)
 
-        agent = agent_class(env, agent_config)
-
-        err |= agent.run()
+            err |= agent.run()
+    except Exception as exc:
+        run_error = exc
+        logging.exception("DSE job aborted by an unexpected error; generating reports before failing.")
 
     if args.mode == "run":
         runner.runner.test_scenario.test_runs = original_test_runs
-        generate_reports(runner.runner.system, runner.runner.test_scenario, runner.runner.scenario_root)
+        generate_reports(
+            runner.runner.system,
+            runner.runner.test_scenario,
+            runner.runner.scenario_root,
+            error=run_error,
+        )
+
+    if run_error is not None:
+        raise run_error
 
     logging.info("All jobs are complete.")
     return err
 
 
-def generate_reports(system: System, test_scenario: TestScenario, result_dir: Path) -> None:
+def _record_run_failure(result_dir: Path, error: BaseException) -> None:
+    """Persist an aborting error into the results dir so the failure is documented with the reports."""
+    failure_path = result_dir / "dse_failure.txt"
+    tb = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    try:
+        result_dir.mkdir(parents=True, exist_ok=True)
+        failure_path.write_text(f"DSE job aborted by an unexpected {type(error).__name__}: {error}\n\n{tb}")
+        logging.info(f"Documented the aborting error in {failure_path}")
+    except OSError:
+        logging.exception(f"Failed to write failure report to {failure_path}")
+
+
+def generate_reports(
+    system: System,
+    test_scenario: TestScenario,
+    result_dir: Path,
+    error: BaseException | None = None,
+) -> None:
     registry = Registry()
+
+    if error is not None:
+        _record_run_failure(result_dir, error)
 
     for name, reporter_class in registry.ordered_scenario_reports():
         logging.debug(f"Generating report '{name}' ({reporter_class.__name__})")

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -20,7 +20,7 @@ import logging
 import signal
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, List, Optional, Protocol, TypeGuard, runtime_checkable
+from typing import Callable, List, Optional
 from unittest.mock import Mock
 
 import toml
@@ -118,60 +118,6 @@ def prepare_installation(
     return installables, installer
 
 
-@runtime_checkable
-class CustomTrainingLoopAgent(Protocol):
-    """
-    Agent that drives its own training loop and skips the ``handle_dse_job`` step loop.
-
-    Set ``HAS_CUSTOM_TRAINING_LOOP = True`` on the agent class to opt in. Used by
-    agents (e.g. RLlib-based) whose training loops are not modelled as a sequence
-    of independent ``select_action`` / ``env.step`` calls.
-    """
-
-    HAS_CUSTOM_TRAINING_LOOP: bool
-
-    def train(self) -> None: ...
-
-
-def _has_custom_training_loop(agent: object) -> TypeGuard[CustomTrainingLoopAgent]:
-    """
-    Narrow ``agent`` to :class:`CustomTrainingLoopAgent` when it opts into the dispatch path.
-
-    Returning :class:`TypeGuard` (instead of plain ``bool``) lets the type checker
-    treat this predicate like ``isinstance``: callers inside the truthy branch see
-    ``agent`` as a :class:`CustomTrainingLoopAgent`, so ``agent.train()`` type-checks
-    without ``getattr`` or ``cast``.
-    """
-    return bool(getattr(agent, "HAS_CUSTOM_TRAINING_LOOP", False))
-
-
-def _run_custom_training_loop(agent: CustomTrainingLoopAgent, agent_type: str) -> int:
-    """
-    Drive an agent's self-contained training loop and return a process-style exit code.
-
-    ``shutdown()`` runs inside its own ``try/except`` so a faulty teardown cannot
-    suppress the exit code from ``train()`` nor propagate out of this helper:
-    ``handle_dse_job`` relies on the returned ``rc`` to accumulate ``err |= rc``
-    and continue with the remaining test runs.
-    """
-    logging.info(f"Agent {agent_type} drives its own training loop; delegating to agent.train().")
-    rc = 0
-    try:
-        agent.train()
-    except Exception:
-        logging.exception(f"Custom training loop failed for agent {agent_type}.")
-        rc = 1
-    finally:
-        shutdown = getattr(agent, "shutdown", None)
-        if callable(shutdown):
-            try:
-                shutdown()
-            except Exception:
-                logging.exception(f"Shutdown failed for agent {agent_type}.")
-                rc = 1
-    return rc
-
-
 def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
     registry = Registry()
 
@@ -211,31 +157,7 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
 
         agent = agent_class(env, agent_config)
 
-        if _has_custom_training_loop(agent):
-            err |= _run_custom_training_loop(agent, agent_type)
-            continue
-
-        observation, _ = env.reset()
-        for _ in range(agent.max_steps):
-            result = agent.select_action(observation=observation)
-            if result is None:
-                break
-            step, action = result
-            env.test_run.step = step
-            logging.info(f"Running step {step} (of {agent.max_steps}) with action {action}")
-            prev_observation = observation
-            observation, reward, done, *_ = env.step(action)
-            agent.update_policy(
-                {
-                    "trial_index": step,
-                    "value": reward,
-                    "observation": observation,
-                    "prev_observation": prev_observation,
-                    "action": action,
-                    "done": done,
-                }
-            )
-            logging.info(f"Step {step}: Observation: {[round(obs, 4) for obs in observation]}, Reward: {reward:.4f}")
+        err |= agent.run()
 
     if args.mode == "run":
         runner.runner.test_scenario.test_runs = original_test_runs

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -20,7 +20,7 @@ import logging
 import signal
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Protocol, runtime_checkable
 from unittest.mock import Mock
 
 import toml
@@ -118,6 +118,40 @@ def prepare_installation(
     return installables, installer
 
 
+@runtime_checkable
+class CustomTrainingLoopAgent(Protocol):
+    """
+    Agent that drives its own training loop and skips the ``handle_dse_job`` step loop.
+
+    Set ``HAS_CUSTOM_TRAINING_LOOP = True`` on the agent class to opt in. Used by
+    agents (e.g. RLlib-based) whose training loops are not modelled as a sequence
+    of independent ``select_action`` / ``env.step`` calls.
+    """
+
+    HAS_CUSTOM_TRAINING_LOOP: bool
+
+    def train(self) -> None: ...
+
+
+def _has_custom_training_loop(agent: object) -> bool:
+    return bool(getattr(agent, "HAS_CUSTOM_TRAINING_LOOP", False))
+
+
+def _run_custom_training_loop(agent: CustomTrainingLoopAgent, agent_type: str) -> int:
+    """Drive an agent's self-contained training loop and return a process-style exit code."""
+    logging.info(f"Agent {agent_type} drives its own training loop; delegating to agent.train().")
+    try:
+        agent.train()
+        return 0
+    except Exception:
+        logging.exception(f"Custom training loop failed for agent {agent_type}.")
+        return 1
+    finally:
+        shutdown = getattr(agent, "shutdown", None)
+        if callable(shutdown):
+            shutdown()
+
+
 def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
     registry = Registry()
 
@@ -156,6 +190,10 @@ def handle_dse_job(runner: Runner, args: argparse.Namespace) -> int:
             logging.info(f"Using deterministic first sweep for the chosen agent: {env.first_sweep}.")
 
         agent = agent_class(env, agent_config)
+
+        if _has_custom_training_loop(agent):
+            err |= _run_custom_training_loop(agent, agent_type)
+            continue
 
         observation, _ = env.reset()
         for _ in range(agent.max_steps):

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -20,7 +20,7 @@ import logging
 import signal
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, List, Optional, Protocol, runtime_checkable
+from typing import Callable, List, Optional, Protocol, TypeGuard, runtime_checkable
 from unittest.mock import Mock
 
 import toml
@@ -133,7 +133,15 @@ class CustomTrainingLoopAgent(Protocol):
     def train(self) -> None: ...
 
 
-def _has_custom_training_loop(agent: object) -> bool:
+def _has_custom_training_loop(agent: object) -> TypeGuard[CustomTrainingLoopAgent]:
+    """
+    Narrow ``agent`` to :class:`CustomTrainingLoopAgent` when it opts into the dispatch path.
+
+    Returning :class:`TypeGuard` (instead of plain ``bool``) lets the type checker
+    treat this predicate like ``isinstance``: callers inside the truthy branch see
+    ``agent`` as a :class:`CustomTrainingLoopAgent`, so ``agent.train()`` type-checks
+    without ``getattr`` or ``cast``.
+    """
     return bool(getattr(agent, "HAS_CUSTOM_TRAINING_LOOP", False))
 
 

--- a/src/cloudai/configurator/base_agent.py
+++ b/src/cloudai/configurator/base_agent.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Literal
 
@@ -111,3 +112,38 @@ class BaseAgent(ABC):
             feedback (Dict[str, Any]): Feedback information from the environment.
         """
         pass
+
+    def run(self) -> int:
+        """
+        Orchestrate this agent's exploration over ``self.env``.
+
+        Default: a step loop driven by the dispatcher (``select_action`` →
+        ``env.step`` → ``update_policy`` per trial). Agents that drive their
+        own training loop (e.g. RLlib-based agents calling ``algo.train()``)
+        override this method.
+
+        Returns:
+            int: Process-style return code (``0`` success, non-zero failure).
+            ``handle_dse_job`` accumulates this via ``err |= agent.run()``.
+        """
+        observation, _ = self.env.reset()
+        for _ in range(self.max_steps):
+            result = self.select_action(observation=observation)
+            if result is None:
+                break
+            step, action = result
+            logging.info(f"Running step {step} (of {self.max_steps}) with action {action}")
+            prev_observation = observation
+            observation, reward, done, *_ = self.env.step(action)
+            self.update_policy(
+                {
+                    "trial_index": step,
+                    "value": reward,
+                    "observation": observation,
+                    "prev_observation": prev_observation,
+                    "action": action,
+                    "done": done,
+                }
+            )
+            logging.info(f"Step {step}: Observation: {[round(obs, 4) for obs in observation]}, Reward: {reward:.4f}")
+        return 0

--- a/src/cloudai/configurator/base_agent.py
+++ b/src/cloudai/configurator/base_agent.py
@@ -122,9 +122,21 @@ class BaseAgent(ABC):
         own training loop (e.g. RLlib-based agents calling ``algo.train()``)
         override this method.
 
+        Failure contract (``handle_dse_job`` consumes the result via
+        ``err |= agent.run()``):
+
+        - Return a non-zero code for *recoverable* failures (e.g. a workload run
+          that failed but should not abort the rest of the sweep). The code is
+          accumulated and the next ``TestRun`` still executes. Workload-level
+          failures are already surfaced this way: ``CloudAIGymEnv.step`` maps a
+          failed metric to ``rewards.metric_failure`` rather than raising, and
+          ``rllib_run`` catches training errors and returns ``rc=1``.
+        - Raise for *unexpected* failures (framework/agent bugs). Exceptions
+          propagate out of ``handle_dse_job`` and hard-fail the job so the bug
+          is surfaced instead of masked as a penalizing reward.
+
         Returns:
-            int: Process-style return code (``0`` success, non-zero failure).
-            ``handle_dse_job`` accumulates this via ``err |= agent.run()``.
+            int: Process-style return code (``0`` success, non-zero recoverable failure).
         """
         observation, _ = self.env.reset()
         for _ in range(self.max_steps):

--- a/src/cloudai/configurator/cloudai_gym.py
+++ b/src/cloudai/configurator/cloudai_gym.py
@@ -118,6 +118,7 @@ class CloudAIGymEnv(BaseGym):
                 - done (bool): Whether the episode is done.
                 - info (dict): Additional info for debugging.
         """
+        self.test_run.increment_step()
         self.test_run = self.test_run.apply_params_set(action)
 
         cached_result = self.get_cached_trajectory_result(action)

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -152,10 +152,13 @@ def test_tr_output_path(setup_env: tuple[TestRun, BaseRunner]):
     agent = GridSearchAgent(env, GridSearchAgent.get_config_class()())
 
     _, action = agent.select_action()
-    env.test_run.step = 42
+    env.test_run.step = 41
     env.step(action)
 
-    assert env.test_run.output_path.name == "42"
+    assert env.test_run.output_path.name == "42", (
+        "CloudAIGymEnv.step() must advance test_run.step before computing output_path; "
+        "starting at 41, step #42's artifacts must land in dir '42'."
+    )
 
 
 @pytest.mark.parametrize(
@@ -417,7 +420,7 @@ def test_cached_step_appends_trajectory_row(nemorun: NeMoRunTestDefinition, tmp_
     env.test_run.current_iteration = 0
     env.trajectory = {0: [TrajectoryEntry(step=1, action=cached_action, reward=0.42, observation=[0.84])]}
 
-    env.test_run.step = 5
+    env.test_run.step = 4
     obs, reward, done, _info = env.step(cached_action)
 
     runner.run.assert_not_called()
@@ -426,7 +429,10 @@ def test_cached_step_appends_trajectory_row(nemorun: NeMoRunTestDefinition, tmp_
     assert done is False
     rows = env.trajectory[0]
     assert len(rows) == 2
-    assert rows[-1].step == 5
+    assert rows[-1].step == 5, (
+        "CloudAIGymEnv.step() advances test_run.step before recording the trajectory row; "
+        "the cached row must be tagged with the advanced trial index, not the pre-step value."
+    )
     assert rows[-1].reward == 0.42
     assert rows[-1].action == cached_action
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -354,6 +354,38 @@ def test_run_custom_training_loop_tolerates_missing_shutdown() -> None:
     agent.train.assert_called_once_with()
 
 
+def test_run_custom_training_loop_reports_shutdown_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """shutdown() raising must not suppress the exit code or propagate the exception."""
+    agent = MagicMock()
+    agent.train = MagicMock()
+    agent.shutdown = MagicMock(side_effect=RuntimeError("teardown blew up"))
+
+    with caplog.at_level(logging.ERROR):
+        assert _run_custom_training_loop(agent, "mock_agent") == 1
+
+    agent.train.assert_called_once_with()
+    agent.shutdown.assert_called_once_with()
+    assert "teardown blew up" in caplog.text
+
+
+def test_run_custom_training_loop_reports_combined_train_and_shutdown_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When both train() and shutdown() raise, the helper still returns 1 and logs both."""
+    agent = MagicMock()
+    agent.train = MagicMock(side_effect=RuntimeError("training boom"))
+    agent.shutdown = MagicMock(side_effect=RuntimeError("teardown boom"))
+
+    with caplog.at_level(logging.ERROR):
+        assert _run_custom_training_loop(agent, "mock_agent") == 1
+
+    agent.shutdown.assert_called_once_with()
+    assert "training boom" in caplog.text
+    assert "teardown boom" in caplog.text
+
+
 def test_handle_dse_job_dispatches_to_custom_training_loop(
     slurm_system: SlurmSystem,
     dse_tr: TestRun,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -15,15 +15,22 @@
 # limitations under the License.
 
 import argparse
+import logging
 from pathlib import Path
-from typing import Any, ClassVar, Iterator
+from typing import Any, ClassVar, Iterator, Optional
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 from pydantic import Field
 
-from cloudai.cli.handlers import handle_dse_job, verify_system_configs, verify_test_configs, verify_test_scenarios
+from cloudai.cli.handlers import (
+    _run_custom_training_loop,
+    handle_dse_job,
+    verify_system_configs,
+    verify_test_configs,
+    verify_test_scenarios,
+)
 from cloudai.core import (
     BaseAgent,
     BaseAgentConfig,
@@ -254,3 +261,122 @@ def test_verify_test_scenarios_logs_failure_details(tmp_path: Path, caplog: pyte
     assert str(broken_scenario) in caplog.text
     assert "duplicate TOML key 'name'" in caplog.text
     assert "1 out of 1 test scenarios have issues." in caplog.text
+
+
+class CustomLoopStubAgentConfig(BaseAgentConfig):
+    pass
+
+
+class CustomLoopStubAgent(BaseAgent):
+    """Stub agent that opts into the custom-training-loop dispatch path."""
+
+    HAS_CUSTOM_TRAINING_LOOP: ClassVar[bool] = True
+
+    train_calls: ClassVar[int] = 0
+    shutdown_calls: ClassVar[int] = 0
+    train_raises: ClassVar[Optional[BaseException]] = None
+
+    def __init__(self, env, config: CustomLoopStubAgentConfig):
+        self.env = env
+        self.config = config
+        self.max_steps = 0
+
+    @staticmethod
+    def get_config_class() -> type[CustomLoopStubAgentConfig]:
+        return CustomLoopStubAgentConfig
+
+    def configure(self, config: dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    def select_action(self) -> tuple[int, dict[str, Any]]:  # pragma: no cover - never called
+        raise AssertionError("select_action must not be called when HAS_CUSTOM_TRAINING_LOOP is True")
+
+    def update_policy(self, _feedback: dict[str, Any]) -> None:
+        return
+
+    def train(self) -> None:
+        CustomLoopStubAgent.train_calls += 1
+        if CustomLoopStubAgent.train_raises is not None:
+            raise CustomLoopStubAgent.train_raises
+
+    def shutdown(self) -> None:
+        CustomLoopStubAgent.shutdown_calls += 1
+
+
+@pytest.fixture
+def custom_loop_agent_name() -> Iterator[str]:
+    registry = Registry()
+    agent_name = "test_handlers_custom_loop_agent"
+    old_agent = registry.agents_map.get(agent_name)
+    registry.update_agent(agent_name, CustomLoopStubAgent)
+    CustomLoopStubAgent.train_calls = 0
+    CustomLoopStubAgent.shutdown_calls = 0
+    CustomLoopStubAgent.train_raises = None
+    yield agent_name
+    CustomLoopStubAgent.train_calls = 0
+    CustomLoopStubAgent.shutdown_calls = 0
+    CustomLoopStubAgent.train_raises = None
+    if old_agent is None:
+        del registry.agents_map[agent_name]
+    else:
+        registry.update_agent(agent_name, old_agent)
+
+
+def test_run_custom_training_loop_calls_train_and_shutdown() -> None:
+    agent = MagicMock()
+    agent.train = MagicMock()
+    agent.shutdown = MagicMock()
+
+    assert _run_custom_training_loop(agent, "mock_agent") == 0
+    agent.train.assert_called_once_with()
+    agent.shutdown.assert_called_once_with()
+
+
+def test_run_custom_training_loop_returns_error_and_still_shuts_down(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    agent = MagicMock()
+    agent.train = MagicMock(side_effect=RuntimeError("boom"))
+    agent.shutdown = MagicMock()
+
+    with caplog.at_level(logging.ERROR):
+        assert _run_custom_training_loop(agent, "mock_agent") == 1
+
+    agent.shutdown.assert_called_once_with()
+    assert "boom" in caplog.text
+
+
+def test_run_custom_training_loop_tolerates_missing_shutdown() -> None:
+    agent = MagicMock(spec=["train"])
+    agent.train = MagicMock()
+
+    assert _run_custom_training_loop(agent, "mock_agent") == 0
+    agent.train.assert_called_once_with()
+
+
+def test_handle_dse_job_dispatches_to_custom_training_loop(
+    slurm_system: SlurmSystem,
+    dse_tr: TestRun,
+    custom_loop_agent_name: str,
+) -> None:
+    dse_tr.test.agent = custom_loop_agent_name
+    test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr])
+    runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
+
+    assert handle_dse_job(runner, argparse.Namespace(mode="dry-run")) == 0
+    assert CustomLoopStubAgent.train_calls == 1
+    assert CustomLoopStubAgent.shutdown_calls == 1
+
+
+def test_handle_dse_job_propagates_custom_loop_failure(
+    slurm_system: SlurmSystem,
+    dse_tr: TestRun,
+    custom_loop_agent_name: str,
+) -> None:
+    CustomLoopStubAgent.train_raises = RuntimeError("training blew up")
+    dse_tr.test.agent = custom_loop_agent_name
+    test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr])
+    runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
+
+    assert handle_dse_job(runner, argparse.Namespace(mode="dry-run")) == 1
+    assert CustomLoopStubAgent.shutdown_calls == 1

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import copy
 from pathlib import Path
 from typing import Any, ClassVar, Iterator, Optional
 from unittest.mock import MagicMock
@@ -284,7 +285,7 @@ class CustomRunStubAgent(BaseAgent):
     def configure(self, config: dict[str, Any]) -> None:
         raise NotImplementedError
 
-    def select_action(self) -> tuple[int, dict[str, Any]]:  # pragma: no cover - never called
+    def select_action(self, observation: list[float] | None = None) -> tuple[int, dict[str, Any]]:
         raise AssertionError("select_action must not be called when run() is overridden")
 
     def update_policy(self, _feedback: dict[str, Any]) -> None:
@@ -343,3 +344,86 @@ def test_handle_dse_job_propagates_agent_run_nonzero_rc(
 
     assert handle_dse_job(runner, argparse.Namespace(mode="dry-run")) == 1
     assert CustomRunStubAgent.run_calls == 1
+
+
+def test_handle_dse_job_accumulates_nonzero_rc_and_continues(
+    slurm_system: SlurmSystem,
+    dse_tr: TestRun,
+    custom_run_agent_name: str,
+) -> None:
+    """Graceful failure: a non-zero rc accumulates via ``err |= rc`` and the sweep continues.
+
+    A ``run()`` that returns a non-zero rc (the convention for recoverable failures, e.g.
+    ``rllib_run`` catching a training error) must not abort the scenario: the remaining
+    independent ``TestRun`` still executes and the accumulated error is reported.
+    """
+    CustomRunStubAgent.run_returns = 1
+    dse_tr.test.agent = custom_run_agent_name
+    second_tr = copy.deepcopy(dse_tr)
+    second_tr.name = "dse_second"
+    test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr, second_tr])
+    runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
+
+    assert handle_dse_job(runner, argparse.Namespace(mode="dry-run")) == 1
+    assert CustomRunStubAgent.run_calls == 2
+
+
+def test_handle_dse_job_propagates_agent_run_exception(
+    slurm_system: SlurmSystem,
+    dse_tr: TestRun,
+    custom_run_agent_name: str,
+) -> None:
+    """Hard failure: an exception out of ``agent.run()`` propagates instead of being swallowed.
+
+    Unexpected exceptions signal framework/agent bugs and must surface (hard-fail) rather than
+    be masked as a non-zero rc; recoverable failures are expected to return a non-zero rc.
+    """
+    CustomRunStubAgent.run_raises = RuntimeError("agent blew up")
+    dse_tr.test.agent = custom_run_agent_name
+    test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr])
+    runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
+
+    with pytest.raises(RuntimeError, match="agent blew up"):
+        handle_dse_job(runner, argparse.Namespace(mode="dry-run"))
+    assert CustomRunStubAgent.run_calls == 1
+
+
+def test_handle_dse_job_hard_fail_aborts_remaining_runs(
+    slurm_system: SlurmSystem,
+    dse_tr: TestRun,
+    custom_run_agent_name: str,
+) -> None:
+    """A raising ``agent.run()`` aborts the scenario; subsequent ``TestRun`` are not started."""
+    CustomRunStubAgent.run_raises = RuntimeError("agent blew up")
+    dse_tr.test.agent = custom_run_agent_name
+    second_tr = copy.deepcopy(dse_tr)
+    second_tr.name = "dse_second"
+    test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr, second_tr])
+    runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
+
+    with pytest.raises(RuntimeError, match="agent blew up"):
+        handle_dse_job(runner, argparse.Namespace(mode="dry-run"))
+    assert CustomRunStubAgent.run_calls == 1
+
+
+def test_handle_dse_job_documents_failure_in_reports_before_raising(
+    slurm_system: SlurmSystem,
+    dse_tr: TestRun,
+    custom_run_agent_name: str,
+    tmp_path: Path,
+) -> None:
+    """On a hard-fail, reports are still generated and the aborting error is documented, then re-raised."""
+    CustomRunStubAgent.run_raises = RuntimeError("agent blew up")
+    dse_tr.test.agent = custom_run_agent_name
+    test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr])
+    runner = Runner(mode="run", system=slurm_system, test_scenario=test_scenario)
+    runner.runner.scenario_root = tmp_path
+
+    with pytest.raises(RuntimeError, match="agent blew up"):
+        handle_dse_job(runner, argparse.Namespace(mode="run"))
+
+    failure_report = tmp_path / "dse_failure.txt"
+    assert failure_report.exists()
+    contents = failure_report.read_text()
+    assert "RuntimeError" in contents
+    assert "agent blew up" in contents

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-import logging
 from pathlib import Path
 from typing import Any, ClassVar, Iterator, Optional
 from unittest.mock import MagicMock
@@ -25,7 +24,6 @@ import pytest
 from pydantic import Field
 
 from cloudai.cli.handlers import (
-    _run_custom_training_loop,
     handle_dse_job,
     verify_system_configs,
     verify_test_configs,
@@ -263,152 +261,85 @@ def test_verify_test_scenarios_logs_failure_details(tmp_path: Path, caplog: pyte
     assert "1 out of 1 test scenarios have issues." in caplog.text
 
 
-class CustomLoopStubAgentConfig(BaseAgentConfig):
+class CustomRunStubAgentConfig(BaseAgentConfig):
     pass
 
 
-class CustomLoopStubAgent(BaseAgent):
-    """Stub agent that opts into the custom-training-loop dispatch path."""
+class CustomRunStubAgent(BaseAgent):
+    """Stub agent that overrides ``run()`` to drive its own training (e.g. RLlib-like)."""
 
-    HAS_CUSTOM_TRAINING_LOOP: ClassVar[bool] = True
+    run_calls: ClassVar[int] = 0
+    run_returns: ClassVar[int] = 0
+    run_raises: ClassVar[Optional[BaseException]] = None
 
-    train_calls: ClassVar[int] = 0
-    shutdown_calls: ClassVar[int] = 0
-    train_raises: ClassVar[Optional[BaseException]] = None
-
-    def __init__(self, env, config: CustomLoopStubAgentConfig):
+    def __init__(self, env, config: CustomRunStubAgentConfig):
         self.env = env
         self.config = config
         self.max_steps = 0
 
     @staticmethod
-    def get_config_class() -> type[CustomLoopStubAgentConfig]:
-        return CustomLoopStubAgentConfig
+    def get_config_class() -> type[CustomRunStubAgentConfig]:
+        return CustomRunStubAgentConfig
 
     def configure(self, config: dict[str, Any]) -> None:
         raise NotImplementedError
 
     def select_action(self) -> tuple[int, dict[str, Any]]:  # pragma: no cover - never called
-        raise AssertionError("select_action must not be called when HAS_CUSTOM_TRAINING_LOOP is True")
+        raise AssertionError("select_action must not be called when run() is overridden")
 
     def update_policy(self, _feedback: dict[str, Any]) -> None:
         return
 
-    def train(self) -> None:
-        CustomLoopStubAgent.train_calls += 1
-        if CustomLoopStubAgent.train_raises is not None:
-            raise CustomLoopStubAgent.train_raises
-
-    def shutdown(self) -> None:
-        CustomLoopStubAgent.shutdown_calls += 1
+    def run(self) -> int:
+        CustomRunStubAgent.run_calls += 1
+        if CustomRunStubAgent.run_raises is not None:
+            raise CustomRunStubAgent.run_raises
+        return CustomRunStubAgent.run_returns
 
 
 @pytest.fixture
-def custom_loop_agent_name() -> Iterator[str]:
+def custom_run_agent_name() -> Iterator[str]:
     registry = Registry()
-    agent_name = "test_handlers_custom_loop_agent"
+    agent_name = "test_handlers_custom_run_agent"
     old_agent = registry.agents_map.get(agent_name)
-    registry.update_agent(agent_name, CustomLoopStubAgent)
-    CustomLoopStubAgent.train_calls = 0
-    CustomLoopStubAgent.shutdown_calls = 0
-    CustomLoopStubAgent.train_raises = None
+    registry.update_agent(agent_name, CustomRunStubAgent)
+    CustomRunStubAgent.run_calls = 0
+    CustomRunStubAgent.run_returns = 0
+    CustomRunStubAgent.run_raises = None
     yield agent_name
-    CustomLoopStubAgent.train_calls = 0
-    CustomLoopStubAgent.shutdown_calls = 0
-    CustomLoopStubAgent.train_raises = None
+    CustomRunStubAgent.run_calls = 0
+    CustomRunStubAgent.run_returns = 0
+    CustomRunStubAgent.run_raises = None
     if old_agent is None:
         del registry.agents_map[agent_name]
     else:
         registry.update_agent(agent_name, old_agent)
 
 
-def test_run_custom_training_loop_calls_train_and_shutdown() -> None:
-    agent = MagicMock()
-    agent.train = MagicMock()
-    agent.shutdown = MagicMock()
-
-    assert _run_custom_training_loop(agent, "mock_agent") == 0
-    agent.train.assert_called_once_with()
-    agent.shutdown.assert_called_once_with()
-
-
-def test_run_custom_training_loop_returns_error_and_still_shuts_down(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    agent = MagicMock()
-    agent.train = MagicMock(side_effect=RuntimeError("boom"))
-    agent.shutdown = MagicMock()
-
-    with caplog.at_level(logging.ERROR):
-        assert _run_custom_training_loop(agent, "mock_agent") == 1
-
-    agent.shutdown.assert_called_once_with()
-    assert "boom" in caplog.text
-
-
-def test_run_custom_training_loop_tolerates_missing_shutdown() -> None:
-    agent = MagicMock(spec=["train"])
-    agent.train = MagicMock()
-
-    assert _run_custom_training_loop(agent, "mock_agent") == 0
-    agent.train.assert_called_once_with()
-
-
-def test_run_custom_training_loop_reports_shutdown_failure(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """shutdown() raising must not suppress the exit code or propagate the exception."""
-    agent = MagicMock()
-    agent.train = MagicMock()
-    agent.shutdown = MagicMock(side_effect=RuntimeError("teardown blew up"))
-
-    with caplog.at_level(logging.ERROR):
-        assert _run_custom_training_loop(agent, "mock_agent") == 1
-
-    agent.train.assert_called_once_with()
-    agent.shutdown.assert_called_once_with()
-    assert "teardown blew up" in caplog.text
-
-
-def test_run_custom_training_loop_reports_combined_train_and_shutdown_failures(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """When both train() and shutdown() raise, the helper still returns 1 and logs both."""
-    agent = MagicMock()
-    agent.train = MagicMock(side_effect=RuntimeError("training boom"))
-    agent.shutdown = MagicMock(side_effect=RuntimeError("teardown boom"))
-
-    with caplog.at_level(logging.ERROR):
-        assert _run_custom_training_loop(agent, "mock_agent") == 1
-
-    agent.shutdown.assert_called_once_with()
-    assert "training boom" in caplog.text
-    assert "teardown boom" in caplog.text
-
-
-def test_handle_dse_job_dispatches_to_custom_training_loop(
+def test_handle_dse_job_invokes_agent_run(
     slurm_system: SlurmSystem,
     dse_tr: TestRun,
-    custom_loop_agent_name: str,
+    custom_run_agent_name: str,
 ) -> None:
-    dse_tr.test.agent = custom_loop_agent_name
+    """``handle_dse_job`` must delegate orchestration to ``agent.run()`` (polymorphism)."""
+    dse_tr.test.agent = custom_run_agent_name
     test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr])
     runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
 
     assert handle_dse_job(runner, argparse.Namespace(mode="dry-run")) == 0
-    assert CustomLoopStubAgent.train_calls == 1
-    assert CustomLoopStubAgent.shutdown_calls == 1
+    assert CustomRunStubAgent.run_calls == 1
 
 
-def test_handle_dse_job_propagates_custom_loop_failure(
+def test_handle_dse_job_propagates_agent_run_nonzero_rc(
     slurm_system: SlurmSystem,
     dse_tr: TestRun,
-    custom_loop_agent_name: str,
+    custom_run_agent_name: str,
 ) -> None:
-    CustomLoopStubAgent.train_raises = RuntimeError("training blew up")
-    dse_tr.test.agent = custom_loop_agent_name
+    """A non-zero rc from ``agent.run()`` must flow through to the caller via ``err |= rc``."""
+    CustomRunStubAgent.run_returns = 1
+    dse_tr.test.agent = custom_run_agent_name
     test_scenario = TestScenario(name="test_scenario", test_runs=[dse_tr])
     runner = Runner(mode="dry-run", system=slurm_system, test_scenario=test_scenario)
 
     assert handle_dse_job(runner, argparse.Namespace(mode="dry-run")) == 1
-    assert CustomLoopStubAgent.shutdown_calls == 1
+    assert CustomRunStubAgent.run_calls == 1

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -281,6 +281,32 @@ def test_total_time_limit_with_empty_hooks():
     assert result == "01:00:00"
 
 
+class TestIncrementStep:
+    """``TestRun.increment_step`` is the single mutator for the trial counter."""
+
+    def _make_tr(self, tdef: TestDefinition) -> TestRun:
+        return TestRun(name="incr_tr", test=tdef, num_nodes=1, nodes=[])
+
+    def test_starts_at_zero_and_advances_to_one(self, tdef: TestDefinition) -> None:
+        tr = self._make_tr(tdef)
+        assert tr.step == 0
+        assert tr.increment_step() == 1
+        assert tr.step == 1
+
+    def test_is_monotonic_across_repeated_calls(self, tdef: TestDefinition) -> None:
+        tr = self._make_tr(tdef)
+        seen = [tr.increment_step() for _ in range(5)]
+        assert seen == [1, 2, 3, 4, 5]
+        assert tr.step == 5
+
+    def test_resumes_from_pre_existing_value(self, tdef: TestDefinition) -> None:
+        """Recovery / batch-unroll callers may seed ``step`` to a historical value."""
+        tr = self._make_tr(tdef)
+        tr.step = 42
+        assert tr.increment_step() == 43
+        assert tr.step == 43
+
+
 class TestInScenario:
     @pytest.mark.parametrize("missing_arg", ["test_template_name", "name", "description"])
     def test_without_base(self, missing_arg: str):


### PR DESCRIPTION
## Issue
- Dispatch: `handle_dse_job` branched on agent identity (flag + Protocol + TypeGuard) to support custom training loops.
- Trial counter: `TestRun.step` had multiple writers; RLlib's frequent `reset()` collapsed every trial onto `step=1`, overwriting `trajectory.csv`/`env.csv` rows.
- Failure handling: the DSE loop didn't distinguish recoverable failures from bugs.

## Fix
- Dispatch: `BaseAgent.run()` is the polymorphic entry point and `handle_dse_job` collapses to `err |= agent.run()` (deletes the flag/Protocol/TypeGuard/helper, −89 lines).
- Trial counter: `TestRun.increment_step()` is the sole mutator, called only by `CloudAIGymEnv.step()`.
- Failure handling: hybrid contract — a non-zero rc accumulates and continues; an exception hard-fails (reports still generated, error written to `<scenario_root>/dse_failure.txt`, then re-raised).

## Testing
- `pytest tests`: 1607 passed, 4 skipped; ruff + pyright + vulture clean.
- Downstream cloudaix RL workloads (PPO + DQN) reinstalled on this branch — full suite green; contract tests confirm `tr.step` monotonicity through the adapter and `env.csv`.

**Stack:** `main` ← **#893** ← #900 ← #901 (merge bottom-up).