### PR TITLE
chore(ai_dynamo): set aiperf as default benchmark in vllm and sglang …

### DIFF
--- a/conf/experimental/ai_dynamo/test/sglang.toml
+++ b/conf/experimental/ai_dynamo/test/sglang.toml
@@ -21,7 +21,7 @@ extra_container_mounts = ["/run/udev:/run/udev", "/tmp:/tmp"]
 
 [cmd_args]
 docker_image_url = "nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.9.0"
-workloads = "genai_perf.sh"
+workloads = "aiperf.sh"
 
   [cmd_args.dynamo]
   backend = "sglang"

--- a/conf/experimental/ai_dynamo/test/vllm.toml
+++ b/conf/experimental/ai_dynamo/test/vllm.toml
@@ -21,7 +21,7 @@ extra_container_mounts = ["/run/udev:/run/udev", "/tmp:/tmp"]
 
 [cmd_args]
 docker_image_url = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.1"
-workloads = "genai_perf.sh"
+workloads = "aiperf.sh"
 
   [cmd_args.dynamo]
   backend = "vllm"


### PR DESCRIPTION

## Summary
- Sets `workloads = "aiperf.sh"` as the default in both `vllm.toml` and `sglang.toml`                                                                                                     
- genai-perf remains available as opt-in                                                                                                                                                  
- Validated on EOS (H100) — single-node and multi-node runs both PASSED
## Test Plan
- Ran on EOS H100 with aiperf.sh — both test.disagg.single-node and test.disagg.multinode PASSED                                                                                      
- aiperf_report.csv generated correctly 