### PR TITLE
[LLM] Gracefully shutdown processes with scancel

### DIFF
--- a/conf/experimental/vllm/test_scenario/vllm.toml
+++ b/conf/experimental/vllm/test_scenario/vllm.toml
@@ -17,6 +17,27 @@
 name = "vllm"
 
 [[Tests]]
+id = "vllm.disagg.4nodes"
+test_name = "vllm"
+num_nodes = 4
+time_limit = "00:30:00"
+
+  [Tests.cmd_args.prefill]
+  num_nodes = 2
+  enforce_eager = ""
+  tensor_parallel_size = 8
+  max_num_batched_tokens = 1024
+
+  [Tests.cmd_args.decode]
+  num_nodes = 2
+  enforce_eager = ""
+  tensor_parallel_size = 8
+  max_num_batched_tokens = 1024
+
+  [Tests.extra_env_vars]
+  CUDA_VISIBLE_DEVICES = "0,1,2,3"
+
+[[Tests]]
 id = "vllm.agg.1node"
 test_name = "vllm"
 num_nodes = 1

--- a/src/cloudai/workloads/common/llm_serving.py
+++ b/src/cloudai/workloads/common/llm_serving.py
@@ -578,6 +578,10 @@ wait_for_health() {{
     def cleanup_prelude(self) -> str:
         return ""
 
+    def cleanup_guard_var(self) -> str:
+        run_id = re.sub(r"\W+", "_", f"{self.test_run.name}_{self.test_run.current_iteration}").strip("_")
+        return f"CLOUDAI_{run_id.upper()}_CLEANUP_DONE"
+
     def _with_slurm_step_name(self, srun_prefix: str, role: str) -> str:
         return f"{srun_prefix} --job-name={self.slurm_step_name(role)}"
 
@@ -630,6 +634,7 @@ echo "Slurm step IDs for {role}: ${{{step_id_var}:-unknown}}"
 
     def generate_cleanup_function(self, pid_vars: list[str], timeout: int = 60) -> str:
         step_id_vars = self.cleanup_step_id_vars(pid_vars)
+        guard_var = self.cleanup_guard_var()
         pid_values = " ".join(f"{pid_var}=${pid_var}" for pid_var in pid_vars)
         step_values = " ".join(f"{step_id_var}=${step_id_var}" for step_id_var in step_id_vars)
         prelude = self.cleanup_prelude()
@@ -645,10 +650,10 @@ echo "Slurm step IDs for {role}: ${{{step_id_var}:-unknown}}"
         )
         return f"""\
 cleanup() {{
-    if [ "${{CLOUDAI_CLEANUP_DONE:-0}}" = "1" ]; then
+    if [ "${{{guard_var}:-0}}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    {guard_var}=1
     cleanup_status=0
 {prelude}    echo "Cleaning up PIDs: {pid_values}"
     echo "Cleaning up Slurm step IDs: {step_values}"

--- a/src/cloudai/workloads/common/llm_serving.py
+++ b/src/cloudai/workloads/common/llm_serving.py
@@ -565,41 +565,98 @@ wait_for_health() {{
     return 1
 }}"""
 
-    def generate_cleanup_function(self, pid_vars: list[str], timeout: int = 15) -> str:
-        if len(pid_vars) == 1:
-            pid_var = pid_vars[0]
-            return f"""\
-cleanup() {{
-    echo "Cleaning up PIDs: {pid_var}=${pid_var}"
-    kill -TERM "${pid_var}" 2>/dev/null
-    i=0
-    while kill -0 "${pid_var}" 2>/dev/null; do
-        [ "$i" -ge {timeout} ] && echo "PID did not exit in time" && return 1
-        sleep 1
-        i=$((i+1))
-    done
-}}
-trap cleanup EXIT"""
+    def slurm_step_name(self, role: str) -> str:
+        return f"cloudai-{self.workload_slug}-{role.replace('_', '-')}"
 
-        pid_values = " ".join(f"{pid_var}=${pid_var}" for pid_var in pid_vars)
-        pid_array = " ".join(f'"${p}"' for p in pid_vars)
+    @staticmethod
+    def slurm_step_id_var(role: str) -> str:
+        return f"{role.replace('-', '_').upper()}_STEP_IDS"
+
+    def cleanup_step_id_vars(self, pid_vars: list[str]) -> list[str]:
+        return [f"{pid_var.removesuffix('_PID')}_STEP_IDS" for pid_var in pid_vars]
+
+    def cleanup_prelude(self) -> str:
+        return ""
+
+    def _with_slurm_step_name(self, srun_prefix: str, role: str) -> str:
+        return f"{srun_prefix} --job-name={self.slurm_step_name(role)}"
+
+    def render_step_discovery(self, role: str, step_id_var: str | None = None, expected_count: int = 1) -> str:
+        step_id_var = step_id_var or self.slurm_step_id_var(role)
+        step_name = self.slurm_step_name(role)
+        squeue_cmd = (
+            'squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null '
+            f"| awk '$2 == \"{step_name}\" {{ print $1 }}'"
+        )
         return f"""\
-cleanup() {{
-    echo "Cleaning up PIDs: {pid_values}"
+{step_id_var}=
+for _ in {{1..10}}; do
+    {step_id_var}=$({squeue_cmd})
+    CLOUDAI_STEP_COUNT=$(printf '%s\\n' "${{{step_id_var}}}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge {expected_count} ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for {role}: ${{{step_id_var}:-unknown}}"
+"""
 
-    for pid in {pid_array}; do
-        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
-    done
+    def _render_cleanup_signal_block(self, pid_var: str, step_id_var: str, signal_name: str) -> str:
+        pid_signal = "KILL" if signal_name == "KILL" else "TERM"
+        return f"""\
+    if [ -n "${{{step_id_var}:-}}" ]; then
+        for step_id in ${{{step_id_var}}}; do
+            scancel --signal={signal_name} "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${{{pid_var}:-}}" ]; then
+        kill -{pid_signal} "${{{pid_var}}}" 2>/dev/null || true
+    fi"""
 
-    for pid in {pid_array}; do
-        [ -z "$pid" ] && continue
+    def _render_cleanup_wait_block(self, pid_var: str, step_id_var: str, timeout: int) -> str:
+        force_block = self._render_cleanup_signal_block(pid_var, step_id_var, "KILL")
+        force_block = "\n".join(f"            {line}" for line in force_block.splitlines())
+        return f"""\
+    if [ -n "${{{pid_var}:-}}" ]; then
         i=0
-        while kill -0 "$pid" 2>/dev/null; do
-            [ "$i" -ge {timeout} ] && echo "PID $pid did not exit in time" && return 1
+        while kill -0 "${{{pid_var}}}" 2>/dev/null; do
+            if [ "$i" -ge {timeout} ]; then
+                echo "PID ${{{pid_var}}} did not exit in time"
+                cleanup_status=1
+{force_block}
+                break
+            fi
             sleep 1
             i=$((i+1))
         done
-    done
+    fi"""
+
+    def generate_cleanup_function(self, pid_vars: list[str], timeout: int = 60) -> str:
+        step_id_vars = self.cleanup_step_id_vars(pid_vars)
+        pid_values = " ".join(f"{pid_var}=${pid_var}" for pid_var in pid_vars)
+        step_values = " ".join(f"{step_id_var}=${step_id_var}" for step_id_var in step_id_vars)
+        prelude = self.cleanup_prelude()
+        if prelude:
+            prelude = f"{prelude}\n"
+        term_blocks = "\n".join(
+            self._render_cleanup_signal_block(pid_var, step_id_var, "TERM")
+            for pid_var, step_id_var in zip(pid_vars, step_id_vars, strict=True)
+        )
+        wait_blocks = "\n".join(
+            self._render_cleanup_wait_block(pid_var, step_id_var, timeout)
+            for pid_var, step_id_var in zip(pid_vars, step_id_vars, strict=True)
+        )
+        return f"""\
+cleanup() {{
+    if [ "${{CLOUDAI_CLEANUP_DONE:-0}}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
+{prelude}    echo "Cleaning up PIDs: {pid_values}"
+    echo "Cleaning up Slurm step IDs: {step_values}"
+
+{term_blocks}
+
+{wait_blocks}
+    return "$cleanup_status"
 }}
 trap cleanup EXIT"""
 
@@ -728,12 +785,15 @@ trap cleanup EXIT"""
         head_node_var: str,
         nodelist_var: str,
     ) -> str:
-        del role, node_count, nodelist_var
+        del node_count, nodelist_var
+        srun_prefix = self._with_slurm_step_name(self._single_role_srun_prefix(head_node_var), role)
+        step_id_var = self.slurm_step_id_var(role)
         return f"""\
-{self._single_role_srun_prefix(head_node_var)} \\
+{srun_prefix} \\
     --output={self.test_run.output_path.absolute()}/{log_file} \\
     {self._with_custom_bash(command_tail)} &
-{pid_var}=$!"""
+{pid_var}=$!
+{self.render_step_discovery(role, step_id_var)}"""
 
     def _expand_semantic_eval_args(self, args: str, *, host: str) -> str:
         replacements = {
@@ -792,11 +852,15 @@ echo "Running semantic validation..."
         node_setup = self.generate_aggregated_node_setup(serve_node_count)
         preamble = self.aggregated_script_preamble()
         if legacy_single_node:
+            serve_srun_prefix = self._with_slurm_step_name(
+                f"{srun_prefix} --overlap --ntasks-per-node=1 --ntasks=1", "serve"
+            )
             serve_launch = f"""\
-{srun_prefix} --overlap --ntasks-per-node=1 --ntasks=1 \\
+{serve_srun_prefix} \\
     --output={(self.test_run.output_path / self.serve_log_file).absolute()} \\
     {self._with_custom_bash(serve_cmd_with_env)} &
-{self.serve_pid_var}=$!"""
+{self.serve_pid_var}=$!
+{self.render_step_discovery("serve", self.slurm_step_id_var("serve"))}"""
         else:
             serve_launch = self.render_serve_launch(
                 "serve",
@@ -889,10 +953,11 @@ echo "Starting {self.workload_name} instances..."
 {wait_block}
 
 echo "Starting {self.proxy_router_name}..."
-{prefill_srun_prefix} \\
+{self._with_slurm_step_name(prefill_srun_prefix, "helper")} \\
     --output={self.test_run.output_path.absolute()}/{self.proxy_router_log_file} \\
     {self._with_custom_bash(" ".join(helper_cmd))} &
 {self.proxy_router_pid_var}=$!
+{self.render_step_discovery("helper", self.slurm_step_id_var("helper"))}
 
 {wait_block_helper}
 

--- a/src/cloudai/workloads/vllm/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/vllm/slurm_command_gen_strategy.py
@@ -174,6 +174,22 @@ export DECODE_NIXL_PORT=$((5557 + PORT_OFFSET + {len(self.gpu_ids)}))
             pid_vars.insert(insert_at, "DECODE_RAY_PID")
         return pid_vars
 
+    def cleanup_step_id_vars(self, pid_vars: list[str]) -> list[str]:
+        step_id_vars: list[str] = []
+        for pid_var in pid_vars:
+            base = pid_var.removesuffix("_PID")
+            if base.endswith("_RAY"):
+                step_id_vars.append(f"{base}_WORKER_STEP_IDS")
+                continue
+
+            role = base.lower()
+            if role in {"serve", "prefill", "decode"} and self._needs_ray(role):
+                step_id_vars.append(f"{base}_RAY_HEAD_STEP_IDS")
+                continue
+
+            step_id_vars.append(f"{base}_STEP_IDS")
+        return step_id_vars
+
     @property
     def proxy_router_healthcheck(self) -> str:
         fields_set = self.tdef.cmd_args.model_fields_set
@@ -216,12 +232,8 @@ export DECODE_NIXL_PORT=$((5557 + PORT_OFFSET + {len(self.gpu_ids)}))
             )
         return "\n".join(lines)
 
-    def generate_cleanup_function(self, pid_vars: list[str], timeout: int = 15) -> str:
-        cleanup = super().generate_cleanup_function(pid_vars, timeout)
-        ray_stop_block = self._ray_stop_cleanup_block()
-        if not ray_stop_block:
-            return cleanup
-        return cleanup.replace("cleanup() {\n", f"cleanup() {{\n{ray_stop_block}\n", 1)
+    def cleanup_prelude(self) -> str:
+        return self._ray_stop_cleanup_block()
 
     def render_serve_launch(
         self,
@@ -246,8 +258,12 @@ export DECODE_NIXL_PORT=$((5557 + PORT_OFFSET + {len(self.gpu_ids)}))
         ray_worker_log = f"{self.workload_slug}-{role}-ray-worker-%N.log"
         serve_log = f"{self.test_run.output_path.absolute()}/{log_file}"
         head_node_expr = f"${{{head_node_var}}}"
-        worker_prefix = self._role_srun_prefix("$node")
-        head_prefix = self._single_role_srun_prefix(head_node_var)
+        worker_role = f"{role}-ray-worker"
+        head_role = f"{role}-ray-head"
+        worker_step_id_var = f"{role_prefix}_RAY_WORKER_STEP_IDS"
+        head_step_id_var = f"{role_prefix}_RAY_HEAD_STEP_IDS"
+        worker_prefix = self._with_slurm_step_name(self._role_srun_prefix("$node"), worker_role)
+        head_prefix = self._with_slurm_step_name(self._single_role_srun_prefix(head_node_var), head_role)
         serve_cmd = self._with_custom_bash(f'env RAY_ADDRESS="{head_node_expr}:${{{ray_port_var}}}" {command_tail}')
         ray_head_args = self._ray_start_args(role, "head", {"head": True, "port": f'"${{{ray_port_var}}}"'})
         ray_worker_args = self._ray_start_args(
@@ -301,11 +317,13 @@ exit 1"""
     wait
 ) &
 {ray_pid_var}=$!
+{self.render_step_discovery(worker_role, worker_step_id_var, node_count - 1)}
 {head_prefix} \\
     --output={serve_log} \\
     --error={self.test_run.output_path.absolute()}/{ray_head_log} \\
     bash -lc {ray_head_command} &
-{pid_var}=$!"""
+{pid_var}=$!
+{self.render_step_discovery(head_role, head_step_id_var)}"""
 
     def disaggregated_role_env(self, role: str, gpu_ids: list[int]) -> dict[str, str]:
         env = super().disaggregated_role_env(role, gpu_ids)

--- a/tests/ref_data/sglang-disagg-2nodes.sbatch
+++ b/tests/ref_data/sglang-disagg-2nodes.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_SGLANG_DISAGG_2NODES_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_SGLANG_DISAGG_2NODES_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
     echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"

--- a/tests/ref_data/sglang-disagg-2nodes.sbatch
+++ b/tests/ref_data/sglang-disagg-2nodes.sbatch
@@ -15,21 +15,94 @@ srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
+    echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
-    done
+    if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+        for step_id in ${PREFILL_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${PREFILL_PID:-}" ]; then
+        kill -TERM "${PREFILL_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${DECODE_STEP_IDS:-}" ]; then
+        for step_id in ${DECODE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${DECODE_PID:-}" ]; then
+        kill -TERM "${DECODE_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${HELPER_STEP_IDS:-}" ]; then
+        for step_id in ${HELPER_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${HELPER_PID:-}" ]; then
+        kill -TERM "${HELPER_PID}" 2>/dev/null || true
+    fi
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -z "$pid" ] && continue
+    if [ -n "${PREFILL_PID:-}" ]; then
         i=0
-        while kill -0 "$pid" 2>/dev/null; do
-            [ "$i" -ge 15 ] && echo "PID $pid did not exit in time" && return 1
+        while kill -0 "${PREFILL_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${PREFILL_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+                    for step_id in ${PREFILL_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${PREFILL_PID:-}" ]; then
+                    kill -KILL "${PREFILL_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
             sleep 1
             i=$((i+1))
         done
-    done
+    fi
+    if [ -n "${DECODE_PID:-}" ]; then
+        i=0
+        while kill -0 "${DECODE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${DECODE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${DECODE_STEP_IDS:-}" ]; then
+                    for step_id in ${DECODE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${DECODE_PID:-}" ]; then
+                    kill -KILL "${DECODE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    if [ -n "${HELPER_PID:-}" ]; then
+        i=0
+        while kill -0 "${HELPER_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${HELPER_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${HELPER_STEP_IDS:-}" ]; then
+                    for step_id in ${HELPER_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${HELPER_PID:-}" ]; then
+                    kill -KILL "${HELPER_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -69,25 +142,52 @@ fi
 echo "Node roles: prefill=${PREFILL_NODES[*]} decode=${DECODE_NODES[*]}"
 
 echo "Starting SGLang instances..."
-srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-sglang-prefill \
     --output=__OUTPUT_DIR__/output/sglang-prefill.log \
     env CUDA_VISIBLE_DEVICES="0,1,2,3" python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --host 0.0.0.0 --port 8400 --disaggregation-mode prefill --disaggregation-transfer-backend nixl &
 PREFILL_PID=$!
+PREFILL_STEP_IDS=
+for _ in {1..10}; do
+    PREFILL_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-prefill" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${PREFILL_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for prefill: ${PREFILL_STEP_IDS:-unknown}"
 
-srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+
+srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-sglang-decode \
     --output=__OUTPUT_DIR__/output/sglang-decode.log \
     env CUDA_VISIBLE_DEVICES="0,1,2,3" python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --host 0.0.0.0 --port 8500 --disaggregation-mode decode --disaggregation-transfer-backend nixl &
 DECODE_PID=$!
+DECODE_STEP_IDS=
+for _ in {1..10}; do
+    DECODE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-decode" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${DECODE_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for decode: ${DECODE_STEP_IDS:-unknown}"
+
 
 echo "Waiting for SGLang on $PREFILL_NODE and $DECODE_NODE to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8400/health" || exit 1
 wait_for_health "http://${DECODE_NODE}:8500/health" || exit 1
 
 echo "Starting router..."
-srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-sglang-helper \
     --output=__OUTPUT_DIR__/output/sglang-router.log \
     python3 -m sglang_router.launch_router --pd-disaggregation --prefill http://${PREFILL_NODE}:8400 --decode http://${DECODE_NODE}:8500 --host 0.0.0.0 --port 8300 &
 HELPER_PID=$!
+HELPER_STEP_IDS=
+for _ in {1..10}; do
+    HELPER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-helper" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${HELPER_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for helper: ${HELPER_STEP_IDS:-unknown}"
+
 
 echo "Waiting for SGLang on $PREFILL_NODE server to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8300/v1/models" || exit 1

--- a/tests/ref_data/sglang-disagg.sbatch
+++ b/tests/ref_data/sglang-disagg.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_SGLANG_DISAGG_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_SGLANG_DISAGG_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
     echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"

--- a/tests/ref_data/sglang-disagg.sbatch
+++ b/tests/ref_data/sglang-disagg.sbatch
@@ -15,21 +15,94 @@ srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
+    echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
-    done
+    if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+        for step_id in ${PREFILL_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${PREFILL_PID:-}" ]; then
+        kill -TERM "${PREFILL_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${DECODE_STEP_IDS:-}" ]; then
+        for step_id in ${DECODE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${DECODE_PID:-}" ]; then
+        kill -TERM "${DECODE_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${HELPER_STEP_IDS:-}" ]; then
+        for step_id in ${HELPER_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${HELPER_PID:-}" ]; then
+        kill -TERM "${HELPER_PID}" 2>/dev/null || true
+    fi
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -z "$pid" ] && continue
+    if [ -n "${PREFILL_PID:-}" ]; then
         i=0
-        while kill -0 "$pid" 2>/dev/null; do
-            [ "$i" -ge 15 ] && echo "PID $pid did not exit in time" && return 1
+        while kill -0 "${PREFILL_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${PREFILL_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+                    for step_id in ${PREFILL_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${PREFILL_PID:-}" ]; then
+                    kill -KILL "${PREFILL_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
             sleep 1
             i=$((i+1))
         done
-    done
+    fi
+    if [ -n "${DECODE_PID:-}" ]; then
+        i=0
+        while kill -0 "${DECODE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${DECODE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${DECODE_STEP_IDS:-}" ]; then
+                    for step_id in ${DECODE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${DECODE_PID:-}" ]; then
+                    kill -KILL "${DECODE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    if [ -n "${HELPER_PID:-}" ]; then
+        i=0
+        while kill -0 "${HELPER_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${HELPER_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${HELPER_STEP_IDS:-}" ]; then
+                    for step_id in ${HELPER_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${HELPER_PID:-}" ]; then
+                    kill -KILL "${HELPER_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -69,25 +142,52 @@ fi
 echo "Node roles: prefill=${PREFILL_NODES[*]} decode=${DECODE_NODES[*]}"
 
 echo "Starting SGLang instances..."
-srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-sglang-prefill \
     --output=__OUTPUT_DIR__/output/sglang-prefill.log \
     env CUDA_VISIBLE_DEVICES="0,1" python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --host 0.0.0.0 --port 8400 --disaggregation-mode prefill --disaggregation-transfer-backend nixl &
 PREFILL_PID=$!
+PREFILL_STEP_IDS=
+for _ in {1..10}; do
+    PREFILL_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-prefill" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${PREFILL_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for prefill: ${PREFILL_STEP_IDS:-unknown}"
 
-srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+
+srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-sglang-decode \
     --output=__OUTPUT_DIR__/output/sglang-decode.log \
     env CUDA_VISIBLE_DEVICES="2,3" python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --host 0.0.0.0 --port 8500 --disaggregation-mode decode --disaggregation-transfer-backend nixl &
 DECODE_PID=$!
+DECODE_STEP_IDS=
+for _ in {1..10}; do
+    DECODE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-decode" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${DECODE_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for decode: ${DECODE_STEP_IDS:-unknown}"
+
 
 echo "Waiting for SGLang on $PREFILL_NODE and $DECODE_NODE to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8400/health" || exit 1
 wait_for_health "http://${DECODE_NODE}:8500/health" || exit 1
 
 echo "Starting router..."
-srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-sglang-helper \
     --output=__OUTPUT_DIR__/output/sglang-router.log \
     python3 -m sglang_router.launch_router --pd-disaggregation --prefill http://${PREFILL_NODE}:8400 --decode http://${DECODE_NODE}:8500 --host 0.0.0.0 --port 8300 &
 HELPER_PID=$!
+HELPER_STEP_IDS=
+for _ in {1..10}; do
+    HELPER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-helper" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${HELPER_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for helper: ${HELPER_STEP_IDS:-unknown}"
+
 
 echo "Waiting for SGLang on $PREFILL_NODE server to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8300/v1/models" || exit 1

--- a/tests/ref_data/sglang-multinode.sbatch
+++ b/tests/ref_data/sglang-multinode.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_SGLANG_MULTINODE_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_SGLANG_MULTINODE_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: SERVE_PID=$SERVE_PID"
     echo "Cleaning up Slurm step IDs: SERVE_STEP_IDS=$SERVE_STEP_IDS"

--- a/tests/ref_data/sglang-multinode.sbatch
+++ b/tests/ref_data/sglang-multinode.sbatch
@@ -15,14 +15,42 @@ srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N2 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: SERVE_PID=$SERVE_PID"
-    kill -TERM "$SERVE_PID" 2>/dev/null
-    i=0
-    while kill -0 "$SERVE_PID" 2>/dev/null; do
-        [ "$i" -ge 15 ] && echo "PID did not exit in time" && return 1
-        sleep 1
-        i=$((i+1))
-    done
+    echo "Cleaning up Slurm step IDs: SERVE_STEP_IDS=$SERVE_STEP_IDS"
+
+    if [ -n "${SERVE_STEP_IDS:-}" ]; then
+        for step_id in ${SERVE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${SERVE_PID:-}" ]; then
+        kill -TERM "${SERVE_PID}" 2>/dev/null || true
+    fi
+
+    if [ -n "${SERVE_PID:-}" ]; then
+        i=0
+        while kill -0 "${SERVE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${SERVE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${SERVE_STEP_IDS:-}" ]; then
+                    for step_id in ${SERVE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${SERVE_PID:-}" ]; then
+                    kill -KILL "${SERVE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 

--- a/tests/ref_data/sglang.sbatch
+++ b/tests/ref_data/sglang.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_SGLANG_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_SGLANG_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: SERVE_PID=$SERVE_PID"
     echo "Cleaning up Slurm step IDs: SERVE_STEP_IDS=$SERVE_STEP_IDS"

--- a/tests/ref_data/sglang.sbatch
+++ b/tests/ref_data/sglang.sbatch
@@ -15,14 +15,42 @@ srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev
 srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: SERVE_PID=$SERVE_PID"
-    kill -TERM "$SERVE_PID" 2>/dev/null
-    i=0
-    while kill -0 "$SERVE_PID" 2>/dev/null; do
-        [ "$i" -ge 15 ] && echo "PID did not exit in time" && return 1
-        sleep 1
-        i=$((i+1))
-    done
+    echo "Cleaning up Slurm step IDs: SERVE_STEP_IDS=$SERVE_STEP_IDS"
+
+    if [ -n "${SERVE_STEP_IDS:-}" ]; then
+        for step_id in ${SERVE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${SERVE_PID:-}" ]; then
+        kill -TERM "${SERVE_PID}" 2>/dev/null || true
+    fi
+
+    if [ -n "${SERVE_PID:-}" ]; then
+        i=0
+        while kill -0 "${SERVE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${SERVE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${SERVE_STEP_IDS:-}" ]; then
+                    for step_id in ${SERVE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${SERVE_PID:-}" ]; then
+                    kill -KILL "${SERVE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -45,10 +73,19 @@ wait_for_health() {
 }
 
 echo "Starting SGLang instances..."
-srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --ntasks-per-node=1 --ntasks=1 \
+srun --export=ALL --mpi=none -N1 --container-image=docker.io/lmsysorg/sglang:dev --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --ntasks-per-node=1 --ntasks=1 --job-name=cloudai-sglang-serve \
     --output=__OUTPUT_DIR__/output/sglang-serve.log \
     env CUDA_VISIBLE_DEVICES="0" python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --host 0.0.0.0 --port 8300 &
 SERVE_PID=$!
+SERVE_STEP_IDS=
+for _ in {1..10}; do
+    SERVE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-sglang-serve" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${SERVE_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for serve: ${SERVE_STEP_IDS:-unknown}"
+
 
 NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 echo "Waiting for SGLang on $NODE to be ready..."

--- a/tests/ref_data/vllm-disagg-2nodes.sbatch
+++ b/tests/ref_data/vllm-disagg-2nodes.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_VLLM_DISAGG_2NODES_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_VLLM_DISAGG_2NODES_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
     echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"

--- a/tests/ref_data/vllm-disagg-2nodes.sbatch
+++ b/tests/ref_data/vllm-disagg-2nodes.sbatch
@@ -15,21 +15,94 @@ srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
+    echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
-    done
+    if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+        for step_id in ${PREFILL_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${PREFILL_PID:-}" ]; then
+        kill -TERM "${PREFILL_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${DECODE_STEP_IDS:-}" ]; then
+        for step_id in ${DECODE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${DECODE_PID:-}" ]; then
+        kill -TERM "${DECODE_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${HELPER_STEP_IDS:-}" ]; then
+        for step_id in ${HELPER_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${HELPER_PID:-}" ]; then
+        kill -TERM "${HELPER_PID}" 2>/dev/null || true
+    fi
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -z "$pid" ] && continue
+    if [ -n "${PREFILL_PID:-}" ]; then
         i=0
-        while kill -0 "$pid" 2>/dev/null; do
-            [ "$i" -ge 15 ] && echo "PID $pid did not exit in time" && return 1
+        while kill -0 "${PREFILL_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${PREFILL_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+                    for step_id in ${PREFILL_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${PREFILL_PID:-}" ]; then
+                    kill -KILL "${PREFILL_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
             sleep 1
             i=$((i+1))
         done
-    done
+    fi
+    if [ -n "${DECODE_PID:-}" ]; then
+        i=0
+        while kill -0 "${DECODE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${DECODE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${DECODE_STEP_IDS:-}" ]; then
+                    for step_id in ${DECODE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${DECODE_PID:-}" ]; then
+                    kill -KILL "${DECODE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    if [ -n "${HELPER_PID:-}" ]; then
+        i=0
+        while kill -0 "${HELPER_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${HELPER_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${HELPER_STEP_IDS:-}" ]; then
+                    for step_id in ${HELPER_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${HELPER_PID:-}" ]; then
+                    kill -KILL "${HELPER_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -73,25 +146,52 @@ fi
 echo "Node roles: prefill=${PREFILL_NODES[*]} decode=${DECODE_NODES[*]}"
 
 echo "Starting vLLM instances..."
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-prefill \
     --output=__OUTPUT_DIR__/output/vllm-prefill.log \
     env CUDA_VISIBLE_DEVICES="0,1,2,3" VLLM_NIXL_SIDE_CHANNEL_HOST="${PREFILL_NODE}" VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_NIXL_PORT" vllm serve Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8400 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}' &
 PREFILL_PID=$!
+PREFILL_STEP_IDS=
+for _ in {1..10}; do
+    PREFILL_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-prefill" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${PREFILL_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for prefill: ${PREFILL_STEP_IDS:-unknown}"
 
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-decode \
     --output=__OUTPUT_DIR__/output/vllm-decode.log \
     env CUDA_VISIBLE_DEVICES="0,1,2,3" VLLM_NIXL_SIDE_CHANNEL_HOST="${DECODE_NODE}" VLLM_NIXL_SIDE_CHANNEL_PORT="$DECODE_NIXL_PORT" vllm serve Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8500 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}' &
 DECODE_PID=$!
+DECODE_STEP_IDS=
+for _ in {1..10}; do
+    DECODE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-decode" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${DECODE_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for decode: ${DECODE_STEP_IDS:-unknown}"
+
 
 echo "Waiting for vLLM on $PREFILL_NODE and $DECODE_NODE to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8400/health" || exit 1
 wait_for_health "http://${DECODE_NODE}:8500/health" || exit 1
 
 echo "Starting router..."
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-helper \
     --output=__OUTPUT_DIR__/output/vllm-router.log \
     python3 /opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --host 0.0.0.0 --port 8300 --prefiller-hosts ${PREFILL_NODE} --prefiller-ports 8400 --decoder-hosts ${DECODE_NODE} --decoder-ports 8500 &
 HELPER_PID=$!
+HELPER_STEP_IDS=
+for _ in {1..10}; do
+    HELPER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-helper" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${HELPER_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for helper: ${HELPER_STEP_IDS:-unknown}"
+
 
 echo "Waiting for vLLM on $PREFILL_NODE server to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8300/healthcheck" || exit 1

--- a/tests/ref_data/vllm-disagg.sbatch
+++ b/tests/ref_data/vllm-disagg.sbatch
@@ -15,21 +15,94 @@ srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
+    echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
-    done
+    if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+        for step_id in ${PREFILL_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${PREFILL_PID:-}" ]; then
+        kill -TERM "${PREFILL_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${DECODE_STEP_IDS:-}" ]; then
+        for step_id in ${DECODE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${DECODE_PID:-}" ]; then
+        kill -TERM "${DECODE_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${HELPER_STEP_IDS:-}" ]; then
+        for step_id in ${HELPER_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${HELPER_PID:-}" ]; then
+        kill -TERM "${HELPER_PID}" 2>/dev/null || true
+    fi
 
-    for pid in "$PREFILL_PID" "$DECODE_PID" "$HELPER_PID"; do
-        [ -z "$pid" ] && continue
+    if [ -n "${PREFILL_PID:-}" ]; then
         i=0
-        while kill -0 "$pid" 2>/dev/null; do
-            [ "$i" -ge 15 ] && echo "PID $pid did not exit in time" && return 1
+        while kill -0 "${PREFILL_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${PREFILL_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${PREFILL_STEP_IDS:-}" ]; then
+                    for step_id in ${PREFILL_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${PREFILL_PID:-}" ]; then
+                    kill -KILL "${PREFILL_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
             sleep 1
             i=$((i+1))
         done
-    done
+    fi
+    if [ -n "${DECODE_PID:-}" ]; then
+        i=0
+        while kill -0 "${DECODE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${DECODE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${DECODE_STEP_IDS:-}" ]; then
+                    for step_id in ${DECODE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${DECODE_PID:-}" ]; then
+                    kill -KILL "${DECODE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    if [ -n "${HELPER_PID:-}" ]; then
+        i=0
+        while kill -0 "${HELPER_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${HELPER_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${HELPER_STEP_IDS:-}" ]; then
+                    for step_id in ${HELPER_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${HELPER_PID:-}" ]; then
+                    kill -KILL "${HELPER_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -73,25 +146,52 @@ fi
 echo "Node roles: prefill=${PREFILL_NODES[*]} decode=${DECODE_NODES[*]}"
 
 echo "Starting vLLM instances..."
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-prefill \
     --output=__OUTPUT_DIR__/output/vllm-prefill.log \
     env CUDA_VISIBLE_DEVICES="0,1" VLLM_NIXL_SIDE_CHANNEL_HOST="${PREFILL_NODE}" VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_NIXL_PORT" vllm serve Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8400 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}' &
 PREFILL_PID=$!
+PREFILL_STEP_IDS=
+for _ in {1..10}; do
+    PREFILL_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-prefill" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${PREFILL_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for prefill: ${PREFILL_STEP_IDS:-unknown}"
 
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${DECODE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-decode \
     --output=__OUTPUT_DIR__/output/vllm-decode.log \
     env CUDA_VISIBLE_DEVICES="2,3" VLLM_NIXL_SIDE_CHANNEL_HOST="${DECODE_NODE}" VLLM_NIXL_SIDE_CHANNEL_PORT="$DECODE_NIXL_PORT" vllm serve Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8500 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}' &
 DECODE_PID=$!
+DECODE_STEP_IDS=
+for _ in {1..10}; do
+    DECODE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-decode" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${DECODE_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for decode: ${DECODE_STEP_IDS:-unknown}"
+
 
 echo "Waiting for vLLM on $PREFILL_NODE and $DECODE_NODE to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8400/health" || exit 1
 wait_for_health "http://${DECODE_NODE}:8500/health" || exit 1
 
 echo "Starting router..."
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${PREFILL_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-helper \
     --output=__OUTPUT_DIR__/output/vllm-router.log \
     python3 /opt/vllm/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --host 0.0.0.0 --port 8300 --prefiller-hosts ${PREFILL_NODE} --prefiller-ports 8400 --decoder-hosts ${DECODE_NODE} --decoder-ports 8500 &
 HELPER_PID=$!
+HELPER_STEP_IDS=
+for _ in {1..10}; do
+    HELPER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-helper" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${HELPER_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for helper: ${HELPER_STEP_IDS:-unknown}"
+
 
 echo "Waiting for vLLM on $PREFILL_NODE server to be ready..."
 wait_for_health "http://${PREFILL_NODE}:8300/healthcheck" || exit 1

--- a/tests/ref_data/vllm-disagg.sbatch
+++ b/tests/ref_data/vllm-disagg.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_VLLM_DISAGG_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_VLLM_DISAGG_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: PREFILL_PID=$PREFILL_PID DECODE_PID=$DECODE_PID HELPER_PID=$HELPER_PID"
     echo "Cleaning up Slurm step IDs: PREFILL_STEP_IDS=$PREFILL_STEP_IDS DECODE_STEP_IDS=$DECODE_STEP_IDS HELPER_STEP_IDS=$HELPER_STEP_IDS"

--- a/tests/ref_data/vllm-multinode.sbatch
+++ b/tests/ref_data/vllm-multinode.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_VLLM_MULTINODE_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_VLLM_MULTINODE_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Stopping Ray clusters..."
     if [ -n "${SERVE_NODELIST:-}" ]; then

--- a/tests/ref_data/vllm-multinode.sbatch
+++ b/tests/ref_data/vllm-multinode.sbatch
@@ -15,6 +15,11 @@ srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N2 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=2 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Stopping Ray clusters..."
     if [ -n "${SERVE_NODELIST:-}" ]; then
         srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${SERVE_NODELIST}" --nodes=2 --ntasks=2 --ntasks-per-node=1 bash -lc 'ray stop --force >/dev/null 2>&1 || true' >/dev/null 2>&1 || true
@@ -22,20 +27,62 @@ cleanup() {
         echo "Skipping Ray stop for serve: node list is not set"
     fi
     echo "Cleaning up PIDs: SERVE_RAY_PID=$SERVE_RAY_PID SERVE_PID=$SERVE_PID"
+    echo "Cleaning up Slurm step IDs: SERVE_RAY_WORKER_STEP_IDS=$SERVE_RAY_WORKER_STEP_IDS SERVE_RAY_HEAD_STEP_IDS=$SERVE_RAY_HEAD_STEP_IDS"
 
-    for pid in "$SERVE_RAY_PID" "$SERVE_PID"; do
-        [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null
-    done
+    if [ -n "${SERVE_RAY_WORKER_STEP_IDS:-}" ]; then
+        for step_id in ${SERVE_RAY_WORKER_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${SERVE_RAY_PID:-}" ]; then
+        kill -TERM "${SERVE_RAY_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${SERVE_RAY_HEAD_STEP_IDS:-}" ]; then
+        for step_id in ${SERVE_RAY_HEAD_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${SERVE_PID:-}" ]; then
+        kill -TERM "${SERVE_PID}" 2>/dev/null || true
+    fi
 
-    for pid in "$SERVE_RAY_PID" "$SERVE_PID"; do
-        [ -z "$pid" ] && continue
+    if [ -n "${SERVE_RAY_PID:-}" ]; then
         i=0
-        while kill -0 "$pid" 2>/dev/null; do
-            [ "$i" -ge 15 ] && echo "PID $pid did not exit in time" && return 1
+        while kill -0 "${SERVE_RAY_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${SERVE_RAY_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${SERVE_RAY_WORKER_STEP_IDS:-}" ]; then
+                    for step_id in ${SERVE_RAY_WORKER_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${SERVE_RAY_PID:-}" ]; then
+                    kill -KILL "${SERVE_RAY_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
             sleep 1
             i=$((i+1))
         done
-    done
+    fi
+    if [ -n "${SERVE_PID:-}" ]; then
+        i=0
+        while kill -0 "${SERVE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${SERVE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${SERVE_RAY_HEAD_STEP_IDS:-}" ]; then
+                    for step_id in ${SERVE_RAY_HEAD_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${SERVE_PID:-}" ]; then
+                    kill -KILL "${SERVE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -74,7 +121,7 @@ echo "Starting vLLM instances..."
 (
     trap 'kill -TERM $(jobs -pr) 2>/dev/null' TERM EXIT
     for node in "${SERVE_NODES[@]:1}"; do
-        srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="$node" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+        srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="$node" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-serve-ray-worker \
             --output=__OUTPUT_DIR__/output/vllm-serve-ray-worker-%N.log \
             bash -lc 'ray stop --force >/dev/null 2>&1 || true
 for (( i=0; i < 300; i+=5 )); do
@@ -91,7 +138,16 @@ exit 1' &
     wait
 ) &
 SERVE_RAY_PID=$!
-srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${SERVE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 \
+SERVE_RAY_WORKER_STEP_IDS=
+for _ in {1..10}; do
+    SERVE_RAY_WORKER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-serve-ray-worker" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${SERVE_RAY_WORKER_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for serve-ray-worker: ${SERVE_RAY_WORKER_STEP_IDS:-unknown}"
+
+srun --export=ALL --mpi=none --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --nodelist="${SERVE_NODE}" --nodes=1 --ntasks=1 --ntasks-per-node=1 --job-name=cloudai-vllm-serve-ray-head \
     --output=__OUTPUT_DIR__/output/vllm-serve.log \
     --error=__OUTPUT_DIR__/output/vllm-serve-ray-head.log \
     bash -lc 'ray stop --force >/dev/null 2>&1 || true
@@ -112,6 +168,15 @@ done
 echo "Waiting for Ray workers timed out: $active_nodes/2 active"
 exit 1' &
 SERVE_PID=$!
+SERVE_RAY_HEAD_STEP_IDS=
+for _ in {1..10}; do
+    SERVE_RAY_HEAD_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-serve-ray-head" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${SERVE_RAY_HEAD_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for serve-ray-head: ${SERVE_RAY_HEAD_STEP_IDS:-unknown}"
+
 
 echo "Waiting for vLLM on $NODE to be ready..."
 wait_for_health "http://${NODE}:8300/healthcheck" || exit 1

--- a/tests/ref_data/vllm.sbatch
+++ b/tests/ref_data/vllm.sbatch
@@ -15,14 +15,42 @@ srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
+    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+        return 0
+    fi
+    CLOUDAI_CLEANUP_DONE=1
+    cleanup_status=0
     echo "Cleaning up PIDs: SERVE_PID=$SERVE_PID"
-    kill -TERM "$SERVE_PID" 2>/dev/null
-    i=0
-    while kill -0 "$SERVE_PID" 2>/dev/null; do
-        [ "$i" -ge 15 ] && echo "PID did not exit in time" && return 1
-        sleep 1
-        i=$((i+1))
-    done
+    echo "Cleaning up Slurm step IDs: SERVE_STEP_IDS=$SERVE_STEP_IDS"
+
+    if [ -n "${SERVE_STEP_IDS:-}" ]; then
+        for step_id in ${SERVE_STEP_IDS}; do
+            scancel --signal=TERM "$step_id" 2>/dev/null || true
+        done
+    elif [ -n "${SERVE_PID:-}" ]; then
+        kill -TERM "${SERVE_PID}" 2>/dev/null || true
+    fi
+
+    if [ -n "${SERVE_PID:-}" ]; then
+        i=0
+        while kill -0 "${SERVE_PID}" 2>/dev/null; do
+            if [ "$i" -ge 60 ]; then
+                echo "PID ${SERVE_PID} did not exit in time"
+                cleanup_status=1
+                if [ -n "${SERVE_STEP_IDS:-}" ]; then
+                    for step_id in ${SERVE_STEP_IDS}; do
+                        scancel --signal=KILL "$step_id" 2>/dev/null || true
+                    done
+                elif [ -n "${SERVE_PID:-}" ]; then
+                    kill -KILL "${SERVE_PID}" 2>/dev/null || true
+                fi
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+    fi
+    return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -45,10 +73,19 @@ wait_for_health() {
 }
 
 echo "Starting vLLM instances..."
-srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --ntasks-per-node=1 --ntasks=1 \
+srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --overlap --ntasks-per-node=1 --ntasks=1 --job-name=cloudai-vllm-serve \
     --output=__OUTPUT_DIR__/output/vllm-serve.log \
     vllm serve Qwen/Qwen3-0.6B --host 0.0.0.0 --port 8300 &
 SERVE_PID=$!
+SERVE_STEP_IDS=
+for _ in {1..10}; do
+    SERVE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID" --format="%i %j" 2>/dev/null | awk '$2 == "cloudai-vllm-serve" { print $1 }')
+    CLOUDAI_STEP_COUNT=$(printf '%s\n' "${SERVE_STEP_IDS}" | wc -w | tr -d ' ')
+    if [ "$CLOUDAI_STEP_COUNT" -ge 1 ]; then break; fi
+    sleep 1
+done
+echo "Slurm step IDs for serve: ${SERVE_STEP_IDS:-unknown}"
+
 
 NODE=$(scontrol show hostname $SLURM_JOB_NODELIST | head -n 1)
 echo "Waiting for vLLM on $NODE to be ready..."

--- a/tests/ref_data/vllm.sbatch
+++ b/tests/ref_data/vllm.sbatch
@@ -15,10 +15,10 @@ srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --
 srun --export=ALL --mpi=none -N1 --container-image=nvcr.io/nvidia/vllm:latest --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output,__INSTALL_DIR__/huggingface:/root/.cache/huggingface --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
 cleanup() {
-    if [ "${CLOUDAI_CLEANUP_DONE:-0}" = "1" ]; then
+    if [ "${CLOUDAI_VLLM_0_CLEANUP_DONE:-0}" = "1" ]; then
         return 0
     fi
-    CLOUDAI_CLEANUP_DONE=1
+    CLOUDAI_VLLM_0_CLEANUP_DONE=1
     cleanup_status=0
     echo "Cleaning up PIDs: SERVE_PID=$SERVE_PID"
     echo "Cleaning up Slurm step IDs: SERVE_STEP_IDS=$SERVE_STEP_IDS"

--- a/tests/workloads/common/test_llm_serving.py
+++ b/tests/workloads/common/test_llm_serving.py
@@ -269,13 +269,24 @@ class TestLLMServingSlurmHelpers:
 
         cleanup = strategy.generate_cleanup_function(["SERVE_PID"])
 
-        assert "CLOUDAI_CLEANUP_DONE=1" in cleanup
+        assert "CLOUDAI_LLM_0_CLEANUP_DONE=1" in cleanup
         assert "SERVE_STEP_IDS=$SERVE_STEP_IDS" in cleanup
         assert 'scancel --signal=TERM "$step_id"' in cleanup
         assert 'kill -TERM "${SERVE_PID}"' in cleanup
         assert 'if [ "$i" -ge 60 ]; then' in cleanup
         assert 'scancel --signal=KILL "$step_id"' in cleanup
         assert 'kill -KILL "${SERVE_PID}"' in cleanup
+
+    def test_cleanup_guard_is_unique_per_test_run(self, slurm_system: SlurmSystem, tmp_path: Path) -> None:
+        first = TestRun(name="llm.first", test=make_tdef(), num_nodes=1, nodes=[], output_path=tmp_path / "first")
+        second = TestRun(name="llm.second", test=make_tdef(), num_nodes=1, nodes=[], output_path=tmp_path / "second")
+
+        first_cleanup = FakeLLMSlurmStrategy(slurm_system, first).generate_cleanup_function(["SERVE_PID"])
+        second_cleanup = FakeLLMSlurmStrategy(slurm_system, second).generate_cleanup_function(["SERVE_PID"])
+
+        assert "CLOUDAI_LLM_FIRST_0_CLEANUP_DONE=1" in first_cleanup
+        assert "CLOUDAI_LLM_SECOND_0_CLEANUP_DONE=1" in second_cleanup
+        assert "CLOUDAI_LLM_FIRST_0_CLEANUP_DONE" not in second_cleanup
 
     def test_aggregated_serving_names_and_discovers_slurm_step(self, slurm_system: SlurmSystem, tmp_path: Path) -> None:
         tdef = make_tdef()

--- a/tests/workloads/common/test_llm_serving.py
+++ b/tests/workloads/common/test_llm_serving.py
@@ -260,6 +260,52 @@ class TestLLMServingTestDefinitionBehavior:
 
 
 class TestLLMServingSlurmHelpers:
+    def test_cleanup_prefers_slurm_steps_and_keeps_pid_fallback(
+        self, slurm_system: SlurmSystem, tmp_path: Path
+    ) -> None:
+        tdef = make_tdef()
+        tr = TestRun(name="llm", test=tdef, num_nodes=1, nodes=[], output_path=tmp_path)
+        strategy = FakeLLMSlurmStrategy(slurm_system, tr)
+
+        cleanup = strategy.generate_cleanup_function(["SERVE_PID"])
+
+        assert "CLOUDAI_CLEANUP_DONE=1" in cleanup
+        assert "SERVE_STEP_IDS=$SERVE_STEP_IDS" in cleanup
+        assert 'scancel --signal=TERM "$step_id"' in cleanup
+        assert 'kill -TERM "${SERVE_PID}"' in cleanup
+        assert 'if [ "$i" -ge 60 ]; then' in cleanup
+        assert 'scancel --signal=KILL "$step_id"' in cleanup
+        assert 'kill -KILL "${SERVE_PID}"' in cleanup
+
+    def test_aggregated_serving_names_and_discovers_slurm_step(self, slurm_system: SlurmSystem, tmp_path: Path) -> None:
+        tdef = make_tdef()
+        tr = TestRun(name="llm", test=tdef, num_nodes=1, nodes=[], output_path=tmp_path)
+        strategy = FakeLLMSlurmStrategy(slurm_system, tr)
+
+        script = LLMServingSlurmCommandGenStrategy._gen_aggregated_script(strategy, ["serve"], "bench")
+
+        assert "--job-name=cloudai-fake-llm-serve" in script
+        assert 'SERVE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in script
+        assert "awk '$2 == \"cloudai-fake-llm-serve\" { print $1 }'" in script
+        assert 'echo "Slurm step IDs for serve: ${SERVE_STEP_IDS:-unknown}"' in script
+
+    def test_disaggregated_serving_names_and_discovers_slurm_steps(
+        self, slurm_system: SlurmSystem, tmp_path: Path
+    ) -> None:
+        tdef = make_tdef(create_prefill=True)
+        tdef.extra_env_vars = {"CUDA_VISIBLE_DEVICES": "0,1,2,3"}
+        tr = TestRun(name="llm", test=tdef, num_nodes=2, nodes=[], output_path=tmp_path)
+        strategy = FakeLLMSlurmStrategy(slurm_system, tr)
+
+        script = strategy._gen_disaggregated_script([["prefill"], ["decode"]], "bench")
+
+        assert "--job-name=cloudai-fake-llm-prefill" in script
+        assert "--job-name=cloudai-fake-llm-decode" in script
+        assert "--job-name=cloudai-fake-llm-helper" in script
+        assert 'PREFILL_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in script
+        assert 'DECODE_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in script
+        assert 'HELPER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in script
+
     def test_two_node_disagg_uses_shared_gpu_ids_and_role_hosts(self, slurm_system: SlurmSystem, tmp_path) -> None:
         tdef = make_tdef(create_prefill=True)
         tdef.extra_env_vars = {"CUDA_VISIBLE_DEVICES": "0,1,2,3"}

--- a/tests/workloads/vllm/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/vllm/test_command_gen_strategy_slurm.py
@@ -391,6 +391,18 @@ class TestVllmDisaggregatedMode:
         assert 'DECODE_NODES=( "${NODES[@]:2:2}" )' in srun_command
         assert "PREFILL_RAY_PID=$!" in srun_command
         assert "DECODE_RAY_PID=$!" in srun_command
+        assert "--job-name=cloudai-vllm-prefill-ray-worker" in srun_command
+        assert "--job-name=cloudai-vllm-prefill-ray-head" in srun_command
+        assert "--job-name=cloudai-vllm-decode-ray-worker" in srun_command
+        assert "--job-name=cloudai-vllm-decode-ray-head" in srun_command
+        assert 'PREFILL_RAY_WORKER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in srun_command
+        assert 'PREFILL_RAY_HEAD_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in srun_command
+        assert 'DECODE_RAY_WORKER_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in srun_command
+        assert 'DECODE_RAY_HEAD_STEP_IDS=$(squeue --noheader --steps --job "$SLURM_JOB_ID"' in srun_command
+        assert "Stopping Ray clusters..." in srun_command
+        assert "Cleaning up Slurm step IDs: PREFILL_RAY_WORKER_STEP_IDS=$PREFILL_RAY_WORKER_STEP_IDS" in srun_command
+        assert "PREFILL_RAY_HEAD_STEP_IDS=$PREFILL_RAY_HEAD_STEP_IDS" in srun_command
+        assert 'scancel --signal=TERM "$step_id"' in srun_command
         assert srun_command.count('sum(node["Alive"] for node in ray.nodes())') == 2
         assert "ray.init(address=" not in srun_command
         assert 'env RAY_ADDRESS="${PREFILL_NODE}:${PREFILL_RAY_PORT}"' in srun_command


### PR DESCRIPTION
## Summary
CloudAI cleanup currently sends SIGTERM directly to tracked process IDs such as PREFILL_PID, DECODE_PID, and HELPER_PID. In Slurm-based runs, those PIDs can correspond to srun processes rather than the actual vLLM processes running inside the Slurm job/container. Testing indicates that kill -TERM <srun_pid> does not reliably propagate SIGTERM to the internal processes launched by srun.

As a result, vLLM may not receive a graceful termination signal. This prevents the shutdown path from completing correctly through vLLM, NIXL, and UCX, and can cause runtime statistics to be lost.

## Test Plan
- Automated CI
- Manual runs (with single sbatch) on different types of scheduling for both vLLM and SGLang:

   - agg
   - disagg
   - single-node
   - multi-node

## Additional Notes
-
