### PR TITLE
[NIXL] Fix NIXL UCX worker node placement

### DIFF
--- a/src/cloudai/workloads/common/nixl.py
+++ b/src/cloudai/workloads/common/nixl.py
@@ -335,7 +335,14 @@ class NIXLCmdGenBase(SlurmCommandGenStrategy):
             nnodes, _ = self.get_cached_nodes_spec()
             if nnodes > 1:
                 cmds = [
-                    [*prefix_part, "--overlap", f"--relative={idx}", *tpn_part, *bash_part] for idx in range(nnodes)
+                    [
+                        *prefix_part,
+                        "--overlap",
+                        f"--nodelist=$(scontrol show hostname $SLURM_JOB_NODELIST | sed -n '{idx + 1}p')",
+                        *tpn_part,
+                        *bash_part,
+                    ]
+                    for idx in range(nnodes)
                 ]
             else:
                 cmds *= max(2, nnodes)

--- a/tests/ref_data/nixl-kvbench.sbatch
+++ b/tests/ref_data/nixl-kvbench.sbatch
@@ -22,9 +22,9 @@ timeout 60 bash -c "until curl -s $NIXL_ETCD_ENDPOINTS/health > /dev/null 2>&1; 
    echo "ETCD ($NIXL_ETCD_ENDPOINTS) was unreachable after 60 seconds";
    exit 1
  }
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=0 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS" &
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --nodelist=$(scontrol show hostname $SLURM_JOB_NODELIST | sed -n '1p') --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS" &
 sleep 15
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=1 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS"
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:tag --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --overlap --nodelist=$(scontrol show hostname $SLURM_JOB_NODELIST | sed -n '2p') --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; path/to/python path/to/kvbench_script.sh profile --backend UCX --etcd_endpoints http://$NIXL_ETCD_ENDPOINTS"
 kill -TERM $etcd_pid
  timeout 60 bash -c "while kill -0 $etcd_pid 2>/dev/null; do sleep 1; done" || {
    echo "Failed to kill ETCD (pid=$etcd_pid) within 60 seconds";

--- a/tests/ref_data/nixl_bench.sbatch
+++ b/tests/ref_data/nixl_bench.sbatch
@@ -22,9 +22,9 @@ timeout 60 bash -c "until curl -s $NIXL_ETCD_ENDPOINTS/health > /dev/null 2>&1; 
    echo "ETCD ($NIXL_ETCD_ENDPOINTS) was unreachable after 60 seconds";
    exit 1
  }
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=0 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ./nixlbench --etcd-endpoints=http://$NIXL_ETCD_ENDPOINTS --backend=UCX" &
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --nodelist=$(scontrol show hostname $SLURM_JOB_NODELIST | sed -n '1p') --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ./nixlbench --etcd-endpoints=http://$NIXL_ETCD_ENDPOINTS --backend=UCX" &
 sleep 15
-srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --relative=1 --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ./nixlbench --etcd-endpoints=http://$NIXL_ETCD_ENDPOINTS --backend=UCX"
+srun --export=ALL --mpi=pmix --container-image=url.com/docker:2 --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__INSTALL_DIR__:/cloudai_install,__OUTPUT_DIR__/output --overlap --nodelist=$(scontrol show hostname $SLURM_JOB_NODELIST | sed -n '2p') --ntasks-per-node=1 --ntasks=1 -N1 bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ./nixlbench --etcd-endpoints=http://$NIXL_ETCD_ENDPOINTS --backend=UCX"
 kill -TERM $etcd_pid
  timeout 60 bash -c "while kill -0 $etcd_pid 2>/dev/null; do sleep 1; done" || {
    echo "Failed to kill ETCD (pid=$etcd_pid) within 60 seconds";

--- a/tests/workloads/nixl_bench/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/nixl_bench/test_command_gen_strategy_slurm.py
@@ -241,7 +241,8 @@ def test_gen_nixl_srun_command(
         assert "-N1" in cmd
         if backend == "UCX":
             if nnodes > 1:
-                assert f"--relative={idx}" in cmd
+                assert f"--nodelist=$(scontrol show hostname $SLURM_JOB_NODELIST | sed -n '{idx + 1}p')" in cmd
+                assert "--relative" not in cmd
             else:
                 assert "--relative" not in cmd
                 assert "--nodelist=$SLURM_JOB_MASTER_NODE" in cmd


### PR DESCRIPTION
## Summary

On some clusters NIXLBench UCX Inter-node tests don’t actually run across two nodes - both the initiator and the target end up on the same node.
Some clusters though are not affected (probably due to older Slurm version, which is most likely the reason). The issue affects all CloudAI workloads that launch two SLURM steps per UCX inter-node run

## Test Plan
- Automated CI
- Manual runs

## Additional Notes
-
