### PR TITLE
Map results dir into container at /cloudai_run_results for m-bridge t…

### DIFF
--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -279,6 +279,8 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
                 container_path = _installed_container_path()
 
         mounts: list[str] = [str(m).strip() for m in (tdef.extra_container_mounts or []) if str(m).strip()]
+        output_dir = self.test_run.output_path.absolute()
+        mounts.append(f"{output_dir}:{self.CONTAINER_MOUNT_OUTPUT}")
 
         # When the user sets mount_as on the Megatron-Bridge git repo, bind-mount the
         # installed clone into the container to override the image's built-in copy.


### PR DESCRIPTION
## Summary
In order to allow direction of nccl debug file to cloudai results directory in case of megatron bridge template, need to add mapping of results dir inside the container (as done in nemorun and megatronrun templates)

## Test Plan
I verified this fix to work with adding the below to test toml file:
"NCCL_DEBUG_FILE" = "/cloudai_run_results/nccl_debug_file.%h.%p.txt"