### PR TITLE
[CI] use uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,32 +57,37 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Install dependencies
-        run: pip install '.[dev]'
+        run: uv sync --python ${{ matrix.python-version }} --extra dev
 
       - name: Run pytest
         run: |
           set -eEx
           set -o pipefail
 
-          python -m pytest -vv --cov
+          uv run python -m pytest -vv --cov
           # <100% coverage might indicate that some tests are not doing what they should,
           # but realistically, it might too hard to reach, so lower it a bit
           # (at the moment of writing, it is 99.95%)
-          coverage report --include='tests/*' --precision=2 --fail-under=97.00
+          uv run coverage report --include='tests/*' --precision=2 --fail-under=97.00
 
-          python -m pytest --dead-fixtures
+          uv run python -m pytest --dead-fixtures
 
-          python -m pytest -vv -m ci_only
+          uv run python -m pytest -vv -m ci_only
 
       - name: Test local installation
         run: |
           set -eE
           set -o pipefail
 
-          pip install .
-          pip uninstall -y cloudai
-          pip install -e .
+          uv pip install --system .
+          uv pip uninstall --system cloudai
+          uv pip install --system -e .
 
       - name: Test commands
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,15 @@ jobs:
           set -eEx
           set -o pipefail
 
-          uv run python -m pytest -vv --cov
+          uv run --python ${{ matrix.python-version }} --extra dev python -m pytest -vv --cov
           # <100% coverage might indicate that some tests are not doing what they should,
           # but realistically, it might too hard to reach, so lower it a bit
           # (at the moment of writing, it is 99.95%)
-          uv run coverage report --include='tests/*' --precision=2 --fail-under=97.00
+          uv run --python ${{ matrix.python-version }} --extra dev coverage report --include='tests/*' --precision=2 --fail-under=97.00
 
-          uv run python -m pytest --dead-fixtures
+          uv run --python ${{ matrix.python-version }} --extra dev python -m pytest --dead-fixtures
 
-          uv run python -m pytest -vv -m ci_only
+          uv run --python ${{ matrix.python-version }} --extra dev python -m pytest -vv -m ci_only
 
       - name: Test local installation
         run: |


### PR DESCRIPTION
## Summary
- `pip install .` or `pip install .[dev]` is not the right way to install requirements for cloudai. It must be `uv sync`

## Test Plan
- Automated CI

## Additional Notes
-
