### PR TITLE
Handle OSError from git subprocess calls in GitRepo installable

### DIFF
--- a/src/cloudai/_core/installables/git_repo.py
+++ b/src/cloudai/_core/installables/git_repo.py
@@ -61,12 +61,15 @@ class GitRepo(Installable, BaseModel):
 
     def check_submodules_state(self, repo_path: Path) -> tuple[bool, str]:
         """Check if submodules state in the cloned repo matches self.init_submodules."""
-        result = subprocess.run(
-            ["git", "submodule", "status", "--recursive"],
-            cwd=str(repo_path),
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["git", "submodule", "status", "--recursive"],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+            )
+        except OSError as e:
+            return False, f"Failed to get submodule status: {e}"
         if result.returncode != 0:
             return False, f"Failed to get submodule status: {result.stderr}"
         output = [line for line in result.stdout.splitlines() if line.strip()]
@@ -92,9 +95,12 @@ class GitRepo(Installable, BaseModel):
             return False, submodules_are_ok_msg
 
         cmd = ["update", "--init", "--recursive"] if self.init_submodules else ["deinit", "--all", "--force"]
-        result = subprocess.run(["git", "submodule", *cmd], cwd=str(repo_path), capture_output=True, text=True)
+        action = "initialize" if self.init_submodules else "deinitialize"
+        try:
+            result = subprocess.run(["git", "submodule", *cmd], cwd=str(repo_path), capture_output=True, text=True)
+        except OSError as e:
+            return False, f"Failed to {action} submodules: {e}"
         if result.returncode != 0:
-            action = "initialize" if self.init_submodules else "deinitialize"
             return False, f"Failed to {action} submodules: {result.stderr}"
 
         return True, ""
@@ -182,14 +188,20 @@ class GitRepo(Installable, BaseModel):
         clone_cmd.extend([self.url, str(path)])
 
         logging.debug(f"Running git clone command: {' '.join(clone_cmd)}")
-        result = subprocess.run(clone_cmd, capture_output=True, text=True)
+        try:
+            result = subprocess.run(clone_cmd, capture_output=True, text=True)
+        except OSError as e:
+            return InstallStatusResult(False, f"Failed to clone repository: {e}")
         if result.returncode != 0:
             return InstallStatusResult(False, f"Failed to clone repository: {result.stderr}")
         return InstallStatusResult(True)
 
     def _checkout_commit(self, commit_hash: str, path: Path) -> InstallStatusResult:
         logging.debug(f"Checking out specific commit in {path}: {commit_hash}")
-        result = subprocess.run(["git", "checkout", commit_hash], cwd=str(path), capture_output=True, text=True)
+        try:
+            result = subprocess.run(["git", "checkout", commit_hash], cwd=str(path), capture_output=True, text=True)
+        except OSError as e:
+            return InstallStatusResult(False, f"Failed to checkout commit {commit_hash}: {e}")
         if result.returncode != 0:
             return InstallStatusResult(False, f"Failed to checkout commit {commit_hash}: {result.stderr}")
         return InstallStatusResult(True)

--- a/tests/core/installables/test_git_repo.py
+++ b/tests/core/installables/test_git_repo.py
@@ -138,6 +138,14 @@ def test_check_submodules_state_status_failure(git_unmocked: GitRepo):
     assert message == "Failed to get submodule status: err"
 
 
+def test_check_submodules_state_oserror(git_unmocked: GitRepo):
+    with patch("subprocess.run", side_effect=OSError("No such file or directory")):
+        result, message = git_unmocked.check_submodules_state(Path("/repo"))
+
+    assert result is False
+    assert "Failed to get submodule status" in message
+
+
 @pytest.mark.parametrize(
     ("init_submodules", "stdout", "expected_command"),
     [
@@ -216,6 +224,28 @@ def test_ensure_submodules_state_status_fails(git_unmocked: GitRepo):
     assert mock_run.call_count == 1
 
 
+@pytest.mark.parametrize(
+    ("init_submodules", "expected_message"),
+    [
+        (True, "Failed to initialize submodules"),
+        (False, "Failed to deinitialize submodules"),
+    ],
+)
+def test_ensure_submodules_state_reconcile_oserror(git_unmocked: GitRepo, init_submodules: bool, expected_message: str):
+    git_unmocked.init_submodules = init_submodules
+    stdout = "-0123456789abcdef path/to/submodule\n" if init_submodules else " 0123456789abcdef path/to/submodule\n"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = [
+            CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=""),
+            OSError("No such file or directory"),
+        ]
+        result, message = git_unmocked.ensure_submodules_state(Path("/repo"))
+
+    assert result is False
+    assert expected_message in message
+
+
 def test_repo_exists_with_correct_commit(installer: BaseInstaller, git: GitRepo):
     repo_path = installer.system.install_path / git.repo_name
     repo_path.mkdir()
@@ -254,6 +284,14 @@ def test_error_cloning_repo(installer: BaseInstaller, git: GitRepo):
     assert res.message == "Failed to clone repository: err"
 
 
+def test_clone_repository_oserror(installer: BaseInstaller, git: GitRepo):
+    repo_path = installer.system.install_path / git.repo_name
+    with patch("subprocess.run", side_effect=OSError("No such file or directory")):
+        res = git._clone_repository(installer, repo_path)
+    assert not res.success
+    assert "Failed to clone repository" in res.message
+
+
 def test_commit_checked_out(installer: BaseInstaller, git: GitRepo):
     repo_path = installer.system.install_path / git.repo_name
     repo_path.mkdir()
@@ -274,6 +312,15 @@ def test_error_checking_out_commit(installer: BaseInstaller, git: GitRepo):
         res = git._checkout_commit(git.commit, repo_path)
     assert not res.success
     assert res.message == f"Failed to checkout commit {git.commit}: err"
+
+
+def test_checkout_commit_oserror(installer: BaseInstaller, git: GitRepo):
+    repo_path = installer.system.install_path / git.repo_name
+    repo_path.mkdir()
+    with patch("subprocess.run", side_effect=OSError("No such file or directory")):
+        res = git._checkout_commit(git.commit, repo_path)
+    assert not res.success
+    assert f"Failed to checkout commit {git.commit}" in res.message
 
 
 def test_checkout_failure_cleans_up_repo(installer: BaseInstaller, git: GitRepo):


### PR DESCRIPTION
## Summary
`_clone_repository`, `_checkout_commit`, `check_submodules_state`, and `ensure_submodules_state` in `GitRepo` called `subprocess.run(["git", ...])` directly with no exception handling, so a missing or unusable `git` binary raises an unhandled `FileNotFoundError`/`OSError` out of `GitRepo.install()` / `is_installed()` instead of returning a clean `InstallStatusResult(False, ...)`.

`_verify_commit` in the same file already guards every `subprocess.run` call with `try/except OSError`, returning a graceful failure result. This PR brings the other four call sites in line with that existing pattern, so installation always reports a clean failure rather than crashing with a traceback. Added an OSError-path test for each of the four methods, mirroring the existing `test_verify_commit_oserror` test.

## Test Plan
Ran the existing `test_git_repo.py` suite plus the new OSError-path tests, and the repo's lint/type/format tooling, all on Python 3.10 via `uv run`.

```
$ uv run python -m pytest tests/core/installables/test_git_repo.py -v -k oserror
test_check_submodules_state_oserror PASSED
test_ensure_submodules_state_reconcile_oserror[True-Failed to initialize submodules] PASSED
test_ensure_submodules_state_reconcile_oserror[False-Failed to deinitialize submodules] PASSED
test_clone_repository_oserror PASSED
test_checkout_commit_oserror PASSED
test_verify_commit_oserror PASSED
6 passed in 0.02s

$ uv run python -m pytest tests/core/installables/test_git_repo.py -q
53 passed in 0.05s

$ uv run pre-commit run --files src/cloudai/_core/installables/git_repo.py tests/core/installables/test_git_repo.py
check for added large files..............................................Passed
check python ast.........................................................Passed
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
pyright..................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
vulture..................................................................Passed
import-linter............................................................Passed
taplo....................................................................Passed
```

## Additional Notes
I ran into this while building Autotune, which wraps the cloudai CLI: subprocess.run raised an unhandled FileNotFoundError when the binary was missing, leaving things in a bad state instead of failing cleanly. After fixing that on my end, I checked for the same pattern here and found _clone_repository/_checkout_commit/check_submodules_state/ensure_submodules_state were missing the try/except OSError guard that _verify_commit (right next to them, in the same file) already has.

Drafted with AI (Claude Code) assistance for context and guidance navigating the codebase; the change itself mirrors an existing, already-reviewed `try/except OSError` pattern present in `_verify_commit` in this same file — it isn't a new approach, just consistency across the four sibling methods.