### PR TITLE
feat(dynamo_mocker): add GPU-free LLM inference simulation workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ These schemas enable CloudAI to be flexible and compatible with different system
 |ChakraReplay|✅|❌|❌|❌|
 |DDLB|✅|❌|❌|❌|
 |DeepEP|✅|❌|❌|❌|
+|DynamoMocker|❌|❌|❌|✅|
 |JaxToolbox workloads (DEPRECATED)|✅|❌|❌|❌|
 |MegatronRun|✅|❌|❌|❌|
 |NCCL|✅|✅|✅|❌|

--- a/conf/experimental/dynamo_mocker/system/standalone_system.toml
+++ b/conf/experimental/dynamo_mocker/system/standalone_system.toml
@@ -1,0 +1,5 @@
+name = "standalone_system"
+scheduler = "standalone"
+
+install_path = "./install"
+output_path = "./results"

--- a/conf/experimental/dynamo_mocker/system/standalone_system.toml
+++ b/conf/experimental/dynamo_mocker/system/standalone_system.toml
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name = "standalone_system"
 scheduler = "standalone"
 

--- a/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
+++ b/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
@@ -1,0 +1,48 @@
+name = "dynamo_mocker_base_test"
+description = "GPU-free LLM inference simulation using dynamo.mocker + aiperf."
+test_template_name = "DynamoMocker"
+
+[cmd_args]
+model_path = "Qwen/Qwen3-0.6B"
+benchmark_tool = "aiperf"
+
+  [cmd_args.engine]
+  speedup_ratio = 1.0
+  block_size = 64
+  num_gpu_blocks_override = 256
+  enable_prefix_caching = true
+  kv_transfer_bandwidth = 200.0
+
+  [cmd_args.worker]
+  disaggregation_mode = "prefill_decode"
+  num_workers = 1
+
+    [cmd_args.worker.prefill_worker]
+    num_nodes = 1
+    cmd = "python3 -m dynamo.mocker --disaggregation-mode prefill"
+    worker_initialized_regex = "created and running"
+
+      [cmd_args.worker.prefill_worker.args]
+      max_num_seqs = 4
+
+    [cmd_args.worker.decode_worker]
+    num_nodes = 1
+    cmd = "python3 -m dynamo.mocker --disaggregation-mode decode"
+    worker_initialized_regex = "created and running"
+
+      [cmd_args.worker.decode_worker.args]
+      max_num_seqs = 16
+
+  [cmd_args.frontend]
+  http_port = 8000
+  router_mode = "kv_router"
+
+  [cmd_args.aiperf]
+  input_tokens = 128
+  output_tokens = 32
+  request_count = 50
+  replay_concurrency = 10
+  replay_mode = "offline"
+  warmup_request_count = 5
+  random_seed = 42
+  output_tokens_stddev = 16

--- a/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
+++ b/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name = "dynamo_mocker_base_test"
 description = "GPU-free LLM inference simulation using dynamo.mocker + aiperf."
 test_template_name = "DynamoMocker"

--- a/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
+++ b/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
@@ -36,7 +36,6 @@ benchmark_tool = "aiperf"
 
     [cmd_args.worker.prefill_worker]
     num_nodes = 1
-    cmd = "python3 -m dynamo.mocker --disaggregation-mode prefill"
     worker_initialized_regex = "created and running"
 
       [cmd_args.worker.prefill_worker.args]
@@ -44,7 +43,6 @@ benchmark_tool = "aiperf"
 
     [cmd_args.worker.decode_worker]
     num_nodes = 1
-    cmd = "python3 -m dynamo.mocker --disaggregation-mode decode"
     worker_initialized_regex = "created and running"
 
       [cmd_args.worker.decode_worker.args]

--- a/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
+++ b/conf/experimental/dynamo_mocker/test/dynamo_mocker.toml
@@ -20,6 +20,7 @@ test_template_name = "DynamoMocker"
 
 [cmd_args]
 model_path = "Qwen/Qwen3-0.6B"
+nats_cmd = "nats-server -js"
 benchmark_tool = "aiperf"
 
   [cmd_args.engine]

--- a/conf/experimental/dynamo_mocker/test_scenario/dynamo_mocker.toml
+++ b/conf/experimental/dynamo_mocker/test_scenario/dynamo_mocker.toml
@@ -1,0 +1,5 @@
+name = "dynamo-mocker-scenario"
+
+[[Tests]]
+id = "dynamo_mocker.base"
+test_name = "dynamo_mocker_base_test"

--- a/conf/experimental/dynamo_mocker/test_scenario/dynamo_mocker.toml
+++ b/conf/experimental/dynamo_mocker/test_scenario/dynamo_mocker.toml
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name = "dynamo-mocker-scenario"
 
 [[Tests]]

--- a/doc/workloads/dynamo_mocker.rst
+++ b/doc/workloads/dynamo_mocker.rst
@@ -6,10 +6,7 @@ using ``dynamo.mocker`` and ``dynamo.frontend`` from the `ai-dynamo <https://git
 package, then benchmarks the stack with `aiperf <https://github.com/NVIDIA/aiperf>`_ or
 `genai-perf <https://github.com/triton-inference-server/client/tree/main/src/c%2B%2B/perf_analyzer/genai-perf>`_.
 
-This workload is designed for latency/throughput profiling on **login nodes** — no GPUs are required.
-It mirrors the ``ai_dynamo`` workload topology (combined or disaggregated prefill/decode) but replaces
-real GPU workers with lightweight mocker processes that simulate KV-cache block allocation, LRU eviction,
-and KV transfer latency.
+It is a **Standalone** workload (no Slurm/Kubernetes/RunAI required).
 
 Prerequisites
 -------------

--- a/doc/workloads/dynamo_mocker.rst
+++ b/doc/workloads/dynamo_mocker.rst
@@ -14,17 +14,25 @@ Prerequisites
 CloudAI automatically installs ``ai-dynamo``, ``aiperf``, and ``genai-perf`` into a managed Python virtual
 environment on first run — no manual pip install is needed.
 
-**The one manual prerequisite is** ``nats-server``. The ``dynamo.mocker`` runtime uses NATS as its event plane.
-Install it from the `official releases <https://github.com/nats-io/nats-server/releases>`_ or via a package
-manager, then make it available either on ``PATH`` or by setting ``nats_cmd`` in the test TOML to the full path:
+The one prerequisite is ``nats-server``. On many clusters ``nats-server`` is pre-installed by administrators
+and is already on ``PATH``. Check if it is already available:
 
-.. code-block:: toml
+.. code-block:: bash
 
-   [cmd_args]
-   nats_cmd = "/path/to/nats-server -js"
+   which nats-server
 
-On many clusters ``nats-server`` is pre-installed by administrators and is already on ``PATH``, in which case
-the default value ``"nats-server -js"`` works without modification.
+If not found, download the binary from the `official releases <https://github.com/nats-io/nats-server/releases>`_,
+extract it, and add it to ``PATH``:
+
+.. code-block:: bash
+
+   # replace <version> with the latest release tag, e.g. v2.10.24
+   curl -L https://github.com/nats-io/nats-server/releases/download/<version>/nats-server-<version>-linux-amd64.zip \
+     -o /tmp/nats-server.zip
+   unzip /tmp/nats-server.zip -d /tmp/
+   mkdir -p ~/.local/bin && mv /tmp/nats-server-<version>-linux-amd64/nats-server ~/.local/bin/
+   export PATH="$HOME/.local/bin:$PATH"  # add to ~/.bashrc to persist
+
 
 An ``HF_TOKEN`` environment variable is required to download gated models from HuggingFace Hub. Set it before
 running:

--- a/doc/workloads/dynamo_mocker.rst
+++ b/doc/workloads/dynamo_mocker.rst
@@ -1,0 +1,120 @@
+DynamoMocker
+============
+
+DynamoMocker workload (``test_template_name`` is ``DynamoMocker``) runs GPU-free LLM inference simulation
+using ``dynamo.mocker`` and ``dynamo.frontend`` from the `ai-dynamo <https://github.com/ai-dynamo/dynamo>`_
+package, then benchmarks the stack with `aiperf <https://github.com/NVIDIA/aiperf>`_ or
+`genai-perf <https://github.com/triton-inference-server/client/tree/main/src/c%2B%2B/perf_analyzer/genai-perf>`_.
+
+This workload is designed for latency/throughput profiling on **login nodes** — no GPUs are required.
+It mirrors the ``ai_dynamo`` workload topology (combined or disaggregated prefill/decode) but replaces
+real GPU workers with lightweight mocker processes that simulate KV-cache block allocation, LRU eviction,
+and KV transfer latency.
+
+Prerequisites
+-------------
+
+CloudAI automatically installs ``ai-dynamo``, ``aiperf``, and ``genai-perf`` into a managed Python virtual
+environment on first run — no manual pip install is needed.
+
+**The one manual prerequisite is** ``nats-server``. The ``dynamo.mocker`` runtime uses NATS as its event plane.
+Install it from the `official releases <https://github.com/nats-io/nats-server/releases>`_ or via a package
+manager, then make it available either on ``PATH`` or by setting ``nats_cmd`` in the test TOML to the full path:
+
+.. code-block:: toml
+
+   [cmd_args]
+   nats_cmd = "/path/to/nats-server -js"
+
+On many clusters ``nats-server`` is pre-installed by administrators and is already on ``PATH``, in which case
+the default value ``"nats-server -js"`` works without modification.
+
+An ``HF_TOKEN`` environment variable is required to download gated models from HuggingFace Hub. Set it before
+running:
+
+.. code-block:: bash
+
+   export HF_TOKEN=<your_token>
+
+Topologies
+----------
+
+The workload supports two disaggregation modes, configured via ``cmd_args.worker.disaggregation_mode``:
+
+- **Combined** (``none``): a single ``dynamo.mocker`` process handles both prefill and decode. Controlled
+  by ``cmd_args.worker.num_workers``.
+- **Disaggregated** (``prefill_decode``): separate prefill and decode mocker instances, mirroring the
+  production ``ai_dynamo`` topology. Instance counts are set via
+  ``cmd_args.worker.prefill_worker.num_nodes`` and ``cmd_args.worker.decode_worker.num_nodes``.
+
+Benchmark Tools
+---------------
+
+Select the benchmark tool with ``cmd_args.benchmark_tool``:
+
+- ``"aiperf"`` (default in the provided TOML) — uses the ``aiperf`` profiler
+- ``"genai_perf"`` — uses ``genai-perf profile``
+
+Parameters for the active tool are configured under ``[cmd_args.aiperf]`` or ``[cmd_args.genai_perf]``.
+
+Run Using Standalone
+--------------------
+
+.. note::
+
+   Set ``HF_TOKEN`` before running to allow model download from HuggingFace Hub.
+
+.. code-block:: bash
+
+   uv run cloudai run \
+     --system-config conf/experimental/dynamo_mocker/system/standalone_system.toml \
+     --tests-dir conf/experimental/dynamo_mocker/test \
+     --test-scenario conf/experimental/dynamo_mocker/test_scenario/dynamo_mocker.toml
+
+CloudAI will:
+
+1. Install ``ai-dynamo``, ``aiperf``, and ``genai-perf`` into a managed venv (first run only).
+2. Write a wrapper script and launch ``dynamo_mocker.sh``.
+3. Start ``nats-server``, ``dynamo.mocker`` (prefill and decode), and ``dynamo.frontend``.
+4. Run the benchmark and write results to the output directory.
+
+Review Benchmark Results
+------------------------
+
+After the run completes, results are placed in ``results/<scenario_name>/<test_id>/``:
+
+- ``benchmark_report.csv`` — full per-request and aggregate metrics (throughput, latency percentiles, TTFT, ITL)
+- ``stdout.txt`` / ``stderr.txt`` — orchestration log and process output
+- ``dynamo_prefill_0.log``, ``dynamo_decode_0.log``, ``dynamo_frontend.log`` — per-component logs
+- ``nats.log`` — NATS server log
+
+Key summary metrics from ``benchmark_report.csv``:
+
+::
+
+   Metric,Value
+   Output Token Throughput (tokens/sec),667.58
+   Request Count,50.00
+   Request Throughput (requests/sec),18.04
+
+   Metric,avg,p50,p99
+   Request Latency (ms),507.49,475.50,893.26
+   Time to First Token (ms),77.82,71.99,137.26
+   Inter Token Latency (ms),12.03,11.55,16.42
+
+API Documentation
+-----------------
+
+Command Arguments
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: cloudai.workloads.dynamo_mocker.dynamo_mocker.DynamoMockerCmdArgs
+   :members:
+   :show-inheritance:
+
+Test Definition
+~~~~~~~~~~~~~~~
+
+.. autoclass:: cloudai.workloads.dynamo_mocker.dynamo_mocker.DynamoMockerTestDefinition
+   :members:
+   :show-inheritance:

--- a/doc/workloads/index.rst
+++ b/doc/workloads/index.rst
@@ -16,6 +16,7 @@ Available Workloads
    ":doc:`chakra_replay`", "✅", "❌", "❌", "❌"
    ":doc:`ddlb`", "✅", "❌", "❌", "❌"
    ":doc:`deepep`", "✅", "❌", "❌", "❌"
+   ":doc:`dynamo_mocker`", "❌", "❌", "❌", "✅"
    ":doc:`jax_toolbox`", "✅", "❌", "❌", "❌"
    "MegatronRun", "✅", "❌", "❌", "❌"
    ":doc:`megatron_bridge`", "✅", "❌", "❌", "❌"

--- a/src/cloudai/registration.py
+++ b/src/cloudai/registration.py
@@ -83,6 +83,11 @@ def register_all():
         DeepEPSlurmCommandGenStrategy,
         DeepEPTestDefinition,
     )
+    from cloudai.workloads.dynamo_mocker import (
+        DynamoMockerReportGenerationStrategy,
+        DynamoMockerStandaloneCommandGenStrategy,
+        DynamoMockerTestDefinition,
+    )
     from cloudai.workloads.jax_toolbox import (
         GPTTestDefinition,
         GrokTestDefinition,
@@ -204,6 +209,9 @@ def register_all():
     Registry().add_command_gen_strategy(
         StandaloneSystem, AiconfiguratorTestDefinition, AiconfiguratorStandaloneCommandGenStrategy
     )
+    Registry().add_command_gen_strategy(
+        StandaloneSystem, DynamoMockerTestDefinition, DynamoMockerStandaloneCommandGenStrategy
+    )
 
     Registry().add_command_gen_strategy(SlurmSystem, MegatronRunTestDefinition, MegatronRunSlurmCommandGenStrategy)
     Registry().add_command_gen_strategy(SlurmSystem, NCCLTestDefinition, NcclTestSlurmCommandGenStrategy)
@@ -271,6 +279,7 @@ def register_all():
     Registry().add_test_definition("NixlPerftest", NixlPerftestTestDefinition)
     Registry().add_test_definition("NIXLKVBench", NIXLKVBenchTestDefinition)
     Registry().add_test_definition("Aiconfigurator", AiconfiguratorTestDefinition)
+    Registry().add_test_definition("DynamoMocker", DynamoMockerTestDefinition)
     Registry().add_test_definition("OSUBench", OSUBenchTestDefinition)
     Registry().add_test_definition("sglang", SglangTestDefinition)
     Registry().add_test_definition("vllm", VllmTestDefinition)
@@ -295,6 +304,7 @@ def register_all():
     Registry().add_report(NixlEPTestDefinition, NixlEPReportGenerationStrategy)
     Registry().add_report(AIDynamoTestDefinition, AIDynamoReportGenerationStrategy)
     Registry().add_report(AiconfiguratorTestDefinition, AiconfiguratorReportGenerationStrategy)
+    Registry().add_report(DynamoMockerTestDefinition, DynamoMockerReportGenerationStrategy)
     Registry().add_report(NixlPerftestTestDefinition, NIXLKVBenchDummyReport)
     Registry().add_report(OSUBenchTestDefinition, OSUBenchReportGenerationStrategy)
     Registry().add_report(SglangTestDefinition, SGLangBenchReportGenerationStrategy)

--- a/src/cloudai/workloads/dynamo_mocker/__init__.py
+++ b/src/cloudai/workloads/dynamo_mocker/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/dynamo_mocker/__init__.py
+++ b/src/cloudai/workloads/dynamo_mocker/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .dynamo_mocker import DynamoMockerCmdArgs, DynamoMockerTestDefinition
+from .report_generation_strategy import DynamoMockerReportGenerationStrategy
+from .standalone_command_gen_strategy import DynamoMockerStandaloneCommandGenStrategy
+
+__all__ = [
+    "DynamoMockerCmdArgs",
+    "DynamoMockerReportGenerationStrategy",
+    "DynamoMockerStandaloneCommandGenStrategy",
+    "DynamoMockerTestDefinition",
+]

--- a/src/cloudai/workloads/dynamo_mocker/aiperf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/aiperf.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES All rights reserved.
 #
 # aiperf.sh — wrapper for aiperf profile, mirroring genai_perf.sh.
 #

--- a/src/cloudai/workloads/dynamo_mocker/aiperf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/aiperf.sh
@@ -61,7 +61,12 @@ process_args() {
     case "$1" in
       --result-dir)  _require_value "$1" "${2-}"; result_dir="$2";  shift 2 ;;
       --model)       _require_value "$1" "${2-}"; model="$2";       shift 2 ;;
-      --port)        _require_value "$1" "${2-}"; port="$2";        shift 2 ;;
+      --port)
+        _require_value "$1" "${2-}"
+        if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          log "ERROR: --port must be numeric (got: '$2')" >&2; exit 1
+        fi
+        port="$2"; shift 2 ;;
       --report-name) _require_value "$1" "${2-}"; report_name="$2"; shift 2 ;;
       --cmd)         _require_value "$1" "${2-}"; cmd="$2";         shift 2 ;;
       --)            shift; parse_aiperf_args "$@"; break ;;

--- a/src/cloudai/workloads/dynamo_mocker/aiperf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/aiperf.sh
@@ -105,6 +105,7 @@ main() {
   local -a run_cmd
   if [[ -n "$cmd" ]]; then
     read -ra run_cmd <<< "$cmd"
+    run_cmd+=(profile)
   else
     if [[ ! -x "$AIPERF" ]] && ! command -v "$AIPERF" > /dev/null 2>&1; then
       log "ERROR: aiperf binary not found or not executable: $AIPERF"; exit 1

--- a/src/cloudai/workloads/dynamo_mocker/aiperf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/aiperf.sh
@@ -113,6 +113,9 @@ main() {
   fi
 
   local artifact_dir="$result_dir/aiperf_artifacts"
+  # Remove stale artifacts from any previous run so process_results only
+  # finds CSV files produced by this invocation.
+  rm -rf "$artifact_dir"
   log "Launching aiperf (cmd=${run_cmd[*]}, model=$model, url=localhost:${port})"
 
   "${run_cmd[@]}" \

--- a/src/cloudai/workloads/dynamo_mocker/aiperf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/aiperf.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES All rights reserved.
+#
+# aiperf.sh — wrapper for aiperf profile, mirroring genai_perf.sh.
+#
+# Called as:
+#   bash aiperf.sh --result-dir <dir> --model <model> --port <port> \
+#                  [--report-name <name>] -- <aiperf-profile-args>...
+#
+# Context flags (before --):
+#   --result-dir   Directory where artifacts and the final report are written.
+#   --model        HuggingFace model identifier (e.g. Qwen/Qwen3-0.6B).
+#   --port         HTTP port the dynamo.frontend is listening on.
+#   --report-name  Output CSV name (default: benchmark_report.csv).
+#
+# Everything after -- is passed directly to "aiperf profile".
+# This wrapper adds the derived flags: --url, --endpoint-type, --streaming,
+# --artifact-dir, --no-server-metrics.
+
+set -Eeuo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── aiperf binary: prefer cloudaix .venv ─────────────────────────────────
+_VENV_AIPERF="${_SCRIPT_DIR}/../../.venv/bin/aiperf"
+if [[ -x "$_VENV_AIPERF" ]]; then
+  AIPERF="$_VENV_AIPERF"
+else
+  AIPERF="aiperf"
+fi
+
+result_dir=""
+model=""
+port=8000
+report_name="benchmark_report.csv"
+cmd=""                  # override launch command (empty = use resolved $AIPERF binary)
+aiperf_profile_args=()
+
+log() {
+  echo "[$(date '+%F %T') $(hostname)]: $*"
+}
+
+_require_value() {
+  local flag="$1" val="${2-}"
+  if [[ -z "$val" || "$val" == -* ]]; then
+    log "ERROR: $flag requires a value (got: '${val:-<empty>}')" >&2; exit 1
+  fi
+}
+
+# Collect all flags after -- into aiperf_profile_args.
+# Kept as a plain array so bare boolean flags are preserved correctly.
+parse_aiperf_args() {
+  aiperf_profile_args=("$@")
+}
+
+# Parse context flags (before --); delegate everything after -- to
+# parse_aiperf_args. Mirrors the process_args / parse_genai_perf_args
+# split in ai_dynamo's genai_perf.sh.
+process_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --result-dir)  _require_value "$1" "${2-}"; result_dir="$2";  shift 2 ;;
+      --model)       _require_value "$1" "${2-}"; model="$2";       shift 2 ;;
+      --port)        _require_value "$1" "${2-}"; port="$2";        shift 2 ;;
+      --report-name) _require_value "$1" "${2-}"; report_name="$2"; shift 2 ;;
+      --cmd)         _require_value "$1" "${2-}"; cmd="$2";         shift 2 ;;
+      --)            shift; parse_aiperf_args "$@"; break ;;
+      --*)           log "WARNING: ignoring unknown context flag: $1" >&2; shift 1 ;;
+      *)             shift ;;
+    esac
+  done
+
+  log "Parsed args:
+    result_dir:  $result_dir
+    model:       $model
+    port:        $port
+    report_name: $report_name
+    cmd:         ${cmd:-<default>}
+    profile_args: ${aiperf_profile_args[*]:-}"
+}
+
+process_results() {
+  local artifact_dir="$result_dir/aiperf_artifacts"
+  local csv_path
+  csv_path=$(find "$artifact_dir" -name "*aiperf*.csv" -print -quit 2>/dev/null || true)
+  if [[ -n "$csv_path" ]]; then
+    cp "$csv_path" "$result_dir/$report_name"
+    log "aiperf report saved to $result_dir/$report_name"
+  else
+    log "ERROR: no CSV found in $artifact_dir — aiperf benchmark may not have completed"
+    exit 1
+  fi
+}
+
+main() {
+  process_args "$@"
+
+  if [[ -z "$result_dir" ]]; then
+    log "ERROR: --result-dir is required"; exit 1
+  fi
+  if [[ -z "$model" ]]; then
+    log "ERROR: --model is required"; exit 1
+  fi
+  # Build the launch command: use custom cmd if provided, else resolved $AIPERF binary.
+  local -a run_cmd
+  if [[ -n "$cmd" ]]; then
+    read -ra run_cmd <<< "$cmd"
+  else
+    if [[ ! -x "$AIPERF" ]] && ! command -v "$AIPERF" > /dev/null 2>&1; then
+      log "ERROR: aiperf binary not found or not executable: $AIPERF"; exit 1
+    fi
+    run_cmd=("$AIPERF" profile)
+  fi
+
+  local artifact_dir="$result_dir/aiperf_artifacts"
+  log "Launching aiperf (cmd=${run_cmd[*]}, model=$model, url=localhost:${port})"
+
+  "${run_cmd[@]}" \
+    --model        "$model" \
+    --url          "localhost:${port}" \
+    --endpoint-type chat \
+    --streaming \
+    --artifact-dir "$artifact_dir" \
+    --no-server-metrics \
+    "${aiperf_profile_args[@]}"
+
+  log "aiperf run complete"
+  process_results
+}
+
+main "$@"
+exit 0

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
@@ -155,7 +155,10 @@ class MockerGenAIPerfArgs(BaseModel):
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-    cmd: str = Field(default="", description="Override genai-perf command. Empty = shell default (genai-perf profile).")
+    cmd: str = Field(
+        default="",
+        description="Override genai-perf binary. 'profile' is always appended. Empty = shell default.",
+    )
     extra_args: Optional[str] = None
     input_tokens: Union[int, List[int]] = Field(default=5000)
     output_tokens: Union[int, List[int]] = Field(default=500)
@@ -190,7 +193,10 @@ class MockerAIPerfArgs(BaseModel):
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
-    cmd: str = Field(default="", description="Override aiperf command. Empty = shell default (aiperf profile).")
+    cmd: str = Field(
+        default="",
+        description="Override aiperf binary. 'profile' is always appended. Empty = shell default.",
+    )
     extra_args: Optional[str] = None
     input_tokens: Union[int, List[int]] = Field(default=5000)
     output_tokens: Union[int, List[int]] = Field(default=500)
@@ -213,6 +219,10 @@ class DynamoMockerCmdArgs(CmdArgs):
     """Top-level command arguments for the Dynamo Mocker workload."""
 
     model_path: str = "Qwen/Qwen3-0.6B"
+    nats_cmd: str = Field(
+        default="nats-server -js",
+        description="Command used to launch nats-server. Override with a full path if nats-server is not on PATH.",
+    )
     engine: MockerEngineArgs = Field(default_factory=MockerEngineArgs)
     worker: MockerWorkerConfig = Field(default_factory=MockerWorkerConfig)
     frontend: MockerFrontendArgs = Field(default_factory=MockerFrontendArgs)

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cloudai.core import Installable, JobStatusResult, PythonEnvironment, TestRun
+from cloudai.models.workload import CmdArgs, TestDefinition
+
+
+class MockerEngineArgs(BaseModel):
+    """
+    Engine simulation parameters for the Dynamo Mocker.
+
+    Any additional dynamo.mocker engine flag can be added directly to
+    [cmd_args.engine] in the TOML and will be forwarded to the dynamo.mocker
+    CLI automatically via the extra="allow" passthrough (--engine-<key>).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    speedup_ratio: float = Field(default=1.0, gt=0)
+    block_size: int = Field(default=64, gt=0)
+    num_gpu_blocks_override: int = Field(default=16384, gt=0, description="Number of simulated KV cache blocks")
+    enable_prefix_caching: bool = True
+
+    # Simulates nixl KV block migration bandwidth (GB/s).
+    # Only active in prefill_decode mode; ignored otherwise.
+    kv_transfer_bandwidth: Union[float, List[float]] = Field(
+        default=200.0, description="Simulated KV transfer bandwidth (GB/s)"
+    )
+
+    @field_validator("kv_transfer_bandwidth")
+    @classmethod
+    def kv_bandwidth_positive(cls, v: Union[float, List[float]]) -> Union[float, List[float]]:
+        vals = v if isinstance(v, list) else [v]
+        if any(x <= 0 for x in vals):
+            raise ValueError("kv_transfer_bandwidth values must be > 0")
+        return v
+
+
+class MockerWorkerInstanceArgs(BaseModel):
+    """
+    Named + extra flags forwarded to a single mocker instance (prefill or decode).
+
+    Any field added here becomes --<prefix>-args-<key> in dynamo_mocker.sh.
+    Example: max_num_seqs = 4 → --prefill-args-max-num-seqs 4 for prefill instances.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class MockerWorkerInstance(BaseModel):
+    """
+    Configuration for one worker role (prefill or decode).
+
+    Mirrors the ai_dynamo WorkerConfig pattern:
+      num_nodes                — number of mocker instances to launch for this role
+      cmd                      — command to launch the worker (empty = use shell default)
+      worker_initialized_regex — log-line pattern that signals the worker is ready
+      extra_args                — raw CLI string appended verbatim to the mocker command
+      args                     — named + extra flags forwarded as --<prefix>-args-<key>
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    num_nodes: int = Field(default=1, gt=0, description="Number of mocker instances for this role")
+    cmd: str = Field(
+        default="",
+        description="Command to launch this worker. Empty = shell default (venv python -m dynamo.mocker).",
+    )
+    worker_initialized_regex: str = "created and running"
+    extra_args: Optional[str] = None
+    args: MockerWorkerInstanceArgs = Field(default_factory=MockerWorkerInstanceArgs)
+
+
+class MockerWorkerConfig(BaseModel):
+    """
+    Worker topology for the Dynamo Mocker.
+
+    disaggregation_mode controls the deployment topology:
+      "none"           → single mocker process (combined prefill+decode)
+      "prefill_decode" → separate prefill + decode mocker instances
+
+    prefill_worker / decode_worker mirror the ai_dynamo WorkerConfig nesting:
+      each holds worker_initialized_regex, optional extra_args (raw CLI string),
+      and an args sub-section with named + extra flags forwarded as
+      --prefill-args-<key> / --decode-args-<key>.
+
+    Any additional dynamo.mocker topology flag can be added directly to
+    [cmd_args.worker] in the TOML and will be forwarded via --mocker-<key>.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    disaggregation_mode: Literal["none", "prefill_decode"] = "none"
+    num_workers: Union[int, List[int]] = Field(default=1)  # combined mode: simulated workers in one process
+
+    # Disaggregated mode: per-role instance counts and commands live inside each worker instance.
+    prefill_worker: MockerWorkerInstance = Field(default_factory=MockerWorkerInstance)
+    decode_worker: MockerWorkerInstance = Field(default_factory=MockerWorkerInstance)
+
+    @field_validator("num_workers")
+    @classmethod
+    def worker_counts_positive(cls, v: Union[int, List[int]]) -> Union[int, List[int]]:
+        vals = v if isinstance(v, list) else [v]
+        if any(x <= 0 for x in vals):
+            raise ValueError("worker count values must be > 0")
+        return v
+
+
+class MockerFrontendArgs(BaseModel):
+    """
+    Frontend / ingress configuration for the Dynamo Mocker.
+
+    Any additional dynamo.frontend flag can be added directly to
+    [cmd_args.frontend] in the TOML and will be forwarded to dynamo.frontend
+    via the extra="allow" passthrough (--frontend-<key>).
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    http_port: int = Field(default=8000, ge=1, le=65535)
+    router_mode: Literal["round_robin", "kv_router"] = "round_robin"
+
+
+class MockerGenAIPerfArgs(BaseModel):
+    """
+    Benchmark parameters passed to genai-perf.
+
+    cmd mirrors the ai_dynamo pattern — override the genai-perf launch command.
+    Empty (default) means genai_perf.sh uses its built-in resolved binary.
+    extra_args is a raw CLI string appended verbatim after all other flags.
+
+    Any additional genai-perf flag (e.g. endpoint_type, streaming) can be
+    added directly to [cmd_args.genai_perf] in the TOML and will be forwarded
+    to the genai-perf CLI automatically via the extra="allow" passthrough.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    cmd: str = Field(default="", description="Override genai-perf command. Empty = shell default (genai-perf profile).")
+    extra_args: Optional[str] = None
+    input_tokens: Union[int, List[int]] = Field(default=5000)
+    output_tokens: Union[int, List[int]] = Field(default=500)
+    request_count: int = Field(default=1000, gt=0)
+    replay_concurrency: Union[int, List[int]] = Field(default=100)
+    # offline → --concurrency (throughput test)
+    # online  → --request-rate (latency-under-load test)
+    replay_mode: Literal["offline", "online"] = "offline"
+
+    @field_validator("input_tokens", "output_tokens", "replay_concurrency")
+    @classmethod
+    def token_counts_positive(cls, v: Union[int, List[int]]) -> Union[int, List[int]]:
+        vals = v if isinstance(v, list) else [v]
+        if any(x <= 0 for x in vals):
+            raise ValueError("values must be > 0")
+        return v
+
+
+class MockerAIPerfArgs(BaseModel):
+    """
+    Benchmark parameters passed to aiperf.
+
+    cmd mirrors the ai_dynamo pattern — override the aiperf launch command.
+    Empty (default) means aiperf.sh uses its built-in resolved binary.
+    extra_args is a raw CLI string appended verbatim after all other flags.
+
+    Base fields mirror MockerGenAIPerfArgs for easy tool switching.
+    Any additional aiperf-specific flag (e.g. arrival_pattern, benchmark_duration)
+    can be added directly to [cmd_args.aiperf] in the TOML and will be forwarded
+    to the aiperf CLI automatically via the extra="allow" passthrough.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    cmd: str = Field(default="", description="Override aiperf command. Empty = shell default (aiperf profile).")
+    extra_args: Optional[str] = None
+    input_tokens: Union[int, List[int]] = Field(default=5000)
+    output_tokens: Union[int, List[int]] = Field(default=500)
+    request_count: int = Field(default=1000, gt=0)
+    replay_concurrency: Union[int, List[int]] = Field(default=100)
+    # offline → --concurrency (throughput test)
+    # online  → --request-rate (latency-under-load test)
+    replay_mode: Literal["offline", "online"] = "offline"
+
+    @field_validator("input_tokens", "output_tokens", "replay_concurrency")
+    @classmethod
+    def token_counts_positive(cls, v: Union[int, List[int]]) -> Union[int, List[int]]:
+        vals = v if isinstance(v, list) else [v]
+        if any(x <= 0 for x in vals):
+            raise ValueError("values must be > 0")
+        return v
+
+
+class DynamoMockerCmdArgs(CmdArgs):
+    """Top-level command arguments for the Dynamo Mocker workload."""
+
+    model_path: str = "Qwen/Qwen3-0.6B"
+    engine: MockerEngineArgs = Field(default_factory=MockerEngineArgs)
+    worker: MockerWorkerConfig = Field(default_factory=MockerWorkerConfig)
+    frontend: MockerFrontendArgs = Field(default_factory=MockerFrontendArgs)
+    benchmark_tool: Literal["genai_perf", "aiperf"] = "genai_perf"
+    genai_perf: MockerGenAIPerfArgs = Field(default_factory=MockerGenAIPerfArgs)
+    aiperf: MockerAIPerfArgs = Field(default_factory=MockerAIPerfArgs)
+
+
+class DynamoMockerTestDefinition(TestDefinition):
+    """
+    Test definition for the Dynamo Mocker workload.
+
+    Runs dynamo.mocker + dynamo.frontend as a lightweight GPU-free LLM inference
+    simulator, then benchmarks it with genai-perf or aiperf via dynamo_mocker.sh.
+    Select the benchmark tool with cmd_args.benchmark_tool ("genai_perf" or "aiperf").
+
+    Supports two topologies mirroring ai_dynamo.sh:
+      - Combined (worker.disaggregation_mode=none): single mocker handles prefill+decode
+      - Disaggregated (worker.disaggregation_mode=prefill_decode): separate prefill and
+        decode mocker instances with KV event publishing and simulated transfer
+
+    Requires: ai-dynamo and genai-perf or aiperf pip-installed in the active environment.
+    """
+
+    cmd_args: DynamoMockerCmdArgs
+
+    success_marker: str = "success-marker.txt"
+    failure_marker: str = "failure-marker.txt"
+
+    @property
+    def python_environment(self) -> PythonEnvironment:
+        return PythonEnvironment(
+            name="dynamo-mocker",
+            python_version="3.12",
+            requirements=["ai-dynamo", "genai-perf", "aiperf"],
+        )
+
+    @property
+    def installables(self) -> list[Installable]:
+        return [self.python_environment]
+
+    def was_run_successful(self, tr: TestRun) -> JobStatusResult:
+        output_path = tr.output_path
+        failure_marker = output_path / self.failure_marker
+        success_marker = output_path / self.success_marker
+
+        if failure_marker.exists():
+            contents = failure_marker.read_text(encoding="utf-8").strip()
+            return JobStatusResult(is_successful=False, error_message=f"Failure marker found: {contents}")
+
+        if not success_marker.exists():
+            return JobStatusResult(
+                is_successful=False,
+                error_message=(
+                    f"Success marker not found: {success_marker.absolute()}. "
+                    "Check stdout.txt and stderr.txt for errors."
+                ),
+            )
+
+        report_csv = output_path / "benchmark_report.csv"
+        if not report_csv.exists():
+            return JobStatusResult(
+                is_successful=False,
+                error_message=(
+                    f"benchmark_report.csv not found in {output_path}. The benchmark may not have completed."
+                ),
+            )
+
+        return JobStatusResult(is_successful=True)

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.py
@@ -252,13 +252,17 @@ class DynamoMockerTestDefinition(TestDefinition):
     success_marker: str = "success-marker.txt"
     failure_marker: str = "failure-marker.txt"
 
+    _python_environment: Optional[PythonEnvironment] = None
+
     @property
     def python_environment(self) -> PythonEnvironment:
-        return PythonEnvironment(
-            name="dynamo-mocker",
-            python_version="3.12",
-            requirements=["ai-dynamo", "genai-perf", "aiperf"],
-        )
+        if not self._python_environment:
+            self._python_environment = PythonEnvironment(
+                name="dynamo-mocker",
+                python_version="3.12",
+                requirements=["ai-dynamo", "genai-perf", "aiperf"],
+            )
+        return self._python_environment
 
     @property
     def installables(self) -> list[Installable]:

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -180,34 +180,42 @@ check_port_free() {
 }
 
 # ── Arg parsing ───────────────────────────────────────────────────────────
+_require_value() {
+  local flag="$1" val="${2-}"
+  if [[ -z "$val" || "$val" == --* ]]; then
+    echo "ERROR: $flag requires a value (got: '${val:-<empty>}')" >&2
+    exit 1
+  fi
+}
+
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --venv-python)              venv_python="$2";              shift 2 ;;
-      --result-dir)               result_dir="$2";               shift 2 ;;
-      --model-path)               model_path="$2";               shift 2 ;;
-      --num-workers)              num_workers="$2";              shift 2 ;;
-      --speedup-ratio)            speedup_ratio="$2";            shift 2 ;;
-      --block-size)               block_size="$2";               shift 2 ;;
-      --num-gpu-blocks-override)  num_gpu_blocks_override="$2";  shift 2 ;;
-      --enable-prefix-caching)    enable_prefix_caching="$2";    shift 2 ;;
-      --http-port)                http_port="$2";                shift 2 ;;
-      --router-mode)              router_mode="$2";              shift 2 ;;
-      --input-tokens)             input_tokens="$2";             shift 2 ;;
-      --output-tokens)            output_tokens="$2";            shift 2 ;;
-      --request-count)            request_count="$2";            shift 2 ;;
-      --replay-concurrency)       replay_concurrency="$2";       shift 2 ;;
-      --replay-mode)              replay_mode="$2";              shift 2 ;;
+      --venv-python)              _require_value "$1" "${2-}"; venv_python="$2";              shift 2 ;;
+      --result-dir)               _require_value "$1" "${2-}"; result_dir="$2";               shift 2 ;;
+      --model-path)               _require_value "$1" "${2-}"; model_path="$2";               shift 2 ;;
+      --num-workers)              _require_value "$1" "${2-}"; num_workers="$2";              shift 2 ;;
+      --speedup-ratio)            _require_value "$1" "${2-}"; speedup_ratio="$2";            shift 2 ;;
+      --block-size)               _require_value "$1" "${2-}"; block_size="$2";               shift 2 ;;
+      --num-gpu-blocks-override)  _require_value "$1" "${2-}"; num_gpu_blocks_override="$2";  shift 2 ;;
+      --enable-prefix-caching)    _require_value "$1" "${2-}"; enable_prefix_caching="$2";    shift 2 ;;
+      --http-port)                _require_value "$1" "${2-}"; http_port="$2";                shift 2 ;;
+      --router-mode)              _require_value "$1" "${2-}"; router_mode="$2";              shift 2 ;;
+      --input-tokens)             _require_value "$1" "${2-}"; input_tokens="$2";             shift 2 ;;
+      --output-tokens)            _require_value "$1" "${2-}"; output_tokens="$2";            shift 2 ;;
+      --request-count)            _require_value "$1" "${2-}"; request_count="$2";            shift 2 ;;
+      --replay-concurrency)       _require_value "$1" "${2-}"; replay_concurrency="$2";       shift 2 ;;
+      --replay-mode)              _require_value "$1" "${2-}"; replay_mode="$2";              shift 2 ;;
       # Disaggregated mode
-      --disaggregation-mode)      disaggregation_mode="$2";    shift 2 ;;
-      --prefill-num-nodes)        prefill_num_nodes="$2";      shift 2 ;;
-      --decode-num-nodes)         decode_num_nodes="$2";       shift 2 ;;
-      --prefill-cmd)              prefill_cmd="$2";            shift 2 ;;
-      --decode-cmd)               decode_cmd="$2";             shift 2 ;;
-      --kv-transfer-bandwidth)    kv_transfer_bandwidth="$2";  shift 2 ;;
-      --prefill-initialized-regex)   prefill_initialized_regex="$2";   shift 2 ;;
-      --decode-initialized-regex)    decode_initialized_regex="$2";    shift 2 ;;
-      --benchmark-tool)              benchmark_tool="$2";              shift 2 ;;
+      --disaggregation-mode)      _require_value "$1" "${2-}"; disaggregation_mode="$2";    shift 2 ;;
+      --prefill-num-nodes)        _require_value "$1" "${2-}"; prefill_num_nodes="$2";      shift 2 ;;
+      --decode-num-nodes)         _require_value "$1" "${2-}"; decode_num_nodes="$2";       shift 2 ;;
+      --prefill-cmd)              _require_value "$1" "${2-}"; prefill_cmd="$2";            shift 2 ;;
+      --decode-cmd)               _require_value "$1" "${2-}"; decode_cmd="$2";             shift 2 ;;
+      --kv-transfer-bandwidth)    _require_value "$1" "${2-}"; kv_transfer_bandwidth="$2";  shift 2 ;;
+      --prefill-initialized-regex)   _require_value "$1" "${2-}"; prefill_initialized_regex="$2";   shift 2 ;;
+      --decode-initialized-regex)    _require_value "$1" "${2-}"; decode_initialized_regex="$2";    shift 2 ;;
+      --benchmark-tool)              _require_value "$1" "${2-}"; benchmark_tool="$2";              shift 2 ;;
       --engine-*)
         # Extra dynamo.mocker engine flags forwarded from [cmd_args.engine] extras.
         engine_extra_args["--${1#--engine-}"]="$2"
@@ -278,7 +286,11 @@ parse_args() {
 # "python3 -m dynamo.mocker", "aiperf profile", "genai-perf profile")
 # resolve to venv binaries without needing full paths.
 resolve_python() {
-  if [[ -n "$venv_python" && -x "$venv_python" ]]; then
+  if [[ -n "$venv_python" ]]; then
+    if [[ ! -x "$venv_python" ]]; then
+      echo "ERROR: --venv-python '$venv_python' does not exist or is not executable" >&2
+      exit 1
+    fi
     PYTHON="$venv_python"
     export PATH="$(dirname "$venv_python"):${PATH}"
   fi
@@ -773,8 +785,11 @@ main() {
   # ── 3. Run benchmark ─────────────────────────────────────────────────────
   if [[ "$benchmark_tool" == "aiperf" ]]; then
     launch_aiperf
-  else
+  elif [[ "$benchmark_tool" == "genai_perf" ]]; then
     launch_genai_perf
+  else
+    write_failure_marker "Unknown benchmark_tool='$benchmark_tool' (must be 'aiperf' or 'genai_perf')"
+    exit 1
   fi
 
   if [[ ! -f "$result_dir/benchmark_report.csv" ]]; then

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -31,7 +31,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── Python: resolved in main() after parse_args ──────────────────────────
 # Set by resolve_python() using --venv-python (CloudAI PythonEnvironment managed venv).
-PYTHON="python3"
+# No default — resolve_python() will fail if --venv-python is not provided.
+PYTHON=""
 
 
 # ── Thread-pool caps ─────────────────────────────────────────────────────
@@ -79,8 +80,8 @@ num_workers=1                   # combined mode: simulated workers in one proces
 # Disaggregated mode: per-role instance counts and launch commands
 prefill_num_nodes=1             # number of prefill mocker instances
 decode_num_nodes=1              # number of decode mocker instances
-prefill_cmd="python3 -m dynamo.mocker --disaggregation-mode prefill"   # command used to launch prefill workers
-decode_cmd="python3 -m dynamo.mocker --disaggregation-mode decode"     # command used to launch decode workers
+prefill_cmd=""   # set after resolve_python() in main(); overridable via --prefill-cmd
+decode_cmd=""    # set after resolve_python() in main(); overridable via --decode-cmd
 kv_transfer_bandwidth=200.0     # GB/s — simulates nixl KV migration latency
 # Per-worker regex: scanned in log files to determine when each role is ready.
 # Mirrors ai_dynamo.sh's worker-initialized-regex (now split per role).
@@ -295,14 +296,14 @@ parse_args() {
 # "python3 -m dynamo.mocker", "aiperf profile", "genai-perf profile")
 # resolve to venv binaries without needing full paths.
 resolve_python() {
-  if [[ -n "$venv_python" ]]; then
-    if [[ ! -x "$venv_python" ]]; then
-      echo "ERROR: --venv-python '$venv_python' does not exist or is not executable" >&2
-      exit 1
-    fi
-    PYTHON="$venv_python"
-    export PATH="$(dirname "$venv_python"):${PATH}"
+  if [[ -z "$venv_python" ]]; then
+    echo "ERROR: --venv-python is required" >&2; exit 1
   fi
+  if [[ ! -x "$venv_python" ]]; then
+    echo "ERROR: --venv-python '$venv_python' does not exist or is not executable" >&2; exit 1
+  fi
+  PYTHON="$venv_python"
+  export PATH="$(dirname "$venv_python"):${PATH}"
 }
 
 # ── Wait helpers ──────────────────────────────────────────────────────────
@@ -726,6 +727,10 @@ launch_aiperf() {
 main() {
   parse_args "$@" || exit 1
   resolve_python
+  # Set defaults that depend on $PYTHON (after venv is resolved).
+  # User-provided --prefill-cmd / --decode-cmd take precedence.
+  [[ -z "$prefill_cmd" ]] && prefill_cmd="$PYTHON -m dynamo.mocker --disaggregation-mode prefill"
+  [[ -z "$decode_cmd" ]]  && decode_cmd="$PYTHON -m dynamo.mocker --disaggregation-mode decode"
 
   if [[ -z "$result_dir" ]]; then
     echo "ERROR: --result-dir is required" >&2

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -410,7 +410,7 @@ write_node_roles() {
       echo "$(hostname),decode_mocker"
     fi
     echo "$(hostname),frontend"
-    echo "$(hostname),genai_perf"
+    echo "$(hostname),${benchmark_tool}"
   } > "$roles_file"
   log "Node roles → $roles_file"
 }

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -1,0 +1,789 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES All rights reserved.
+#
+# dynamo_mocker.sh — GPU-free dynamo inference simulation mirroring ai_dynamo.sh.
+#
+# Mockable counterparts of ai_dynamo.sh components:
+#   etcd              → --discovery-backend file  (no etcd process needed)
+#   nats-server       → still required (DistributedRuntime event plane)
+#   dynamo.frontend   → identical, used as-is
+#   prefill workers   → dynamo.mocker --disaggregation-mode prefill
+#   decode workers    → dynamo.mocker --disaggregation-mode decode
+#   KV block manager  → simulated internally by mocker (block alloc + LRU eviction)
+#   KV events         → published to NATS; kv router mode on frontend responds to them
+#   nixl KV transfer  → simulated via --kv-transfer-bandwidth (no real GPU memory move)
+#   LMCache           → NOT supported (multi-tier memory N/A for mocker)
+#   GPU allocation    → N/A (no GPUs needed)
+#   nvidia-smi        → N/A
+#   genai-perf        → identical, used as-is
+#
+# Modes:
+#   none           — single mocker process handles combined prefill+decode (default)
+#   prefill_decode — separate prefill and decode mocker instances, mirrors
+#                    ai_dynamo.sh's disaggregated worker topology
+#
+# Usage:
+#   bash dynamo_mocker.sh --result-dir <dir> [options...]
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Python: resolved in main() after parse_args ──────────────────────────
+# Set by resolve_python() using --venv-python (CloudAI PythonEnvironment managed venv).
+PYTHON="python3"
+
+
+# ── Thread-pool caps ─────────────────────────────────────────────────────
+# The user cgroup on login nodes is typically limited to ~640 PIDs total.
+# On a 128-CPU node, Python processes that import numpy load OpenBLAS, which
+# spawns 128 threads by default. Two mocker processes + cloudai + genai-perf
+# each doing this would alone account for 4×128=512 threads, leaving almost
+# no room before hitting the 640 PID cap.
+# OMP_NUM_THREADS=1 limits all OpenBLAS/OpenMP thread pools to 1 thread.
+# GOMAXPROCS=4 limits NATS's Go runtime to 4 OS threads (default is cpu_count).
+export OMP_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export GOMAXPROCS=4               # Go runtime: 4 OS threads (NATS)
+
+# ── Logging env setup (mirrors ai_dynamo.sh) ──────────────────────────────
+export DYN_SDK_DISABLE_ANSI_LOGGING=1
+export VLLM_DISABLE_COLORED_OUTPUT=1
+export VLLM_NO_COLOR=1
+export DYN_LOGGING_DISABLE_ANSI_COLORS=1
+export TERM=dumb
+export NO_COLOR=1
+export TQDM_DISABLE=1
+export TQDM_MININTERVAL=999999
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+venv_python=""          # path to venv python3, passed via --venv-python from CloudAI
+result_dir=""
+model_path="Qwen/Qwen3-0.6B"
+speedup_ratio=1.0
+block_size=64
+num_gpu_blocks_override=16384
+enable_prefix_caching="true"
+http_port=8000
+router_mode="round_robin"
+input_tokens=5000
+output_tokens=500
+request_count=1000
+replay_concurrency=100
+replay_mode="offline"
+
+# Disaggregated mode
+disaggregation_mode="none"      # none | prefill_decode
+num_workers=1                   # combined mode: simulated workers in one process
+# Disaggregated mode: per-role instance counts and launch commands
+prefill_num_nodes=1             # number of prefill mocker instances
+decode_num_nodes=1              # number of decode mocker instances
+prefill_cmd="python3 -m dynamo.mocker --disaggregation-mode prefill"   # command used to launch prefill workers
+decode_cmd="python3 -m dynamo.mocker --disaggregation-mode decode"     # command used to launch decode workers
+kv_transfer_bandwidth=200.0     # GB/s — simulates nixl KV migration latency
+# Per-worker regex: scanned in log files to determine when each role is ready.
+# Mirrors ai_dynamo.sh's worker-initialized-regex (now split per role).
+prefill_initialized_regex="created and running"
+decode_initialized_regex="created and running"
+
+# Benchmark tool selection
+benchmark_tool="genai_perf"          # genai_perf | aiperf
+aiperf_cmd=""                        # override aiperf command (empty = aiperf.sh default)
+genai_perf_cmd=""                    # override genai-perf command (empty = genai_perf.sh default)
+aiperf_extra_args_raw=""             # raw CLI string appended to aiperf profile command
+genai_perf_extra_args_raw=""         # raw CLI string appended to genai-perf profile command
+declare -A aiperf_extra_args=()      # extra aiperf flags from --aiperf-<key> <val>
+declare -A genai_perf_extra_args=()  # extra genai-perf flags from --genai-perf-<key> <val>
+declare -A engine_extra_args=()      # extra dynamo.mocker engine flags from --engine-<key> <val>
+declare -A mocker_extra_args=()      # extra dynamo.mocker topology flags from --mocker-<key> <val>
+declare -A frontend_extra_args=()    # extra dynamo.frontend flags from --frontend-<key> <val>
+declare -A prefill_args_extra=()     # named flags for prefill mockers from --prefill-args-<key> <val>
+declare -A decode_args_extra=()      # named flags for decode mockers from --decode-args-<key> <val>
+prefill_extra_args_raw=""            # raw CLI string for prefill mockers from --prefill-extra-args
+decode_extra_args_raw=""             # raw CLI string for decode mockers from --decode-extra-args
+
+# ── ERR trap ──────────────────────────────────────────────────────────────
+on_error() {
+  local exit_code=$? file=$1 line=$2
+  log "ERROR: command failed with exit code $exit_code at $file:$line"
+}
+trap 'on_error "${BASH_SOURCE[0]}" "$LINENO"' ERR
+
+# ── PID tracking ──────────────────────────────────────────────────────────
+NATS_PID=""
+FRONTEND_PID=""
+COMBINED_MOCKER_PID=""
+declare -a PREFILL_PIDS=()
+declare -a DECODE_PIDS=()
+
+# ── Logging ───────────────────────────────────────────────────────────────
+log() {
+  echo "[$(date +%F\ %T) $(hostname)]: $*"
+}
+
+# ── Failure / cleanup ─────────────────────────────────────────────────────
+write_failure_marker() {
+  local msg="${1:-Unknown error}"
+  echo "$msg" > "$result_dir/failure-marker.txt"
+  log "Failure marker written: $msg"
+}
+
+cleanup() {
+  log "Stopping background processes..."
+  local pid
+  # Kill in reverse startup order (frontend first, then workers, then NATS)
+  [[ -n "$FRONTEND_PID" ]]        && kill "$FRONTEND_PID"        2>/dev/null || true
+  [[ -n "$COMBINED_MOCKER_PID" ]] && kill "$COMBINED_MOCKER_PID" 2>/dev/null || true
+  for pid in "${PREFILL_PIDS[@]+"${PREFILL_PIDS[@]}"}"; do kill "$pid" 2>/dev/null || true; done
+  for pid in "${DECODE_PIDS[@]+"${DECODE_PIDS[@]}"}";  do kill "$pid" 2>/dev/null || true; done
+  [[ -n "$NATS_PID" ]]            && kill "$NATS_PID"            2>/dev/null || true
+  # Wait for all to exit cleanly
+  [[ -n "$FRONTEND_PID" ]]        && wait "$FRONTEND_PID"        2>/dev/null || true
+  [[ -n "$COMBINED_MOCKER_PID" ]] && wait "$COMBINED_MOCKER_PID" 2>/dev/null || true
+  for pid in "${PREFILL_PIDS[@]+"${PREFILL_PIDS[@]}"}"; do wait "$pid" 2>/dev/null || true; done
+  for pid in "${DECODE_PIDS[@]+"${DECODE_PIDS[@]}"}";  do wait "$pid" 2>/dev/null || true; done
+  [[ -n "$NATS_PID" ]]            && wait "$NATS_PID"            2>/dev/null || true
+  log "Background processes stopped."
+}
+
+on_exit() {
+  local exit_code=$?
+  if [[ $exit_code -ne 0 && ! -f "$result_dir/failure-marker.txt" ]]; then
+    write_failure_marker "Script exited with code $exit_code"
+  fi
+  cleanup
+}
+
+# ── Port checking (mirrors ai_dynamo.sh _check_free_port_or_die) ──────────
+_port_in_use() {
+  local port="$1"
+  if command -v ss >/dev/null 2>&1; then
+    ss -lnt 2>/dev/null | awk -v p=":$port$" '$4 ~ p {found=1} END{exit !found}'
+    return $?
+  elif command -v lsof >/dev/null 2>&1; then
+    lsof -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  return 1  # assume free if cannot check
+}
+
+check_port_free() {
+  local name="$1" port="$2"
+  log "Checking if port $port ($name) is free..."
+  if _port_in_use "$port"; then
+    log "ERROR: Port $port ($name) is already in use on $(hostname)"
+    write_failure_marker "Port $port ($name) is already in use"
+    exit 1
+  fi
+  log "Port $port ($name) is free"
+}
+
+# ── Arg parsing ───────────────────────────────────────────────────────────
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --venv-python)              venv_python="$2";              shift 2 ;;
+      --result-dir)               result_dir="$2";               shift 2 ;;
+      --model-path)               model_path="$2";               shift 2 ;;
+      --num-workers)              num_workers="$2";              shift 2 ;;
+      --speedup-ratio)            speedup_ratio="$2";            shift 2 ;;
+      --block-size)               block_size="$2";               shift 2 ;;
+      --num-gpu-blocks-override)  num_gpu_blocks_override="$2";  shift 2 ;;
+      --enable-prefix-caching)    enable_prefix_caching="$2";    shift 2 ;;
+      --http-port)                http_port="$2";                shift 2 ;;
+      --router-mode)              router_mode="$2";              shift 2 ;;
+      --input-tokens)             input_tokens="$2";             shift 2 ;;
+      --output-tokens)            output_tokens="$2";            shift 2 ;;
+      --request-count)            request_count="$2";            shift 2 ;;
+      --replay-concurrency)       replay_concurrency="$2";       shift 2 ;;
+      --replay-mode)              replay_mode="$2";              shift 2 ;;
+      # Disaggregated mode
+      --disaggregation-mode)      disaggregation_mode="$2";    shift 2 ;;
+      --prefill-num-nodes)        prefill_num_nodes="$2";      shift 2 ;;
+      --decode-num-nodes)         decode_num_nodes="$2";       shift 2 ;;
+      --prefill-cmd)              prefill_cmd="$2";            shift 2 ;;
+      --decode-cmd)               decode_cmd="$2";             shift 2 ;;
+      --kv-transfer-bandwidth)    kv_transfer_bandwidth="$2";  shift 2 ;;
+      --prefill-initialized-regex)   prefill_initialized_regex="$2";   shift 2 ;;
+      --decode-initialized-regex)    decode_initialized_regex="$2";    shift 2 ;;
+      --benchmark-tool)              benchmark_tool="$2";              shift 2 ;;
+      --engine-*)
+        # Extra dynamo.mocker engine flags forwarded from [cmd_args.engine] extras.
+        engine_extra_args["--${1#--engine-}"]="$2"
+        shift 2 ;;
+      --mocker-*)
+        # Extra dynamo.mocker topology flags forwarded from [cmd_args.worker] extras.
+        # "mocker" prefix avoids any ambiguity with --worker-initialized-regex.
+        mocker_extra_args["--${1#--mocker-}"]="$2"
+        shift 2 ;;
+      --frontend-*)
+        # Extra dynamo.frontend flags forwarded from [cmd_args.frontend] extras.
+        frontend_extra_args["--${1#--frontend-}"]="$2"
+        shift 2 ;;
+      --prefill-extra-args)
+        # Raw CLI string appended verbatim to prefill mocker invocations.
+        prefill_extra_args_raw="$2"
+        shift 2 ;;
+      --prefill-args-*)
+        # Named flags from [cmd_args.worker.prefill_worker.args] — applied to prefill mockers only.
+        prefill_args_extra["--${1#--prefill-args-}"]="$2"
+        shift 2 ;;
+      --decode-extra-args)
+        # Raw CLI string appended verbatim to decode mocker invocations.
+        decode_extra_args_raw="$2"
+        shift 2 ;;
+      --decode-args-*)
+        # Named flags from [cmd_args.worker.decode_worker.args] — applied to decode mockers only.
+        decode_args_extra["--${1#--decode-args-}"]="$2"
+        shift 2 ;;
+      --aiperf-cmd)
+        # Override aiperf launch command (forwarded from [cmd_args.aiperf] cmd field).
+        aiperf_cmd="$2"
+        shift 2 ;;
+      --aiperf-extra-args)
+        # Raw CLI string appended verbatim to the aiperf profile command.
+        aiperf_extra_args_raw="$2"
+        shift 2 ;;
+      --aiperf-*)
+        # Extra aiperf-specific flags forwarded from the TOML [cmd_args.aiperf] section.
+        # Stored as --<flag-name> → value and appended to the aiperf profile command.
+        aiperf_extra_args["--${1#--aiperf-}"]="$2"
+        shift 2 ;;
+      --genai-perf-cmd)
+        # Override genai-perf launch command (forwarded from [cmd_args.genai_perf] cmd field).
+        genai_perf_cmd="$2"
+        shift 2 ;;
+      --genai-perf-extra-args)
+        # Raw CLI string appended verbatim to the genai-perf profile command.
+        genai_perf_extra_args_raw="$2"
+        shift 2 ;;
+      --genai-perf-*)
+        # Extra genai-perf-specific flags forwarded from the TOML [cmd_args.genai_perf] section.
+        # Stored as --<flag-name> → value and appended to the genai-perf profile command.
+        genai_perf_extra_args["--${1#--genai-perf-}"]="$2"
+        shift 2 ;;
+      *)
+        echo "ERROR: Unknown argument: $1" >&2
+        echo "Usage: bash dynamo_mocker.sh --result-dir <dir> --model-path <path> [options...]" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+# ── Python resolution ────────────────────────────────────────────────────
+# Called in main() after parse_args so --venv-python is available.
+# Prepends venv bin to PATH so cmd fields in the TOML (e.g.
+# "python3 -m dynamo.mocker", "aiperf profile", "genai-perf profile")
+# resolve to venv binaries without needing full paths.
+resolve_python() {
+  if [[ -n "$venv_python" && -x "$venv_python" ]]; then
+    PYTHON="$venv_python"
+    export PATH="$(dirname "$venv_python"):${PATH}"
+  fi
+}
+
+# ── Wait helpers ──────────────────────────────────────────────────────────
+wait_for_service() {
+  local url="$1"
+  local max_wait="${2:-120}"
+  local waited=0
+  log "Waiting for service at $url (timeout: ${max_wait}s)..."
+  while ! curl -sf "$url" > /dev/null 2>&1; do
+    if [[ $waited -ge $max_wait ]]; then
+      log "ERROR: Service at $url did not become ready after ${max_wait}s"
+      return 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  log "Service ready at $url (waited ${waited}s)"
+}
+
+wait_for_model() {
+  # Wait until /v1/models lists at least one model (a decode worker has registered).
+  local base_url="$1"
+  local max_wait="${2:-300}"
+  local waited=0
+  log "Waiting for mocker worker to register a model at $base_url/v1/models (timeout: ${max_wait}s)..."
+  while true; do
+    local count
+    count=$(curl -sf "$base_url/v1/models" 2>/dev/null \
+      | "$PYTHON" -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('data', [])))" \
+      2>/dev/null || echo "0")
+    if [[ "$count" -gt 0 ]]; then
+      log "Mocker worker registered ($count model(s) listed, waited ${waited}s)"
+      return 0
+    fi
+    if [[ $waited -ge $max_wait ]]; then
+      log "ERROR: No mocker worker registered after ${max_wait}s"
+      log "Current /v1/models: $(curl -sf "$base_url/v1/models" 2>/dev/null || echo 'no response')"
+      return 1
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+}
+
+# Wait for worker log files to contain the initialization regex.
+# Mirrors ai_dynamo.sh's wait_for_dynamo_frontend / _count_initialized_*.
+wait_for_workers_initialized() {
+  local role="$1"               # prefill | decode
+  local expected="$2"
+  local initialized_regex="$3"  # per-role init regex (replaces global worker_initialized_regex)
+  local max_wait="${4:-300}"
+  local waited=0
+  log "Waiting for $expected $role mocker(s) to initialize (timeout: ${max_wait}s)..."
+  while true; do
+    local ready=0
+    # || true: with set -o pipefail, grep non-zero exit (no files) would otherwise
+    # cause both wc -l's "0" AND "echo 0" to land in the variable giving "0\n0".
+    ready=$(grep -i -l -E "$initialized_regex" \
+      "$result_dir/dynamo_${role}_"*.log 2>/dev/null | wc -l) || true
+    ready="${ready//[[:space:]]/}"   # strip whitespace from wc output
+    if [[ "$ready" -ge "$expected" ]]; then
+      log "$role workers ready: $ready/$expected (waited ${waited}s)"
+      return 0
+    fi
+    log "  $role initialized: $ready/$expected (waited ${waited}s)..."
+    if [[ $waited -ge $max_wait ]]; then
+      log "ERROR: Only $ready/$expected $role workers initialized after ${max_wait}s"
+      return 1
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+}
+
+# Scan worker logs for fatal errors. Mirrors ai_dynamo.sh's exit_on_error.
+detect_fatal_errors() {
+  local error_pattern="Exception:|FATAL|RuntimeError:|Failed to connect|Address already in use|Error.*initialization"
+  local -a files=()
+  [[ -f "$result_dir/dynamo_mocker_combined.log" ]] && files+=("$result_dir/dynamo_mocker_combined.log")
+  for f in "$result_dir"/dynamo_prefill_*.log "$result_dir"/dynamo_decode_*.log; do
+    [[ -f "$f" ]] && files+=("$f")
+  done
+  [[ ${#files[@]} -eq 0 ]] && return 0
+
+  local n
+  n=$(grep -c -E "$error_pattern" "${files[@]}" 2>/dev/null \
+    | awk -F: '{sum += $NF} END {print sum+0}')
+  if [[ "$n" -gt 0 ]]; then
+    log "ERROR: Detected $n fatal error line(s) in worker logs"
+    grep -h -E "$error_pattern" "${files[@]}" 2>/dev/null \
+      >> "$result_dir/failure-marker.txt" || true
+    return 1
+  fi
+  return 0
+}
+
+# ── Node roles log (mirrors ai_dynamo.sh NODE_ROLES_FILE) ─────────────────
+write_node_roles() {
+  local roles_file="$result_dir/node_roles.log"
+  {
+    if [[ "$disaggregation_mode" == "none" ]]; then
+      echo "$(hostname),combined_mocker"
+    else
+      echo "$(hostname),prefill_mocker"
+      echo "$(hostname),decode_mocker"
+    fi
+    echo "$(hostname),frontend"
+    echo "$(hostname),genai_perf"
+  } > "$roles_file"
+  log "Node roles → $roles_file"
+}
+
+# ── NATS (mirrors ai_dynamo.sh launch_nats) ───────────────────────────────
+launch_nats() {
+  local NATS_BIN
+  NATS_BIN="$(command -v nats-server 2>/dev/null || true)"
+  if [[ -z "$NATS_BIN" || ! -x "$NATS_BIN" ]]; then
+    write_failure_marker "nats-server not found in PATH. Install nats-server and ensure it is on PATH."
+    exit 1
+  fi
+  check_port_free "nats"             4222
+  check_port_free "nats-monitoring"  8222
+
+  log "Starting nats-server..."
+  "$NATS_BIN" -js -p 4222 -m 8222 > "$result_dir/nats.log" 2>&1 &
+  NATS_PID=$!
+  log "nats-server started (PID=$NATS_PID)"
+  wait_for_service "http://localhost:8222/healthz" 30
+  log "NATS ready"
+}
+
+# ── Extra-flags expansion helper ──────────────────────────────────────────
+# Usage: _build_extra_flags <src-assoc-array-name> <dst-indexed-array-name>
+# Expands an associative array of --flag → value pairs into a flat indexed
+# array suitable for splicing into a command invocation.  Bool convention:
+#   "true"  → bare flag (no value argument)
+#   "false" → omitted entirely
+#   other   → --flag value
+# Requires bash 4.3+ (local -n nameref).
+_build_extra_flags() {
+  local -n _src="$1"
+  local -n _dst="$2"
+  local key val
+  for key in "${!_src[@]}"; do
+    val="${_src[$key]}"
+    if   [[ "$val" == "true"  ]]; then _dst+=("$key")
+    elif [[ "$val" != "false" ]]; then _dst+=("$key" "$val")
+    fi
+  done
+}
+
+# ── Frontend (mirrors ai_dynamo.sh launch_ingress) ────────────────────────
+launch_frontend() {
+  # Convert router_mode underscores to dashes (round_robin → round-robin)
+  local frontend_router_mode="${router_mode//_/-}"
+  # kv_router → kv  (frontend uses short form)
+  [[ "$frontend_router_mode" == "kv-router" ]] && frontend_router_mode="kv"
+
+  local extra_flags=()
+  _build_extra_flags frontend_extra_args extra_flags
+
+  # In kv router mode, mocker workers publish KV events via ZMQ (file-based
+  # discovery backend), not via NATS.  ai-dynamo ≥1.2 changed kv router's
+  # EventSubscriber to require NATS, which breaks chat-endpoint registration
+  # when using file discovery.  --no-router-kv-events makes the router predict
+  # cache state from routing decisions instead of subscribing to worker events,
+  # which is the correct behaviour for a GPU-free mocker workload anyway.
+  local kv_events_flag=()
+  [[ "$frontend_router_mode" == "kv" ]] && kv_events_flag=("--no-router-kv-events")
+
+  check_port_free "dynamo.frontend" "$http_port"
+  log "Starting dynamo.frontend (port=$http_port, router=$frontend_router_mode)..."
+  "$PYTHON" -m dynamo.frontend \
+    --http-port "$http_port" \
+    --router-mode "$frontend_router_mode" \
+    --discovery-backend file \
+    --request-plane tcp \
+    "${kv_events_flag[@]+"${kv_events_flag[@]}"}" \
+    "${extra_flags[@]+"${extra_flags[@]}"}" \
+    > "$result_dir/dynamo_frontend.log" 2>&1 &
+  FRONTEND_PID=$!
+  log "dynamo.frontend started (PID=$FRONTEND_PID)"
+
+  if ! wait_for_service "http://localhost:${http_port}/v1/models"; then
+    write_failure_marker "dynamo.frontend did not become ready on port $http_port"
+    exit 1
+  fi
+}
+
+# ── Combined mocker (non-disaggregated) ───────────────────────────────────
+launch_combined_mocker() {
+  local prefix_caching_flag="--enable-prefix-caching"
+  [[ "$enable_prefix_caching" == "false" ]] && prefix_caching_flag="--no-enable-prefix-caching"
+
+  local extra_flags=()
+  _build_extra_flags engine_extra_args extra_flags
+  _build_extra_flags mocker_extra_args extra_flags
+
+  log "Starting dynamo.mocker combined (num_workers=$num_workers, speedup=$speedup_ratio)..."
+  # shellcheck disable=SC2086
+  "$PYTHON" -m dynamo.mocker \
+    --model-path "$model_path" \
+    --num-workers "$num_workers" \
+    --speedup-ratio "$speedup_ratio" \
+    --block-size "$block_size" \
+    --num-gpu-blocks-override "$num_gpu_blocks_override" \
+    $prefix_caching_flag \
+    --discovery-backend file \
+    --request-plane tcp \
+    "${extra_flags[@]+"${extra_flags[@]}"}" \
+    > "$result_dir/dynamo_mocker_combined.log" 2>&1 &
+  COMBINED_MOCKER_PID=$!
+  log "dynamo.mocker (combined) started (PID=$COMBINED_MOCKER_PID)"
+}
+
+# ── Disaggregated: prefill mockers (mirrors ai_dynamo.sh launch_prefill) ──
+launch_prefill_mockers() {
+  local prefix_caching_flag="--enable-prefix-caching"
+  [[ "$enable_prefix_caching" == "false" ]] && prefix_caching_flag="--no-enable-prefix-caching"
+
+  local extra_flags=()
+  _build_extra_flags engine_extra_args  extra_flags
+  _build_extra_flags mocker_extra_args  extra_flags
+  _build_extra_flags prefill_args_extra extra_flags
+  # Append raw extra_args string if provided (word-split intentional for raw CLI string)
+  # shellcheck disable=SC2206
+  [[ -n "$prefill_extra_args_raw" ]] && extra_flags+=($prefill_extra_args_raw)
+
+  # Split cmd string into array for safe word-splitting (no eval needed)
+  local -a _prefill_cmd
+  read -ra _prefill_cmd <<< "$prefill_cmd"
+
+  log "Launching $prefill_num_nodes prefill mocker(s) via: $prefill_cmd"
+  for i in $(seq 0 $(( prefill_num_nodes - 1 ))); do
+    local log_file="$result_dir/dynamo_prefill_${i}.log"
+    log "  prefill mocker $i → $log_file"
+    # --disaggregation-mode prefill is owned by the cmd (set in TOML prefill_worker.cmd).
+    # shellcheck disable=SC2086
+    "${_prefill_cmd[@]}" \
+      --model-path "$model_path" \
+      --num-workers 1 \
+      --speedup-ratio "$speedup_ratio" \
+      --block-size "$block_size" \
+      --num-gpu-blocks-override "$num_gpu_blocks_override" \
+      $prefix_caching_flag \
+      --kv-transfer-bandwidth "$kv_transfer_bandwidth" \
+      --discovery-backend file \
+      --request-plane tcp \
+      "${extra_flags[@]+"${extra_flags[@]}"}" \
+      > "$log_file" 2>&1 &
+    PREFILL_PIDS+=($!)
+    log "  prefill mocker $i started (PID=${PREFILL_PIDS[-1]})"
+  done
+}
+
+# ── Disaggregated: decode mockers (mirrors ai_dynamo.sh launch_decode) ────
+launch_decode_mockers() {
+  local prefix_caching_flag="--enable-prefix-caching"
+  [[ "$enable_prefix_caching" == "false" ]] && prefix_caching_flag="--no-enable-prefix-caching"
+
+  local extra_flags=()
+  _build_extra_flags engine_extra_args extra_flags
+  _build_extra_flags mocker_extra_args extra_flags
+  _build_extra_flags decode_args_extra extra_flags
+  # Append raw extra_args string if provided (word-split intentional for raw CLI string)
+  # shellcheck disable=SC2206
+  [[ -n "$decode_extra_args_raw" ]] && extra_flags+=($decode_extra_args_raw)
+
+  # Split cmd string into array for safe word-splitting (no eval needed)
+  local -a _decode_cmd
+  read -ra _decode_cmd <<< "$decode_cmd"
+
+  log "Launching $decode_num_nodes decode mocker(s) via: $decode_cmd"
+  for i in $(seq 0 $(( decode_num_nodes - 1 ))); do
+    local log_file="$result_dir/dynamo_decode_${i}.log"
+    log "  decode mocker $i → $log_file"
+    # --disaggregation-mode decode is owned by the cmd (set in TOML decode_worker.cmd).
+    # shellcheck disable=SC2086
+    "${_decode_cmd[@]}" \
+      --model-path "$model_path" \
+      --num-workers 1 \
+      --speedup-ratio "$speedup_ratio" \
+      --block-size "$block_size" \
+      --num-gpu-blocks-override "$num_gpu_blocks_override" \
+      $prefix_caching_flag \
+      --kv-transfer-bandwidth "$kv_transfer_bandwidth" \
+      --discovery-backend file \
+      --request-plane tcp \
+      "${extra_flags[@]+"${extra_flags[@]}"}" \
+      > "$log_file" 2>&1 &
+    DECODE_PIDS+=($!)
+    log "  decode mocker $i started (PID=${DECODE_PIDS[-1]})"
+  done
+}
+
+# ── genai_perf (mirrors ai_dynamo.sh launch_workload / genai_perf.sh) ─────
+resolve_genai_perf_sh() {
+  local local_copy="$SCRIPT_DIR/genai_perf.sh"
+  if [[ -f "$local_copy" ]]; then echo "$local_copy"; return; fi
+  "$PYTHON" - <<'EOF'
+import sys
+try:
+    from pathlib import Path
+    import cloudai.workloads.ai_dynamo as m
+    p = Path(m.__file__).parent / "genai_perf.sh"
+    if p.exists():
+        print(p)
+        sys.exit(0)
+except Exception:
+    pass
+sys.exit(1)
+EOF
+}
+
+launch_genai_perf() {
+  local GENAI_PERF_SH
+  if ! GENAI_PERF_SH="$(resolve_genai_perf_sh)"; then
+    write_failure_marker "genai_perf.sh not found — install cloudai or place genai_perf.sh alongside dynamo_mocker.sh"
+    exit 1
+  fi
+  log "Using genai_perf.sh at: $GENAI_PERF_SH"
+
+  # replay_mode: offline → --concurrency (throughput test)
+  #              online  → --request-rate (latency-under-load test)
+  local load_flag
+  if [[ "$replay_mode" == "online" ]]; then
+    load_flag="--request-rate $replay_concurrency"
+  else
+    load_flag="--concurrency $replay_concurrency"
+  fi
+
+  # Collect extra genai-perf flags from --genai-perf-* passthrough args.
+  # Bool extras: "true" → bare flag, "false" → omitted.
+  local extra_flags=()
+  for key in "${!genai_perf_extra_args[@]}"; do
+    local val="${genai_perf_extra_args[$key]}"
+    if [[ "$val" == "true" ]]; then
+      extra_flags+=("$key")
+    elif [[ "$val" != "false" ]]; then
+      extra_flags+=("$key" "$val")
+    fi
+  done
+  # Append raw extra_args string if provided (word-split intentional for raw CLI string)
+  # shellcheck disable=SC2206
+  [[ -n "$genai_perf_extra_args_raw" ]] && extra_flags+=($genai_perf_extra_args_raw)
+
+  # Build context args array; only pass --cmd when explicitly overridden.
+  local context_args=(--result-dir "$result_dir" --model "$model_path" --port "$http_port")
+  [[ -n "$genai_perf_cmd" ]] && context_args+=(--cmd "$genai_perf_cmd")
+
+  # shellcheck disable=SC2086
+  bash "$GENAI_PERF_SH" \
+    "${context_args[@]}" \
+    -- \
+    $load_flag \
+    --request-count "$request_count" \
+    --synthetic-input-tokens-mean "$input_tokens" \
+    --output-tokens-mean "$output_tokens" \
+    --endpoint-type chat \
+    "${extra_flags[@]}"
+
+  log "genai_perf.sh completed"
+}
+
+# ── aiperf (alternative to genai-perf, mirrors launch_genai_perf) ────────
+resolve_aiperf_sh() {
+  local local_copy="$SCRIPT_DIR/aiperf.sh"
+  if [[ -f "$local_copy" ]]; then echo "$local_copy"; return; fi
+  return 1
+}
+
+launch_aiperf() {
+  local AIPERF_SH
+  if ! AIPERF_SH="$(resolve_aiperf_sh)"; then
+    write_failure_marker "aiperf.sh not found — place aiperf.sh alongside dynamo_mocker.sh"
+    exit 1
+  fi
+  log "Using aiperf.sh at: $AIPERF_SH"
+
+  local load_flag
+  if [[ "$replay_mode" == "online" ]]; then
+    load_flag="--request-rate $replay_concurrency"
+  else
+    load_flag="--concurrency $replay_concurrency"
+  fi
+
+  # Collect extra aiperf flags from --aiperf-* passthrough args.
+  # Bool extras: "true" → bare flag, "false" → omitted.
+  local extra_flags=()
+  for key in "${!aiperf_extra_args[@]}"; do
+    local val="${aiperf_extra_args[$key]}"
+    if [[ "$val" == "true" ]]; then
+      extra_flags+=("$key")
+    elif [[ "$val" != "false" ]]; then
+      extra_flags+=("$key" "$val")
+    fi
+  done
+  # Append raw extra_args string if provided (word-split intentional for raw CLI string)
+  # shellcheck disable=SC2206
+  [[ -n "$aiperf_extra_args_raw" ]] && extra_flags+=($aiperf_extra_args_raw)
+
+  # Build context args array; only pass --cmd when explicitly overridden.
+  local context_args=(--result-dir "$result_dir" --model "$model_path" --port "$http_port")
+  [[ -n "$aiperf_cmd" ]] && context_args+=(--cmd "$aiperf_cmd")
+
+  # shellcheck disable=SC2086
+  bash "$AIPERF_SH" \
+    "${context_args[@]}" \
+    -- \
+    --synthetic-input-tokens-mean "$input_tokens" \
+    --output-tokens-mean          "$output_tokens" \
+    --request-count               "$request_count" \
+    $load_flag \
+    "${extra_flags[@]}"
+
+  log "aiperf.sh completed"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────
+main() {
+  parse_args "$@" || exit 1
+  resolve_python
+
+  if [[ -z "$result_dir" ]]; then
+    echo "ERROR: --result-dir is required" >&2
+    exit 1
+  fi
+
+  mkdir -p "$result_dir"
+  trap on_exit EXIT
+
+  log "disaggregation_mode=$disaggregation_mode  router_mode=$router_mode  replay_mode=$replay_mode"
+  write_node_roles
+
+  # ── 1. NATS — always required (DistributedRuntime event plane) ──────────
+  launch_nats
+
+  if [[ "$disaggregation_mode" == "none" ]]; then
+    # ── Combined mode: one mocker process, combined prefill+decode ─────────
+    log "=== Combined mode: num_workers=$num_workers ==="
+    launch_combined_mocker
+    launch_frontend
+
+    if ! wait_for_model "http://localhost:${http_port}"; then
+      write_failure_marker "dynamo.mocker did not register after 300s — check dynamo_mocker_combined.log"
+      exit 1
+    fi
+
+  elif [[ "$disaggregation_mode" == "prefill_decode" ]]; then
+    # ── Disaggregated mode: separate prefill + decode mocker processes ─────
+    # Mirrors ai_dynamo.sh: launch workers first, wait for init, then frontend.
+    log "=== Disaggregated mode: prefill=$prefill_num_nodes, decode=$decode_num_nodes ==="
+    launch_prefill_mockers
+    launch_decode_mockers
+
+    # Wait for prefill workers (log-based — prefill doesn't expose HTTP)
+    if ! wait_for_workers_initialized "prefill" "$prefill_num_nodes" "$prefill_initialized_regex" 300; then
+      detect_fatal_errors || true
+      write_failure_marker "Prefill mocker(s) did not initialize — check dynamo_prefill_*.log"
+      exit 1
+    fi
+
+    # Wait for decode workers (log-based)
+    if ! wait_for_workers_initialized "decode" "$decode_num_nodes" "$decode_initialized_regex" 300; then
+      detect_fatal_errors || true
+      write_failure_marker "Decode mocker(s) did not initialize — check dynamo_decode_*.log"
+      exit 1
+    fi
+
+    launch_frontend
+
+    # Confirm at least one decode worker registered with the frontend
+    if ! wait_for_model "http://localhost:${http_port}"; then
+      write_failure_marker "No decode workers registered with frontend after 300s"
+      exit 1
+    fi
+
+  else
+    write_failure_marker "Unknown disaggregation_mode='$disaggregation_mode' (must be 'none' or 'prefill_decode')"
+    exit 1
+  fi
+
+  # ── 2. Check for startup errors before running the benchmark ────────────
+  if ! detect_fatal_errors; then
+    write_failure_marker "Fatal errors detected in worker logs before benchmark — aborting"
+    exit 1
+  fi
+
+  # ── 3. Run benchmark ─────────────────────────────────────────────────────
+  if [[ "$benchmark_tool" == "aiperf" ]]; then
+    launch_aiperf
+  else
+    launch_genai_perf
+  fi
+
+  if [[ ! -f "$result_dir/benchmark_report.csv" ]]; then
+    write_failure_marker "benchmark_report.csv not found in $result_dir — benchmark may not have completed"
+    exit 1
+  fi
+  echo "SUCCESS" > "$result_dir/success-marker.txt"
+  log "Run complete — SUCCESS"
+  trap cleanup EXIT
+}
+
+main "$@"

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES All rights reserved.
 #
 # dynamo_mocker.sh — GPU-free dynamo inference simulation mirroring ai_dynamo.sh.
 #

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -87,6 +87,9 @@ kv_transfer_bandwidth=200.0     # GB/s — simulates nixl KV migration latency
 prefill_initialized_regex="created and running"
 decode_initialized_regex="created and running"
 
+# NATS server command (override with full path if nats-server is not on PATH)
+nats_cmd="nats-server -js"
+
 # Benchmark tool selection
 benchmark_tool="genai_perf"          # genai_perf | aiperf
 aiperf_cmd=""                        # override aiperf command (empty = aiperf.sh default)
@@ -192,6 +195,7 @@ parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --venv-python)              _require_value "$1" "${2-}"; venv_python="$2";              shift 2 ;;
+      --nats-cmd)                 _require_value "$1" "${2-}"; nats_cmd="$2";                 shift 2 ;;
       --result-dir)               _require_value "$1" "${2-}"; result_dir="$2";               shift 2 ;;
       --model-path)               _require_value "$1" "${2-}"; model_path="$2";               shift 2 ;;
       --num-workers)              _require_value "$1" "${2-}"; num_workers="$2";              shift 2 ;;
@@ -408,17 +412,18 @@ write_node_roles() {
 
 # ── NATS (mirrors ai_dynamo.sh launch_nats) ───────────────────────────────
 launch_nats() {
-  local NATS_BIN
-  NATS_BIN="$(command -v nats-server 2>/dev/null || true)"
-  if [[ -z "$NATS_BIN" || ! -x "$NATS_BIN" ]]; then
-    write_failure_marker "nats-server not found in PATH. Install nats-server and ensure it is on PATH."
+  # First token of nats_cmd is the binary (e.g. "nats-server" or "/full/path/nats-server")
+  local nats_bin="${nats_cmd%% *}"
+  if ! command -v "$nats_bin" > /dev/null 2>&1 && [[ ! -x "$nats_bin" ]]; then
+    write_failure_marker "nats-server not found: '$nats_bin'. Set nats_cmd in [cmd_args] to the full path."
     exit 1
   fi
   check_port_free "nats"             4222
   check_port_free "nats-monitoring"  8222
 
-  log "Starting nats-server..."
-  "$NATS_BIN" -js -p 4222 -m 8222 > "$result_dir/nats.log" 2>&1 &
+  log "Starting nats-server (cmd=$nats_cmd)..."
+  # shellcheck disable=SC2086
+  $nats_cmd -p 4222 -m 8222 > "$result_dir/nats.log" 2>&1 &
   NATS_PID=$!
   log "nats-server started (PID=$NATS_PID)"
   wait_for_service "http://localhost:8222/healthz" 30

--- a/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
+++ b/src/cloudai/workloads/dynamo_mocker/dynamo_mocker.sh
@@ -203,7 +203,12 @@ parse_args() {
       --block-size)               _require_value "$1" "${2-}"; block_size="$2";               shift 2 ;;
       --num-gpu-blocks-override)  _require_value "$1" "${2-}"; num_gpu_blocks_override="$2";  shift 2 ;;
       --enable-prefix-caching)    _require_value "$1" "${2-}"; enable_prefix_caching="$2";    shift 2 ;;
-      --http-port)                _require_value "$1" "${2-}"; http_port="$2";                shift 2 ;;
+      --http-port)
+        _require_value "$1" "${2-}"
+        if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          echo "ERROR: --http-port must be numeric (got: '$2')" >&2; exit 1
+        fi
+        http_port="$2"; shift 2 ;;
       --router-mode)              _require_value "$1" "${2-}"; router_mode="$2";              shift 2 ;;
       --input-tokens)             _require_value "$1" "${2-}"; input_tokens="$2";             shift 2 ;;
       --output-tokens)            _require_value "$1" "${2-}"; output_tokens="$2";            shift 2 ;;

--- a/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES All rights reserved.
+#
+# genai_perf.sh — wrapper for genai-perf profile, mirroring aiperf.sh.
+#
+# Called as:
+#   bash genai_perf.sh --result-dir <dir> --model <model> --port <port> \
+#                      [--report-name <name>] -- <genai-perf-profile-args>...
+#
+# Context flags (before --):
+#   --result-dir   Directory where artifacts and the final report are written.
+#   --model        HuggingFace model identifier (e.g. Qwen/Qwen3-0.6B).
+#   --port         HTTP port the dynamo.frontend is listening on.
+#   --report-name  Output CSV name (default: benchmark_report.csv).
+#
+# Everything after -- is passed directly to "genai-perf profile".
+
+set -Eeuo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── genai-perf + perf_analyzer: prefer cloudaix .venv ────────────────────
+# genai-perf invokes perf_analyzer as a subprocess via PATH lookup, so both
+# binaries must be reachable. Prepending the venv bin covers both.
+_VENV_BIN="${_SCRIPT_DIR}/../../.venv/bin"
+if [[ -x "${_VENV_BIN}/genai-perf" ]]; then
+  export PATH="${_VENV_BIN}:${PATH}"
+  GENAI_PERF="${_VENV_BIN}/genai-perf"
+else
+  GENAI_PERF="genai-perf"
+fi
+
+result_dir=""
+model=""
+port=8000
+report_name="benchmark_report.csv"
+cmd=""                       # override launch command (empty = use resolved $GENAI_PERF binary)
+genai_perf_profile_args=()
+
+log() {
+  echo "[$(date '+%F %T') $(hostname)]: $*"
+}
+
+# Collect all flags after -- into genai_perf_profile_args.
+# Kept as a plain array (not associative) so bare boolean flags like --streaming
+# are preserved correctly without an eval round-trip.
+parse_genai_perf_args() {
+  genai_perf_profile_args=("$@")
+}
+
+# Parse context flags (before --); delegate everything after -- to
+# parse_genai_perf_args. Mirrors the process_args / parse_genai_perf_args
+# split in ai_dynamo's genai_perf.sh.
+process_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --result-dir)  result_dir="$2";  shift 2 ;;
+      --model)       model="$2";       shift 2 ;;
+      --port)        port="$2";        shift 2 ;;
+      --report-name) report_name="$2"; shift 2 ;;
+      --cmd)         cmd="$2";         shift 2 ;;
+      --)            shift; parse_genai_perf_args "$@"; break ;;
+      --*)           echo "[$(date '+%F %T') $(hostname)]: WARNING: ignoring unknown context flag: $1" >&2; shift 1 ;;
+      *)             shift ;;
+    esac
+  done
+
+  log "Parsed args:
+    result_dir:  $result_dir
+    model:       $model
+    port:        $port
+    report_name: $report_name
+    cmd:         ${cmd:-<default>}
+    profile_args: ${genai_perf_profile_args[*]:-}"
+}
+
+process_results() {
+  local artifact_dir="$result_dir/genai_perf_artifacts"
+  local csv_path
+  # genai-perf >=0.0.16 writes profile_export_genai_perf.csv inside a run-specific subdir;
+  # older versions write profile_genai_perf.csv directly in artifact_dir.
+  # Search recursively for either pattern.
+  csv_path=$(find "$artifact_dir" -name "*genai_perf*.csv" -print -quit 2>/dev/null || true)
+  if [[ -n "$csv_path" ]]; then
+    cp "$csv_path" "$result_dir/$report_name"
+    log "genai-perf report saved to $result_dir/$report_name"
+  else
+    log "ERROR: no *genai_perf*.csv found in $artifact_dir — genai-perf benchmark may not have completed"
+    exit 1
+  fi
+}
+
+main() {
+  process_args "$@"
+
+  if [[ -z "$result_dir" ]]; then
+    log "ERROR: --result-dir is required"; exit 1
+  fi
+  if [[ -z "$model" ]]; then
+    log "ERROR: --model is required"; exit 1
+  fi
+  # Build the launch command: use custom cmd if provided, else resolved $GENAI_PERF binary.
+  local -a run_cmd
+  if [[ -n "$cmd" ]]; then
+    read -ra run_cmd <<< "$cmd"
+  else
+    if [[ ! -x "$GENAI_PERF" ]] && ! command -v "$GENAI_PERF" > /dev/null 2>&1; then
+      log "ERROR: genai-perf binary not found or not executable: $GENAI_PERF"; exit 1
+    fi
+    run_cmd=("$GENAI_PERF" profile)
+  fi
+
+  local artifact_dir="$result_dir/genai_perf_artifacts"
+  log "Launching genai-perf (cmd=${run_cmd[*]}, model=$model, url=localhost:${port})"
+
+  "${run_cmd[@]}" \
+    --model        "$model" \
+    --url          "localhost:${port}" \
+    --artifact-dir "$artifact_dir" \
+    "${genai_perf_profile_args[@]}"
+
+  log "genai-perf run complete"
+  process_results
+}
+
+main "$@"
+exit 0

--- a/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
@@ -110,6 +110,7 @@ main() {
   local -a run_cmd
   if [[ -n "$cmd" ]]; then
     read -ra run_cmd <<< "$cmd"
+    run_cmd+=(profile)
   else
     if [[ ! -x "$GENAI_PERF" ]] && ! command -v "$GENAI_PERF" > /dev/null 2>&1; then
       log "ERROR: genai-perf binary not found or not executable: $GENAI_PERF"; exit 1

--- a/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES All rights reserved.
 #
 # genai_perf.sh — wrapper for genai-perf profile, mirroring aiperf.sh.
 #

--- a/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
@@ -41,6 +41,13 @@ log() {
   echo "[$(date '+%F %T') $(hostname)]: $*"
 }
 
+_require_value() {
+  local flag="$1" val="${2-}"
+  if [[ -z "$val" || "$val" == --* ]]; then
+    log "ERROR: $flag requires a value (got: '${val:-<empty>}')" >&2; exit 1
+  fi
+}
+
 # Collect all flags after -- into genai_perf_profile_args.
 # Kept as a plain array (not associative) so bare boolean flags like --streaming
 # are preserved correctly without an eval round-trip.
@@ -54,11 +61,11 @@ parse_genai_perf_args() {
 process_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --result-dir)  result_dir="$2";  shift 2 ;;
-      --model)       model="$2";       shift 2 ;;
-      --port)        port="$2";        shift 2 ;;
-      --report-name) report_name="$2"; shift 2 ;;
-      --cmd)         cmd="$2";         shift 2 ;;
+      --result-dir)  _require_value "$1" "${2-}"; result_dir="$2";  shift 2 ;;
+      --model)       _require_value "$1" "${2-}"; model="$2";       shift 2 ;;
+      --port)        _require_value "$1" "${2-}"; port="$2";        shift 2 ;;
+      --report-name) _require_value "$1" "${2-}"; report_name="$2"; shift 2 ;;
+      --cmd)         _require_value "$1" "${2-}"; cmd="$2";         shift 2 ;;
       --)            shift; parse_genai_perf_args "$@"; break ;;
       --*)           echo "[$(date '+%F %T') $(hostname)]: WARNING: ignoring unknown context flag: $1" >&2; shift 1 ;;
       *)             shift ;;
@@ -111,6 +118,9 @@ main() {
   fi
 
   local artifact_dir="$result_dir/genai_perf_artifacts"
+  # Remove stale artifacts from any previous run so process_results only
+  # finds CSV files produced by this invocation.
+  rm -rf "$artifact_dir"
   log "Launching genai-perf (cmd=${run_cmd[*]}, model=$model, url=localhost:${port})"
 
   "${run_cmd[@]}" \

--- a/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
+++ b/src/cloudai/workloads/dynamo_mocker/genai_perf.sh
@@ -63,7 +63,12 @@ process_args() {
     case "$1" in
       --result-dir)  _require_value "$1" "${2-}"; result_dir="$2";  shift 2 ;;
       --model)       _require_value "$1" "${2-}"; model="$2";       shift 2 ;;
-      --port)        _require_value "$1" "${2-}"; port="$2";        shift 2 ;;
+      --port)
+        _require_value "$1" "${2-}"
+        if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          log "ERROR: --port must be numeric (got: '$2')" >&2; exit 1
+        fi
+        port="$2"; shift 2 ;;
       --report-name) _require_value "$1" "${2-}"; report_name="$2"; shift 2 ;;
       --cmd)         _require_value "$1" "${2-}"; cmd="$2";         shift 2 ;;
       --)            shift; parse_genai_perf_args "$@"; break ;;

--- a/src/cloudai/workloads/dynamo_mocker/report_generation_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/report_generation_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/dynamo_mocker/report_generation_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/report_generation_strategy.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from cloudai.workloads.ai_dynamo.report_generation_strategy import AIDynamoReportGenerationStrategy
+
+from .dynamo_mocker import DynamoMockerTestDefinition
+
+
+class DynamoMockerReportGenerationStrategy(AIDynamoReportGenerationStrategy):
+    """
+    Generate metrics from Dynamo Mocker benchmark output (benchmark_report.csv).
+
+    Inherits genai_perf CSV parsing from AIDynamoReportGenerationStrategy.
+    The CSV is written by genai_perf.sh with columns: Metric, avg, min, max, p99, ...
+
+    Metric names to use in agent_metrics / get_metric():
+      - "Time To First Token (ms)"           — TTFT average
+      - "Inter Token Latency (ms)"           — TPOT / ITL average
+      - "Output Token Throughput (tokens/sec)"
+      - "Request Throughput (per sec)"
+      - "Output tokens per second per gpu"   — added by genai_perf.sh
+      Use "genai_perf:<metric name>:<column>" for non-avg columns, e.g.
+      "genai_perf:Time To First Token (ms):p99"
+    """
+
+    def can_handle_directory(self) -> bool:
+        return (
+            isinstance(self.test_run.test, DynamoMockerTestDefinition)
+            and (self.test_run.output_path / "benchmark_report.csv").exists()
+        )

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -37,10 +37,6 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
     parameters and redirects stdout/stderr to the output directory.
     """
 
-    _script_path: Optional[Path] = None
-    _script_args: Optional[List[str]] = None
-    _wrapper_path: Optional[Path] = None
-
     @staticmethod
     def _extra_flags(model_extra: Optional[dict], prefix: str) -> List[str]:
         """
@@ -165,41 +161,51 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
         output_path = self.test_run.output_path
         output_path.mkdir(parents=True, exist_ok=True)
 
+        if tdef.python_environment.venv_path is None:
+            raise RuntimeError("Unexpected state: python environment is not installed yet")
         python_exec = tdef.python_environment.python_path(self.system.install_path)
 
-        self._script_path = _SCRIPT_DIR / "dynamo_mocker.sh"
-        self._script_args = self._build_script_args(args, output_path, python_exec)
-        self._wrapper_path = output_path / "dynamo_mocker_run.sh"
+        script_path = _SCRIPT_DIR / "dynamo_mocker.sh"
+        script_args = self._build_script_args(args, output_path, python_exec)
+        wrapper_path = output_path / "dynamo_mocker_run.sh"
 
         # Wrapper script: redirects stdout/stderr for cloudai log capture
         stdout_file = output_path / "stdout.txt"
         stderr_file = output_path / "stderr.txt"
-        quoted_args = " ".join(shlex.quote(a) for a in self._script_args)
+        quoted_args = " ".join(shlex.quote(a) for a in script_args)
         wrapper_lines = [
             "#!/usr/bin/env bash",
             (
-                f"bash {shlex.quote(str(self._script_path))} {quoted_args}"
+                f"bash {shlex.quote(str(script_path))} {quoted_args}"
                 f" > {shlex.quote(str(stdout_file))} 2> {shlex.quote(str(stderr_file))}"
             ),
         ]
-        self._wrapper_path.write_text("\n".join(wrapper_lines), encoding="utf-8")
-        self._wrapper_path.chmod(self._wrapper_path.stat().st_mode | stat.S_IXUSR)
+        wrapper_path.write_text("\n".join(wrapper_lines), encoding="utf-8")
+        wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IXUSR)
 
         self.store_test_run()
 
-        return f'bash "{self._wrapper_path}"'
+        return f'bash "{wrapper_path}"'
 
     def store_test_run(self) -> None:
         """Persist TestRunDetails to the output directory for inspection."""
-        assert self._script_path is not None and self._script_args is not None and self._wrapper_path is not None, (
-            "store_test_run() must be called after gen_exec_command()"
-        )
+        tdef = cast(DynamoMockerTestDefinition, self.test_run.test)
+        args: DynamoMockerCmdArgs = tdef.cmd_args
         output_path = self.test_run.output_path
         output_path.mkdir(parents=True, exist_ok=True)
+
+        if tdef.python_environment.venv_path is None:
+            raise RuntimeError("Unexpected state: python environment is not installed yet")
+        python_exec = tdef.python_environment.python_path(self.system.install_path)
+
+        script_path = _SCRIPT_DIR / "dynamo_mocker.sh"
+        script_args = self._build_script_args(args, output_path, python_exec)
+        wrapper_path = output_path / "dynamo_mocker_run.sh"
+
         test_cmd = (
-            "bash " + shlex.quote(str(self._script_path)) + " " + " ".join(shlex.quote(a) for a in self._script_args)
+            "bash " + shlex.quote(str(script_path)) + " " + " ".join(shlex.quote(a) for a in script_args)
         )
-        full_cmd = f'bash "{self._wrapper_path}"'
+        full_cmd = f'bash "{wrapper_path}"'
         dump_path = output_path / self.TEST_RUN_DUMP_FILE_NAME
         trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)
         with dump_path.open("w", encoding="utf-8") as f:

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -202,9 +202,7 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
         script_args = self._build_script_args(args, output_path, python_exec)
         wrapper_path = output_path / "dynamo_mocker_run.sh"
 
-        test_cmd = (
-            "bash " + shlex.quote(str(script_path)) + " " + " ".join(shlex.quote(a) for a in script_args)
-        )
+        test_cmd = "bash " + shlex.quote(str(script_path)) + " " + " ".join(shlex.quote(a) for a in script_args)
         full_cmd = f'bash "{wrapper_path}"'
         dump_path = output_path / self.TEST_RUN_DUMP_FILE_NAME
         trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -196,8 +196,8 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
         )
         output_path = self.test_run.output_path
         output_path.mkdir(parents=True, exist_ok=True)
-        test_cmd = "bash " + shlex.quote(str(self._script_path)) + " " + " ".join(
-            shlex.quote(a) for a in self._script_args
+        test_cmd = (
+            "bash " + shlex.quote(str(self._script_path)) + " " + " ".join(shlex.quote(a) for a in self._script_args)
         )
         full_cmd = f'bash "{self._wrapper_path}"'
         dump_path = output_path / self.TEST_RUN_DUMP_FILE_NAME

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -196,7 +196,9 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
         )
         output_path = self.test_run.output_path
         output_path.mkdir(parents=True, exist_ok=True)
-        test_cmd = "bash " + str(self._script_path) + " " + " ".join(f'"{a}"' for a in self._script_args)
+        test_cmd = "bash " + shlex.quote(str(self._script_path)) + " " + " ".join(
+            shlex.quote(a) for a in self._script_args
+        )
         full_cmd = f'bash "{self._wrapper_path}"'
         dump_path = output_path / self.TEST_RUN_DUMP_FILE_NAME
         trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -175,7 +175,10 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
         quoted_args = " ".join(shlex.quote(a) for a in self._script_args)
         wrapper_lines = [
             "#!/usr/bin/env bash",
-            f"bash {self._script_path} {quoted_args} > {stdout_file} 2> {stderr_file}",
+            (
+                f"bash {shlex.quote(str(self._script_path))} {quoted_args}"
+                f" > {shlex.quote(str(stdout_file))} 2> {shlex.quote(str(stderr_file))}"
+            ),
         ]
         self._wrapper_path.write_text("\n".join(wrapper_lines), encoding="utf-8")
         self._wrapper_path.chmod(self._wrapper_path.stat().st_mode | stat.S_IXUSR)

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -163,7 +163,7 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
 
         if tdef.python_environment.venv_path is None:
             raise RuntimeError("Unexpected state: python environment is not installed yet")
-        python_exec = tdef.python_environment.python_path(self.system.install_path)
+        python_exec = tdef.python_environment.venv_path / "bin" / "python"
 
         script_path = _SCRIPT_DIR / "dynamo_mocker.sh"
         script_args = self._build_script_args(args, output_path, python_exec)
@@ -196,7 +196,7 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
 
         if tdef.python_environment.venv_path is None:
             raise RuntimeError("Unexpected state: python environment is not installed yet")
-        python_exec = tdef.python_environment.python_path(self.system.install_path)
+        python_exec = tdef.python_environment.venv_path / "bin" / "python"
 
         script_path = _SCRIPT_DIR / "dynamo_mocker.sh"
         script_args = self._build_script_args(args, output_path, python_exec)

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -122,6 +122,8 @@ class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
             str(result_dir),
             "--model-path",
             args.model_path,
+            "--nats-cmd",
+            args.nats_cmd,
             "--speedup-ratio",
             str(e.speedup_ratio),
             "--block-size",

--- a/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/dynamo_mocker/standalone_command_gen_strategy.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shlex
+import stat
+from pathlib import Path
+from typing import List, Optional, cast
+
+import toml
+
+from cloudai.core import CommandGenStrategy
+from cloudai.models.scenario import TestRunDetails
+
+from .dynamo_mocker import DynamoMockerCmdArgs, DynamoMockerTestDefinition
+
+_SCRIPT_DIR = Path(__file__).parent
+
+
+class DynamoMockerStandaloneCommandGenStrategy(CommandGenStrategy):
+    """
+    Command generation strategy for DynamoMocker on StandaloneSystem.
+
+    Builds the command that invokes dynamo_mocker.sh with all configured
+    parameters and redirects stdout/stderr to the output directory.
+    """
+
+    _script_path: Optional[Path] = None
+    _script_args: Optional[List[str]] = None
+    _wrapper_path: Optional[Path] = None
+
+    @staticmethod
+    def _extra_flags(model_extra: Optional[dict], prefix: str) -> List[str]:
+        """
+        Convert a model_extra dict to flat --<prefix>-<key> value pairs.
+
+        Python booleans are lowercased (True → "true") so the bash boolean
+        check [[ "$val" == "true" ]] correctly converts them to bare flags.
+        """
+        result: List[str] = []
+        for key, val in (model_extra or {}).items():
+            str_val = str(val).lower() if isinstance(val, bool) else str(val)
+            result += [f"--{prefix}-{key.replace('_', '-')}", str_val]
+        return result
+
+    def _worker_flags(self, args: DynamoMockerCmdArgs) -> List[str]:
+        """Return disaggregation-mode-specific flags for the worker section."""
+        w = args.worker
+        if w.disaggregation_mode == "none":
+            flags: List[str] = ["--num-workers", str(w.num_workers)]
+        else:
+            # prefill_decode: per-role instance counts, commands, KV bandwidth, init regex
+            flags = [
+                "--prefill-num-nodes",
+                str(w.prefill_worker.num_nodes),
+                "--decode-num-nodes",
+                str(w.decode_worker.num_nodes),
+                "--kv-transfer-bandwidth",
+                str(args.engine.kv_transfer_bandwidth),
+                "--prefill-initialized-regex",
+                w.prefill_worker.worker_initialized_regex,
+                "--decode-initialized-regex",
+                w.decode_worker.worker_initialized_regex,
+            ]
+            if w.prefill_worker.cmd:
+                flags += ["--prefill-cmd", w.prefill_worker.cmd]
+            if w.decode_worker.cmd:
+                flags += ["--decode-cmd", w.decode_worker.cmd]
+
+        # Per-worker instance args and extra_args are emitted regardless of mode.
+        flags += self._extra_flags(w.prefill_worker.args.model_extra, "prefill-args")
+        if w.prefill_worker.extra_args:
+            flags += ["--prefill-extra-args", w.prefill_worker.extra_args]
+        flags += self._extra_flags(w.decode_worker.args.model_extra, "decode-args")
+        if w.decode_worker.extra_args:
+            flags += ["--decode-extra-args", w.decode_worker.extra_args]
+        return flags
+
+    def _benchmark_flags(self, args: DynamoMockerCmdArgs) -> List[str]:
+        """
+        Return benchmark-tool cmd, extra_args, and passthrough flags.
+
+        cmd/extra_args are named fields (not in model_extra) so they are
+        emitted explicitly before the model_extra wildcard loop.
+        """
+        if args.benchmark_tool == "aiperf":
+            bench, prefix = args.aiperf, "aiperf"
+        else:
+            bench, prefix = args.genai_perf, "genai-perf"
+
+        flags: List[str] = []
+        if bench.cmd:
+            flags += [f"--{prefix}-cmd", bench.cmd]
+        if bench.extra_args:
+            flags += [f"--{prefix}-extra-args", bench.extra_args]
+        flags += self._extra_flags(bench.model_extra, prefix)
+        return flags
+
+    def _build_script_args(self, args: DynamoMockerCmdArgs, result_dir: Path, python_exec: Path) -> List[str]:
+        """Return the CLI arg list to pass to dynamo_mocker.sh."""
+        e = args.engine
+        w = args.worker
+        f = args.frontend
+        bench = args.aiperf if args.benchmark_tool == "aiperf" else args.genai_perf
+
+        cli_args = [
+            "--venv-python",
+            str(python_exec),
+            "--result-dir",
+            str(result_dir),
+            "--model-path",
+            args.model_path,
+            "--speedup-ratio",
+            str(e.speedup_ratio),
+            "--block-size",
+            str(e.block_size),
+            "--num-gpu-blocks-override",
+            str(e.num_gpu_blocks_override),
+            "--enable-prefix-caching",
+            str(e.enable_prefix_caching).lower(),
+            "--http-port",
+            str(f.http_port),
+            "--router-mode",
+            f.router_mode,
+            "--disaggregation-mode",
+            w.disaggregation_mode,
+            "--benchmark-tool",
+            args.benchmark_tool,
+            "--input-tokens",
+            str(bench.input_tokens),
+            "--output-tokens",
+            str(bench.output_tokens),
+            "--request-count",
+            str(bench.request_count),
+            "--replay-concurrency",
+            str(bench.replay_concurrency),
+            "--replay-mode",
+            bench.replay_mode,
+        ]
+        cli_args += self._worker_flags(args)
+        # Forward extras: engine → --engine-*, worker → --mocker-*, frontend → --frontend-*
+        cli_args += self._extra_flags(e.model_extra, "engine")
+        cli_args += self._extra_flags(w.model_extra, "mocker")
+        cli_args += self._extra_flags(f.model_extra, "frontend")
+        cli_args += self._benchmark_flags(args)
+        return cli_args
+
+    def gen_exec_command(self) -> str:
+        tdef = cast(DynamoMockerTestDefinition, self.test_run.test)
+        args: DynamoMockerCmdArgs = tdef.cmd_args
+        output_path = self.test_run.output_path
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        python_exec = tdef.python_environment.python_path(self.system.install_path)
+
+        self._script_path = _SCRIPT_DIR / "dynamo_mocker.sh"
+        self._script_args = self._build_script_args(args, output_path, python_exec)
+        self._wrapper_path = output_path / "dynamo_mocker_run.sh"
+
+        # Wrapper script: redirects stdout/stderr for cloudai log capture
+        stdout_file = output_path / "stdout.txt"
+        stderr_file = output_path / "stderr.txt"
+        quoted_args = " ".join(shlex.quote(a) for a in self._script_args)
+        wrapper_lines = [
+            "#!/usr/bin/env bash",
+            f"bash {self._script_path} {quoted_args} > {stdout_file} 2> {stderr_file}",
+        ]
+        self._wrapper_path.write_text("\n".join(wrapper_lines), encoding="utf-8")
+        self._wrapper_path.chmod(self._wrapper_path.stat().st_mode | stat.S_IXUSR)
+
+        self.store_test_run()
+
+        return f'bash "{self._wrapper_path}"'
+
+    def store_test_run(self) -> None:
+        """Persist TestRunDetails to the output directory for inspection."""
+        assert self._script_path is not None and self._script_args is not None and self._wrapper_path is not None, (
+            "store_test_run() must be called after gen_exec_command()"
+        )
+        output_path = self.test_run.output_path
+        output_path.mkdir(parents=True, exist_ok=True)
+        test_cmd = "bash " + str(self._script_path) + " " + " ".join(f'"{a}"' for a in self._script_args)
+        full_cmd = f'bash "{self._wrapper_path}"'
+        dump_path = output_path / self.TEST_RUN_DUMP_FILE_NAME
+        trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)
+        with dump_path.open("w", encoding="utf-8") as f:
+            toml.dump(trd.model_dump(), f)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -42,6 +42,10 @@ from cloudai.workloads.deepep import (
     DeepEPSlurmCommandGenStrategy,
     DeepEPTestDefinition,
 )
+from cloudai.workloads.dynamo_mocker import (
+    DynamoMockerStandaloneCommandGenStrategy,
+    DynamoMockerTestDefinition,
+)
 from cloudai.workloads.jax_toolbox import (
     GPTTestDefinition,
     GrokTestDefinition,
@@ -143,6 +147,7 @@ CMD_GEN_STRATEGIES = {
     (SlurmSystem, MegatronBridgeTestDefinition): MegatronBridgeSlurmCommandGenStrategy,
     (StandaloneSystem, SleepTestDefinition): SleepStandaloneCommandGenStrategy,
     (StandaloneSystem, AiconfiguratorTestDefinition): AiconfiguratorStandaloneCommandGenStrategy,
+    (StandaloneSystem, DynamoMockerTestDefinition): DynamoMockerStandaloneCommandGenStrategy,
     (LSFSystem, SleepTestDefinition): SleepLSFCommandGenStrategy,
     (SlurmSystem, TritonInferenceTestDefinition): TritonInferenceSlurmCommandGenStrategy,
     (SlurmSystem, NIXLBenchTestDefinition): NIXLBenchSlurmCommandGenStrategy,
@@ -227,7 +232,7 @@ def test_installers():
 
 def test_definitions():
     test_defs = Registry().test_definitions_map
-    assert len(test_defs) == 25
+    assert len(test_defs) == 26
     for tdef in [
         ("UCCTest", UCCTestDefinition),
         ("DDLBTest", DDLBTestDefinition),
@@ -254,6 +259,7 @@ def test_definitions():
         ("OSUBench", OSUBenchTestDefinition),
         ("sglang", SglangTestDefinition),
         ("vllm", VllmTestDefinition),
+        ("DynamoMocker", DynamoMockerTestDefinition),
     ]:
         assert test_defs[tdef[0]] == tdef[1]
 

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -38,6 +38,7 @@ from cloudai.models.scenario import TestRunModel, TestScenarioModel
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.test_scenario_parser import calculate_total_time_limit, get_reporters
 from cloudai.workloads.ai_dynamo import AIDynamoReportGenerationStrategy, AIDynamoTestDefinition
+from cloudai.workloads.dynamo_mocker import DynamoMockerReportGenerationStrategy, DynamoMockerTestDefinition
 from cloudai.workloads.aiconfig import AiconfiguratorReportGenerationStrategy, AiconfiguratorTestDefinition
 from cloudai.workloads.chakra_replay import ChakraReplayReportGenerationStrategy, ChakraReplayTestDefinition
 from cloudai.workloads.deepep import (
@@ -649,6 +650,7 @@ class TestReporters:
             (OSUBenchTestDefinition, {OSUBenchReportGenerationStrategy}),
             (SglangTestDefinition, {SGLangBenchReportGenerationStrategy}),
             (AIDynamoTestDefinition, {AIDynamoReportGenerationStrategy}),
+            (DynamoMockerTestDefinition, {DynamoMockerReportGenerationStrategy}),
             (NixlPerftestTestDefinition, {NIXLKVBenchDummyReport}),
             (AiconfiguratorTestDefinition, {AiconfiguratorReportGenerationStrategy}),
         ],

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -624,7 +624,7 @@ class TestReporters:
         assert len(reporters) == 0
 
     def test_default_reporters_size(self):
-        assert len(Registry().reports_map) == 20
+        assert len(Registry().reports_map) == 21
 
     @pytest.mark.parametrize(
         "tdef,expected_reporters",

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -38,13 +38,13 @@ from cloudai.models.scenario import TestRunModel, TestScenarioModel
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.test_scenario_parser import calculate_total_time_limit, get_reporters
 from cloudai.workloads.ai_dynamo import AIDynamoReportGenerationStrategy, AIDynamoTestDefinition
-from cloudai.workloads.dynamo_mocker import DynamoMockerReportGenerationStrategy, DynamoMockerTestDefinition
 from cloudai.workloads.aiconfig import AiconfiguratorReportGenerationStrategy, AiconfiguratorTestDefinition
 from cloudai.workloads.chakra_replay import ChakraReplayReportGenerationStrategy, ChakraReplayTestDefinition
 from cloudai.workloads.deepep import (
     DeepEPReportGenerationStrategy,
     DeepEPTestDefinition,
 )
+from cloudai.workloads.dynamo_mocker import DynamoMockerReportGenerationStrategy, DynamoMockerTestDefinition
 from cloudai.workloads.jax_toolbox import (
     GPTTestDefinition,
     GrokTestDefinition,

--- a/tests/workloads/dynamo_mocker/__init__.py
+++ b/tests/workloads/dynamo_mocker/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/workloads/dynamo_mocker/__init__.py
+++ b/tests/workloads/dynamo_mocker/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
+++ b/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
+++ b/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
@@ -60,6 +60,8 @@ def _make_strategy(
         test_template_name="DynamoMockerTest",
         cmd_args=cmd_args,
     )
+    # Simulate post-install state: venv_path is set on the cached instance.
+    tdef.python_environment.venv_path = system.install_path / tdef.python_environment.venv_name
     tr = TestRun(
         name="test-run",
         test=tdef,

--- a/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
+++ b/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
@@ -1,0 +1,616 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from cloudai.core import TestRun
+from cloudai.systems.standalone import StandaloneSystem
+from cloudai.workloads.dynamo_mocker.dynamo_mocker import (
+    DynamoMockerCmdArgs,
+    DynamoMockerTestDefinition,
+    MockerAIPerfArgs,
+    MockerEngineArgs,
+    MockerFrontendArgs,
+    MockerGenAIPerfArgs,
+    MockerWorkerConfig,
+    MockerWorkerInstance,
+    MockerWorkerInstanceArgs,
+)
+from cloudai.workloads.dynamo_mocker.standalone_command_gen_strategy import (
+    DynamoMockerStandaloneCommandGenStrategy,
+)
+
+_VENV_PYTHON = Path("/venv/bin/python")
+
+
+@pytest.fixture
+def standalone_system(tmp_path: Path) -> StandaloneSystem:
+    return StandaloneSystem(
+        name="test_system",
+        install_path=tmp_path / "install",
+        output_path=tmp_path / "output",
+    )
+
+
+def _make_strategy(
+    system: StandaloneSystem,
+    tmp_path: Path,
+    cmd_args: DynamoMockerCmdArgs | None = None,
+) -> DynamoMockerStandaloneCommandGenStrategy:
+    if cmd_args is None:
+        cmd_args = DynamoMockerCmdArgs()
+    tdef = DynamoMockerTestDefinition(
+        name="dynamo_mocker",
+        description="test",
+        test_template_name="DynamoMockerTest",
+        cmd_args=cmd_args,
+    )
+    tr = TestRun(
+        name="test-run",
+        test=tdef,
+        num_nodes=1,
+        nodes=[],
+        output_path=tmp_path / "output" / "test-run",
+    )
+    return DynamoMockerStandaloneCommandGenStrategy(system=system, test_run=tr)
+
+
+class TestBuildScriptArgsCombined:
+    """_build_script_args in combined (disaggregation_mode=none) mode."""
+
+    def test_contains_required_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--model-path" in args
+        assert "--disaggregation-mode" in args
+        assert "none" in args
+        assert "--num-workers" in args
+
+    def test_no_disaggregated_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--num-prefill-workers" not in args
+        assert "--num-decode-workers" not in args
+        assert "--kv-transfer-bandwidth" not in args
+
+    def test_venv_python_is_first(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        result_dir = tmp_path / "result"
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, result_dir, _VENV_PYTHON)
+        assert args[0] == "--venv-python"
+        assert args[1] == str(_VENV_PYTHON)
+        assert "--result-dir" in args
+        assert args[args.index("--result-dir") + 1] == str(result_dir)
+
+
+class TestBuildScriptArgsDisaggregated:
+    """_build_script_args in disaggregated (disaggregation_mode=prefill_decode) mode."""
+
+    def test_contains_disaggregated_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(worker=MockerWorkerConfig(disaggregation_mode="prefill_decode"))
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--disaggregation-mode" in args
+        assert "prefill_decode" in args
+        assert "--prefill-num-nodes" in args
+        assert "--decode-num-nodes" in args
+        assert "--kv-transfer-bandwidth" in args
+        assert "--prefill-initialized-regex" in args
+        assert "--decode-initialized-regex" in args
+
+    def test_no_combined_flag(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(worker=MockerWorkerConfig(disaggregation_mode="prefill_decode"))
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        # --num-workers is combined-mode only
+        assert "--num-workers" not in args
+
+
+class TestBuildScriptArgsBenchmarkTool:
+    """benchmark_tool selection routes to the right config section."""
+
+    def test_default_is_genai_perf(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--benchmark-tool" in args
+        idx = args.index("--benchmark-tool")
+        assert args[idx + 1] == "genai_perf"
+
+    def test_aiperf_sets_benchmark_tool_flag(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(benchmark_tool="aiperf")
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        idx = args.index("--benchmark-tool")
+        assert args[idx + 1] == "aiperf"
+
+    def test_aiperf_uses_aiperf_section_values(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="aiperf",
+            aiperf=MockerAIPerfArgs(input_tokens=1234, output_tokens=56, request_count=99),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert args[args.index("--input-tokens") + 1] == "1234"
+        assert args[args.index("--output-tokens") + 1] == "56"
+        assert args[args.index("--request-count") + 1] == "99"
+
+    def test_genai_perf_uses_genai_perf_section_values(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="genai_perf",
+            genai_perf=MockerGenAIPerfArgs(input_tokens=7777, output_tokens=88, request_count=11),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert args[args.index("--input-tokens") + 1] == "7777"
+        assert args[args.index("--output-tokens") + 1] == "88"
+        assert args[args.index("--request-count") + 1] == "11"
+
+    def test_aiperf_extra_fields_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="aiperf",
+            aiperf=MockerAIPerfArgs.model_validate({"arrival_pattern": "poisson", "benchmark_duration": "120"}),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--aiperf-arrival-pattern" in args
+        assert args[args.index("--aiperf-arrival-pattern") + 1] == "poisson"
+        assert "--aiperf-benchmark-duration" in args
+        assert args[args.index("--aiperf-benchmark-duration") + 1] == "120"
+
+    def test_genai_perf_extra_fields_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="genai_perf",
+            genai_perf=MockerGenAIPerfArgs.model_validate({"streaming": "true", "endpoint_type": "chat_completions"}),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--genai-perf-streaming" in args
+        assert args[args.index("--genai-perf-streaming") + 1] == "true"
+        assert "--genai-perf-endpoint-type" in args
+        assert args[args.index("--genai-perf-endpoint-type") + 1] == "chat_completions"
+
+    def test_genai_perf_no_aiperf_extra_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert not any(a.startswith("--aiperf-") for a in args)
+
+    def test_aiperf_no_genai_perf_extra_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(benchmark_tool="aiperf")
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert not any(a.startswith("--genai-perf-") for a in args)
+
+    def test_bool_extra_field_lowercased_aiperf(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Python bool True must be forwarded as lowercase 'true' so bash [[ '$val' == 'true' ]] works."""
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="aiperf",
+            aiperf=MockerAIPerfArgs.model_validate({"some_flag": True}),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--aiperf-some-flag" in args
+        assert args[args.index("--aiperf-some-flag") + 1] == "true"
+
+    def test_bool_extra_field_lowercased_genai_perf(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Python bool True must be forwarded as lowercase 'true' so bash [[ '$val' == 'true' ]] works."""
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="genai_perf",
+            genai_perf=MockerGenAIPerfArgs.model_validate({"output_tokens_mean_deterministic": True}),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--genai-perf-output-tokens-mean-deterministic" in args
+        assert args[args.index("--genai-perf-output-tokens-mean-deterministic") + 1] == "true"
+
+    def test_aiperf_cmd_forwarded_when_set(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="aiperf",
+            aiperf=MockerAIPerfArgs(cmd="aiperf profile"),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--aiperf-cmd" in args
+        assert args[args.index("--aiperf-cmd") + 1] == "aiperf profile"
+
+    def test_aiperf_cmd_not_emitted_when_empty(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Empty cmd (default) means use shell default — no --aiperf-cmd emitted."""
+        cmd_args = DynamoMockerCmdArgs(benchmark_tool="aiperf")
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--aiperf-cmd" not in args
+
+    def test_aiperf_extra_args_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="aiperf",
+            aiperf=MockerAIPerfArgs(extra_args="--streaming --verbose"),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--aiperf-extra-args" in args
+        assert args[args.index("--aiperf-extra-args") + 1] == "--streaming --verbose"
+
+    def test_aiperf_extra_args_not_emitted_when_none(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """extra_args=None (default) must not emit --aiperf-extra-args."""
+        cmd_args = DynamoMockerCmdArgs(benchmark_tool="aiperf")
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--aiperf-extra-args" not in args
+
+    def test_genai_perf_cmd_forwarded_when_set(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="genai_perf",
+            genai_perf=MockerGenAIPerfArgs(cmd="genai-perf profile"),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--genai-perf-cmd" in args
+        assert args[args.index("--genai-perf-cmd") + 1] == "genai-perf profile"
+
+    def test_genai_perf_cmd_not_emitted_when_empty(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Empty cmd (default) means use shell default — no --genai-perf-cmd emitted."""
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--genai-perf-cmd" not in args
+
+    def test_genai_perf_extra_args_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            benchmark_tool="genai_perf",
+            genai_perf=MockerGenAIPerfArgs(extra_args="--streaming --verbose -- -v --async"),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--genai-perf-extra-args" in args
+        assert args[args.index("--genai-perf-extra-args") + 1] == "--streaming --verbose -- -v --async"
+
+    def test_genai_perf_extra_args_not_emitted_when_none(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """extra_args=None (default) must not emit --genai-perf-extra-args."""
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--genai-perf-extra-args" not in args
+
+
+class TestGenExecCommand:
+    """gen_exec_command writes a wrapper script and returns a bash invocation."""
+
+    def test_returns_bash_invocation(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        cmd = strategy.gen_exec_command()
+        assert cmd.startswith("bash ")
+        assert "dynamo_mocker_run.sh" in cmd
+
+    def test_wrapper_script_created(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        strategy.gen_exec_command()
+        wrapper = strategy.test_run.output_path / "dynamo_mocker_run.sh"
+        assert wrapper.exists()
+
+    def test_wrapper_invokes_dynamo_mocker_sh(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        strategy.gen_exec_command()
+        content = (strategy.test_run.output_path / "dynamo_mocker_run.sh").read_text()
+        assert "dynamo_mocker.sh" in content
+
+    def test_wrapper_redirects_stdout_stderr(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        strategy.gen_exec_command()
+        content = (strategy.test_run.output_path / "dynamo_mocker_run.sh").read_text()
+        assert "stdout.txt" in content
+        assert "stderr.txt" in content
+        assert ">" in content
+
+
+class TestComponentExtraArgs:
+    """Extra-args passthrough for engine, worker (mocker), and frontend."""
+
+    def test_engine_extra_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(engine=MockerEngineArgs.model_validate({"extra_param": "42"}))
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--engine-extra-param" in args
+        assert args[args.index("--engine-extra-param") + 1] == "42"
+
+    def test_engine_extra_bool_lowercased(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(engine=MockerEngineArgs.model_validate({"experimental_flag": True}))
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--engine-experimental-flag" in args
+        assert args[args.index("--engine-experimental-flag") + 1] == "true"
+
+    def test_engine_no_extra_produces_no_engine_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert not any(a.startswith("--engine-") for a in args)
+
+    def test_worker_extra_uses_mocker_prefix(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Worker extras become --mocker-*, never --worker-* (avoids --worker-initialized-regex clash)."""
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig.model_validate({"disaggregation_mode": "none", "extra_topo_flag": "yes"})
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--mocker-extra-topo-flag" in args
+        assert args[args.index("--mocker-extra-topo-flag") + 1] == "yes"
+        assert not any(a.startswith("--worker-extra") for a in args)
+
+    def test_worker_extra_bool_lowercased(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig.model_validate({"disaggregation_mode": "none", "some_feature": True})
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--mocker-some-feature" in args
+        assert args[args.index("--mocker-some-feature") + 1] == "true"
+
+    def test_worker_no_extra_produces_no_mocker_extra_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert not any(a.startswith("--mocker-") for a in args)
+
+    def test_frontend_extra_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            frontend=MockerFrontendArgs.model_validate(
+                {"http_port": 8000, "router_mode": "round_robin", "grpc_port": "9000"}
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--frontend-grpc-port" in args
+        assert args[args.index("--frontend-grpc-port") + 1] == "9000"
+
+    def test_frontend_extra_bool_lowercased(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            frontend=MockerFrontendArgs.model_validate(
+                {"http_port": 8000, "router_mode": "round_robin", "enable_tls": True}
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--frontend-enable-tls" in args
+        assert args[args.index("--frontend-enable-tls") + 1] == "true"
+
+    def test_frontend_no_extra_produces_no_frontend_extra_flags(
+        self, standalone_system: StandaloneSystem, tmp_path: Path
+    ):
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert not any(a.startswith("--frontend-") for a in args)
+
+    def test_all_three_extras_simultaneously(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            engine=MockerEngineArgs.model_validate({"eng_opt": "1"}),
+            worker=MockerWorkerConfig.model_validate({"disaggregation_mode": "none", "wkr_opt": "2"}),
+            frontend=MockerFrontendArgs.model_validate(
+                {"http_port": 8000, "router_mode": "round_robin", "frt_opt": "3"}
+            ),
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--engine-eng-opt" in args
+        assert "--mocker-wkr-opt" in args
+        assert "--frontend-frt-opt" in args
+
+    def test_engine_extra_not_in_mocker_prefix(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(engine=MockerEngineArgs.model_validate({"shared_name": "v"}))
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--engine-shared-name" in args
+        assert "--mocker-shared-name" not in args
+
+
+class TestPrefillDecodeExtraArgs:
+    """Nested per-worker args and extra_args passthrough for prefill and decode mocker instances."""
+
+    def test_prefill_args_extra_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                prefill_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "10"})
+                ),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-args-max-num-seqs" in args
+        assert args[args.index("--prefill-args-max-num-seqs") + 1] == "10"
+
+    def test_decode_args_extra_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                decode_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "20"})
+                ),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--decode-args-max-num-seqs" in args
+        assert args[args.index("--decode-args-max-num-seqs") + 1] == "20"
+
+    def test_prefill_and_decode_different_values(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Prefill and decode can carry the same flag name with different values."""
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                prefill_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "10"})
+                ),
+                decode_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "20"})
+                ),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-args-max-num-seqs" in args
+        assert args[args.index("--prefill-args-max-num-seqs") + 1] == "10"
+        assert "--decode-args-max-num-seqs" in args
+        assert args[args.index("--decode-args-max-num-seqs") + 1] == "20"
+
+    def test_prefill_args_not_in_decode_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                prefill_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"prefill_only_flag": "x"})
+                ),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-args-prefill-only-flag" in args
+        assert "--decode-args-prefill-only-flag" not in args
+
+    def test_decode_args_not_in_prefill_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                decode_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"decode_only_flag": "y"})
+                ),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--decode-args-decode-only-flag" in args
+        assert "--prefill-args-decode-only-flag" not in args
+
+    def test_prefill_args_bool_lowercased(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                prefill_worker=MockerWorkerInstance(
+                    args=MockerWorkerInstanceArgs.model_validate({"enable_chunked_prefill": True})
+                ),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-args-enable-chunked-prefill" in args
+        assert args[args.index("--prefill-args-enable-chunked-prefill") + 1] == "true"
+
+    def test_no_prefill_decode_extras_by_default(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Combined mode (default) produces no --prefill-* or --decode-* flags."""
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert not any(a.startswith("--prefill-") for a in args)
+        assert not any(a.startswith("--decode-") for a in args)
+
+    def test_prefill_initialized_regex_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
+                prefill_worker=MockerWorkerInstance(worker_initialized_regex="prefill ready"),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-initialized-regex" in args
+        assert args[args.index("--prefill-initialized-regex") + 1] == "prefill ready"
+
+    def test_decode_initialized_regex_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
+                decode_worker=MockerWorkerInstance(worker_initialized_regex="decode ready"),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--decode-initialized-regex" in args
+        assert args[args.index("--decode-initialized-regex") + 1] == "decode ready"
+
+    def test_prefill_extra_args_raw_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                prefill_worker=MockerWorkerInstance(extra_args="--no-enable-expert-parallel"),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-extra-args" in args
+        assert args[args.index("--prefill-extra-args") + 1] == "--no-enable-expert-parallel"
+
+    def test_decode_extra_args_raw_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                decode_worker=MockerWorkerInstance(extra_args="--some-decode-flag"),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--decode-extra-args" in args
+        assert args[args.index("--decode-extra-args") + 1] == "--some-decode-flag"
+
+    def test_no_extra_args_if_none(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """When extra_args is None (default), --prefill-extra-args and --decode-extra-args are not emitted."""
+        strategy = _make_strategy(standalone_system, tmp_path)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-extra-args" not in args
+        assert "--decode-extra-args" not in args
+
+    def test_prefill_num_nodes_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
+                prefill_worker=MockerWorkerInstance(num_nodes=3),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-num-nodes" in args
+        assert args[args.index("--prefill-num-nodes") + 1] == "3"
+
+    def test_decode_num_nodes_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
+                decode_worker=MockerWorkerInstance(num_nodes=2),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--decode-num-nodes" in args
+        assert args[args.index("--decode-num-nodes") + 1] == "2"
+
+    def test_prefill_cmd_forwarded_when_set(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
+                prefill_worker=MockerWorkerInstance(cmd="python3 -m dynamo.mocker"),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-cmd" in args
+        assert args[args.index("--prefill-cmd") + 1] == "python3 -m dynamo.mocker"
+
+    def test_decode_cmd_forwarded_when_set(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        cmd_args = DynamoMockerCmdArgs(
+            worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
+                decode_worker=MockerWorkerInstance(cmd="python3 -m dynamo.mocker"),
+            )
+        )
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--decode-cmd" in args
+        assert args[args.index("--decode-cmd") + 1] == "python3 -m dynamo.mocker"
+
+    def test_cmd_not_emitted_when_empty(self, standalone_system: StandaloneSystem, tmp_path: Path):
+        """Empty cmd (default) means use shell default — no --prefill-cmd/--decode-cmd emitted."""
+        cmd_args = DynamoMockerCmdArgs(worker=MockerWorkerConfig(disaggregation_mode="prefill_decode"))
+        strategy = _make_strategy(standalone_system, tmp_path, cmd_args)
+        args = strategy._build_script_args(strategy.test_run.test.cmd_args, tmp_path / "result", _VENV_PYTHON)
+        assert "--prefill-cmd" not in args
+        assert "--decode-cmd" not in args

--- a/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
+++ b/tests/workloads/dynamo_mocker/test_command_gen_strategy_standalone.py
@@ -418,6 +418,7 @@ class TestPrefillDecodeExtraArgs:
     def test_prefill_args_extra_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 prefill_worker=MockerWorkerInstance(
                     args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "10"})
                 ),
@@ -431,6 +432,7 @@ class TestPrefillDecodeExtraArgs:
     def test_decode_args_extra_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 decode_worker=MockerWorkerInstance(
                     args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "20"})
                 ),
@@ -445,6 +447,7 @@ class TestPrefillDecodeExtraArgs:
         """Prefill and decode can carry the same flag name with different values."""
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 prefill_worker=MockerWorkerInstance(
                     args=MockerWorkerInstanceArgs.model_validate({"max_num_seqs": "10"})
                 ),
@@ -463,6 +466,7 @@ class TestPrefillDecodeExtraArgs:
     def test_prefill_args_not_in_decode_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 prefill_worker=MockerWorkerInstance(
                     args=MockerWorkerInstanceArgs.model_validate({"prefill_only_flag": "x"})
                 ),
@@ -476,6 +480,7 @@ class TestPrefillDecodeExtraArgs:
     def test_decode_args_not_in_prefill_flags(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 decode_worker=MockerWorkerInstance(
                     args=MockerWorkerInstanceArgs.model_validate({"decode_only_flag": "y"})
                 ),
@@ -489,6 +494,7 @@ class TestPrefillDecodeExtraArgs:
     def test_prefill_args_bool_lowercased(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 prefill_worker=MockerWorkerInstance(
                     args=MockerWorkerInstanceArgs.model_validate({"enable_chunked_prefill": True})
                 ),
@@ -533,6 +539,7 @@ class TestPrefillDecodeExtraArgs:
     def test_prefill_extra_args_raw_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 prefill_worker=MockerWorkerInstance(extra_args="--no-enable-expert-parallel"),
             )
         )
@@ -544,6 +551,7 @@ class TestPrefillDecodeExtraArgs:
     def test_decode_extra_args_raw_forwarded(self, standalone_system: StandaloneSystem, tmp_path: Path):
         cmd_args = DynamoMockerCmdArgs(
             worker=MockerWorkerConfig(
+                disaggregation_mode="prefill_decode",
                 decode_worker=MockerWorkerInstance(extra_args="--some-decode-flag"),
             )
         )


### PR DESCRIPTION
Adds the DynamoMocker workload to cloudai — a lightweight GPU-free LLM inference simulator using dynamo.mocker + dynamo.frontend, benchmarked with genai-perf or aiperf.

- Pydantic models for engine, worker, frontend, and benchmark config
- StandaloneCommandGenStrategy that invokes dynamo_mocker.sh via an isolated uv-managed venv (PythonEnvironment installable)
- ReportGenerationStrategy reusing AIDynamoReportGenerationStrategy for benchmark_report.csv parsing
- Shell scripts: dynamo_mocker.sh, genai_perf.sh, aiperf.sh
- Supports combined and disaggregated (prefill/decode) topologies
- Supports round_robin and kv_router frontend modes
- Staging configs under conf/experimental/dynamo_mocker/
- 55 unit tests covering all CLI arg paths and flag passthrough

## Summary
Provide a concise summary of the changes introduced by this pull request. Detail the purpose and scope of the changes, referencing any relevant issues or discussions. Explain how these changes address the problem or improve the project.

## Test Plan
In this section, describe the testing you have performed to verify the changes. Include:
- A clear description of the testing environment.
- The steps you followed to test the new features or bug fixes.
- Any specific commands used during testing, along with their outputs.
- A description of the results and observations from your testing.
This information is crucial for reviewers to understand how the changes have been validated.

## Additional Notes
Include any other notes or comments about the pull request here. This can include challenges faced, future considerations, or context that reviewers might find helpful.
