### PR TITLE
Standardize copyright headers on a single year range

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/cloudai/util/command_shell.py
+++ b/src/cloudai/util/command_shell.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024, 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_check_copyright_headers.py
+++ b/tests/test_check_copyright_headers.py
@@ -49,11 +49,16 @@ CURRENT_YEAR = datetime.now().year
 _REC_SEP = "\x1e"
 
 
-def _format_years_to_ranges(years: list[int]) -> str:
-    """Turn sorted unique years into a string with ranges for consecutive years.
+def _format_years_to_range(years: list[int]) -> str:
+    """Collapse unique years into a single copyright range.
 
-    E.g. [2024, 2026] -> "2024, 2026"
-         [2024, 2025, 2027] -> "2024-2025, 2027"
+    The earliest and latest touch years bound the range; any gap years in
+    between are absorbed, so the result is always a single year or a
+    continuous ``YYYY-YYYY`` range.
+
+    E.g. [2024]             -> "2024"
+         [2024, 2026]       -> "2024-2026"
+         [2024, 2025, 2027] -> "2024-2027"
     """
     if not years:
         raise ValueError(
@@ -61,36 +66,26 @@ def _format_years_to_ranges(years: list[int]) -> str:
             "current year"
         )
 
-    parts: list[str] = []
-    range_start = years[0]
-    range_end = years[0]
-    for y in years[1:]:
-        if y == range_end + 1:
-            range_end = y
-        else:
-            parts.append(f"{range_start}-{range_end}" if range_start != range_end else str(range_start))
-            range_start = y
-            range_end = y
-    parts.append(f"{range_start}-{range_end}" if range_start != range_end else str(range_start))
-    return ", ".join(parts)
+    lo, hi = min(years), max(years)
+    return str(lo) if lo == hi else f"{lo}-{hi}"
 
 
 @pytest.mark.parametrize(
     ("years_list", "expected"),
     (
-        ([2024, 2026], "2024, 2026"),
-        ([2024, 2025, 2027], "2024-2025, 2027"),
+        ([2024, 2026], "2024-2026"),
+        ([2024, 2025, 2027], "2024-2027"),
         ([2024], "2024"),
         ([2024, 2025, 2026], "2024-2026"),
     ),
 )
-def test_format_years_to_ranges(years_list: list[int], expected: str):
-    assert _format_years_to_ranges(years_list) == expected
+def test_format_years_to_range(years_list: list[int], expected: str):
+    assert _format_years_to_range(years_list) == expected
 
 
-def test_empty_format_years_to_ranges():
+def test_empty_format_years_to_range():
     with pytest.raises(ValueError):
-        _format_years_to_ranges([])
+        _format_years_to_range([])
 
 
 def run_git(cmd: list[str]) -> str:
@@ -157,7 +152,7 @@ def collect_years_same_file(path: Path) -> list[int]:
 
 
 def prepare_copyright_with_year(years: list[int]) -> str:
-    years_str = _format_years_to_ranges(years)
+    years_str = _format_years_to_range(years)
     after_year_str = "NVIDIA CORPORATION & AFFILIATES. All rights reserved."
     return f"# Copyright (c) {years_str} {after_year_str}"
 


### PR DESCRIPTION
## Summary

Two copyright headers were out of sync with their files' git history, and
the in-repo check rendered gap years in a comma form that the release
pipeline's header check can't parse. This brings everything onto a single
range form.

- `doc/Makefile`: touched in 2025 and 2026, header listed `2025` only -> `2025-2026`.
- `src/cloudai/util/command_shell.py`: touched in 2024 and 2026, header used the comma form `2024, 2026` -> `2024-2026`.
- `tests/test_check_copyright_headers.py`: `_format_years_to_range` now collapses a year set to a single earliest-latest range, absorbing gap years, so every header is a single year or a continuous `YYYY-YYYY` range.

## Test plan

- [x] `uv run --extra dev python -m pytest -vv -m ci_only tests/test_check_copyright_headers.py` -> 478 passed