### PR TITLE
[NCCL] Handle malformed NCCL metric rows

### DIFF
--- a/src/cloudai/workloads/nccl_test/performance_report_generation_strategy.py
+++ b/src/cloudai/workloads/nccl_test/performance_report_generation_strategy.py
@@ -28,10 +28,25 @@ from cloudai.report_generator.tool.csv_report_tool import CSVReportTool
 from cloudai.report_generator.util import add_human_readable_sizes
 from cloudai.util.lazy_imports import lazy
 
+from .report_generation_strategy import NcclTestReportGenerationStrategy
+
 if TYPE_CHECKING:
     import pandas as pd
 
-from .report_generation_strategy import NcclTestReportGenerationStrategy
+
+NUMERIC_DATA_COLUMNS = [
+    "Size (B)",
+    "Time (us) Out-of-place",
+    "Algbw (GB/s) Out-of-place",
+    "Busbw (GB/s) Out-of-place",
+    "Time (us) In-place",
+    "Algbw (GB/s) In-place",
+    "Busbw (GB/s) In-place",
+]
+TIME_DATA_COLUMNS = [
+    "Time (us) Out-of-place",
+    "Time (us) In-place",
+]
 
 
 def _parse_data_rows(file: TextIOWrapper) -> List[List[str]]:
@@ -130,13 +145,15 @@ class NcclTestPerformanceReportGenerationStrategy(NcclTestReportGenerationStrate
         df["Devices per Node"] = num_devices_per_node
         df["Ranks"] = num_ranks
 
+        for col in NUMERIC_DATA_COLUMNS:
+            df[col] = lazy.pd.to_numeric(df[col], errors="coerce")
+        df = df.dropna(subset=NUMERIC_DATA_COLUMNS).copy()
+        if df.empty:
+            return df
+
         df["Size (B)"] = df["Size (B)"].astype(int)
-        df["Time (us) Out-of-place"] = df["Time (us) Out-of-place"].astype(float).round(2)
-        df["Time (us) In-place"] = df["Time (us) In-place"].astype(float).round(2)
-        df["Algbw (GB/s) Out-of-place"] = df["Algbw (GB/s) Out-of-place"].astype(float)
-        df["Busbw (GB/s) Out-of-place"] = df["Busbw (GB/s) Out-of-place"].astype(float)
-        df["Algbw (GB/s) In-place"] = df["Algbw (GB/s) In-place"].astype(float)
-        df["Busbw (GB/s) In-place"] = df["Busbw (GB/s) In-place"].astype(float)
+        for col in TIME_DATA_COLUMNS:
+            df[col] = df[col].round(2)
 
         df = add_human_readable_sizes(df, "Size (B)", "Size Human-readable")
 

--- a/tests/workloads/nccl_test/test_performance_report_gen_strategy.py
+++ b/tests/workloads/nccl_test/test_performance_report_gen_strategy.py
@@ -24,7 +24,7 @@ from cloudai.core import METRIC_ERROR
 from cloudai.systems.slurm.slurm_system import SlurmSystem
 from cloudai.util.lazy_imports import lazy
 from cloudai.workloads.nccl_test import NcclTestPerformanceReportGenerationStrategy
-from cloudai.workloads.nccl_test.performance_report_generation_strategy import _parse_device_info
+from cloudai.workloads.nccl_test.performance_report_generation_strategy import _parse_device_info, extract_nccl_data
 
 
 @pytest.fixture
@@ -111,3 +111,20 @@ def test_get_metric(
     res = report_strategy.get_metric(metric)
     assert res is not None and res != METRIC_ERROR
     assert res == lazy.np.mean(ref_values)
+
+
+def test_get_metric_returns_metric_error_for_malformed_numeric_row(
+    report_strategy: NcclTestPerformanceReportGenerationStrategy, nccl_tr: TestRun
+) -> None:
+    (nccl_tr.output_path / "stdout.txt").write_text(
+        """# Rank  0 Group  0 Pid 1000 on node1 device  0 [0xaa] NVIDIA H100
+#
+#                                                              out-of-place                       in-place
+#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
+         8             2       float     sum      -1    NaNbad  2.0     3.0       0    1.0     2.0     3.0       0
+# Avg bus bandwidth    : 111.111
+"""
+    )
+    extract_nccl_data.cache_clear()
+
+    assert report_strategy.get_metric("default") is METRIC_ERROR


### PR DESCRIPTION
## Summary

Fix NCCL metric parsing for malformed `stdout.txt` rows.

Root cause: parser accepted any digit-starting 13-field row, then unchecked `astype(int/float)` raised on bad numeric values like `NaNbad`.

Fix: coerce numeric columns, drop invalid rows, return `METRIC_ERROR` when no valid metric data remains. DSE now follows `rewards.metric_failure` path instead of crashing.

## Test Plan

- Automated CI

## Additional Notes

-
