### PR TITLE
Report run status from Slurm exit code in SlurmContainer

### DIFF
--- a/doc/workloads/slurm_container.rst
+++ b/doc/workloads/slurm_container.rst
@@ -15,7 +15,7 @@ Test TOML example:
    test_template_name = "SlurmContainer"
 
    [cmd_args]
-   image_path = "/path/to/container.sqsh"
+   docker_image_url = "/path/to/container.sqsh"
    cmd = "python train.py"
 
 Test Scenario example:
@@ -47,8 +47,16 @@ Test-in-Scenario example:
    test_template_name = "SlurmContainer"
 
      [Tests.cmd_args]
-     image_path = "/path/to/container.sqsh"
+     docker_image_url = "/path/to/container.sqsh"
      cmd = "python train.py"
+
+Run Status
+----------
+
+CloudAI determines success by reading the per-test ``exit_code.txt`` file from
+the test output directory. Only integer ``0`` is successful. Any non-zero
+integer, or a missing, malformed, unreadable, or undecodable file, marks the run
+as failed. Slurm-style exit code ``0:0`` is not accepted.
 
 API Documentation
 -----------------

--- a/doc/workloads/slurm_container.rst
+++ b/doc/workloads/slurm_container.rst
@@ -15,6 +15,7 @@ Test TOML example:
    test_template_name = "SlurmContainer"
 
    [cmd_args]
+   check_exit_code = true
    docker_image_url = "/path/to/container.sqsh"
    cmd = "python train.py"
 
@@ -47,16 +48,19 @@ Test-in-Scenario example:
    test_template_name = "SlurmContainer"
 
      [Tests.cmd_args]
+     check_exit_code = true
      docker_image_url = "/path/to/container.sqsh"
      cmd = "python train.py"
 
 Run Status
 ----------
 
-CloudAI determines success by reading the per-test ``exit_code.txt`` file from
-the test output directory. Only integer ``0`` is successful. Any non-zero
-integer, or a missing, malformed, unreadable, or undecodable file, marks the run
-as failed. Slurm-style exit code ``0:0`` is not accepted.
+Exit-code checking is disabled by default for backwards compatibility. Set
+``check_exit_code = true`` in ``cmd_args`` to record the aggregate ``srun`` exit
+code in the per-test ``exit_code.txt`` file and use it to determine success.
+Only integer ``0`` is successful. Any non-zero integer, or a missing, malformed,
+unreadable, or undecodable file, marks the run as failed. Slurm-style exit code
+``0:0`` is not accepted.
 
 API Documentation
 -----------------

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shlex
 from typing import cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
@@ -40,18 +41,20 @@ class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
         tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test)
         return [*cmd, *tdef.extra_srun_args]
 
+    def _gen_srun_command(self) -> str:
+        srun_command = super()._gen_srun_command()
+        exit_code_path = shlex.quote(str((self.test_run.output_path / EXIT_CODE_FILE_NAME).absolute()))
+        return (
+            f"{srun_command}; "
+            "rc=$?; "
+            f"""printf '%s\\n' "$rc" > {exit_code_path}; """
+            """(exit "$rc")"""
+        )
+
     def generate_test_command(self) -> list[str]:
         tdef: SlurmContainerTestDefinition = cast(SlurmContainerTestDefinition, self.test_run.test)
         command_parts: list[str] = [*super().gen_nsys_command(), tdef.cmd_args.cmd]
         if self.test_run.test.extra_cmd_args:
             command_parts.append(self.test_run.test.extra_args_str)
 
-        command = " ".join(command_parts)
-        wrapped_command = (
-            f"( {command} ); "
-            r"rc=\$?; "
-            rf"printf '%s\n' \"\$rc\" > /cloudai_run_results/{EXIT_CODE_FILE_NAME}; "
-            r"exit \"\$rc\""
-        )
-
-        return [wrapped_command]
+        return command_parts

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,7 @@ from typing import cast
 
 from cloudai.systems.slurm import SlurmCommandGenStrategy
 
-from .slurm_container import SlurmContainerTestDefinition
+from .slurm_container import EXIT_CODE_FILE_NAME, SlurmContainerTestDefinition
 
 
 class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
@@ -46,4 +46,12 @@ class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
         if self.test_run.test.extra_cmd_args:
             command_parts.append(self.test_run.test.extra_args_str)
 
-        return command_parts
+        command = " ".join(command_parts)
+        wrapped_command = (
+            f"( {command} ); "
+            r"rc=\$?; "
+            rf"printf '%s\n' \"\$rc\" > /cloudai_run_results/{EXIT_CODE_FILE_NAME}; "
+            r"exit \"\$rc\""
+        )
+
+        return [wrapped_command]

--- a/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/slurm_container/slurm_command_gen_strategy.py
@@ -43,6 +43,10 @@ class SlurmContainerCommandGenStrategy(SlurmCommandGenStrategy):
 
     def _gen_srun_command(self) -> str:
         srun_command = super()._gen_srun_command()
+        tdef = cast(SlurmContainerTestDefinition, self.test_run.test)
+        if not tdef.cmd_args.check_exit_code:
+            return srun_command
+
         exit_code_path = shlex.quote(str((self.test_run.output_path / EXIT_CODE_FILE_NAME).absolute()))
         return (
             f"{srun_command}; "

--- a/src/cloudai/workloads/slurm_container/slurm_container.py
+++ b/src/cloudai/workloads/slurm_container/slurm_container.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,10 @@ from typing import Optional
 
 from pydantic import Field
 
-from cloudai.core import DockerImage, File, Installable
+from cloudai.core import DockerImage, File, Installable, JobStatusResult, TestRun
 from cloudai.models.workload import CmdArgs, TestDefinition
+
+EXIT_CODE_FILE_NAME = "exit_code.txt"
 
 
 class SlurmContainerCmdArgs(CmdArgs):
@@ -53,3 +55,36 @@ class SlurmContainerTestDefinition(TestDefinition):
         for k, v in self.extra_cmd_args.items():
             parts.append(f"{k} {v}" if v else k)
         return " ".join(parts)
+
+    def was_run_successful(self, tr: TestRun) -> JobStatusResult:
+        """Grade the run from the container command exit code."""
+        exit_code_path = tr.output_path / EXIT_CODE_FILE_NAME
+        if not exit_code_path.is_file():
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"Exit code file {exit_code_path} not found.",
+            )
+
+        try:
+            exit_code_text = exit_code_path.read_text(encoding="utf-8").strip()
+        except (OSError, UnicodeDecodeError) as err:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"Could not read exit code file {exit_code_path}: {err}.",
+            )
+
+        try:
+            exit_code = int(exit_code_text)
+        except ValueError:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"Could not parse exit code from {exit_code_path}: {exit_code_text!r}.",
+            )
+
+        if exit_code != 0:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"Container command exited with code {exit_code}.",
+            )
+
+        return JobStatusResult(is_successful=True)

--- a/src/cloudai/workloads/slurm_container/slurm_container.py
+++ b/src/cloudai/workloads/slurm_container/slurm_container.py
@@ -29,6 +29,10 @@ class SlurmContainerCmdArgs(CmdArgs):
 
     docker_image_url: str
     cmd: str
+    check_exit_code: bool = Field(
+        default=False,
+        description="Whether to grade the run from the container command exit code.",
+    )
 
 
 class SlurmContainerTestDefinition(TestDefinition):
@@ -58,6 +62,9 @@ class SlurmContainerTestDefinition(TestDefinition):
 
     def was_run_successful(self, tr: TestRun) -> JobStatusResult:
         """Grade the run from the container command exit code."""
+        if not self.cmd_args.check_exit_code:
+            return JobStatusResult(is_successful=True)
+
         exit_code_path = tr.output_path / EXIT_CODE_FILE_NAME
         if not exit_code_path.is_file():
             return JobStatusResult(

--- a/tests/ref_data/slurm_container.sbatch
+++ b/tests/ref_data/slurm_container.sbatch
@@ -14,4 +14,4 @@ srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --containe
 
 srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
-srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; pwd ; ls"
+srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ( pwd ; ls ); rc=\$?; printf '%s\n' \"\$rc\" > /cloudai_run_results/exit_code.txt; exit \"\$rc\""

--- a/tests/ref_data/slurm_container.sbatch
+++ b/tests/ref_data/slurm_container.sbatch
@@ -14,4 +14,4 @@ srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --containe
 
 srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
-srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; ( pwd ; ls ); rc=\$?; printf '%s\n' \"\$rc\" > /cloudai_run_results/exit_code.txt; exit \"\$rc\""
+srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; pwd ; ls"; rc=$?; printf '%s\n' "$rc" > __OUTPUT_DIR__/output/exit_code.txt; (exit "$rc")

--- a/tests/ref_data/slurm_container.sbatch
+++ b/tests/ref_data/slurm_container.sbatch
@@ -14,4 +14,4 @@ srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --containe
 
 srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output --ntasks=1 --ntasks-per-node=1 --output=__OUTPUT_DIR__/output/metadata/node-%N.toml --error=__OUTPUT_DIR__/output/metadata/nodes.err bash /cloudai_install/slurm-metadata.sh
 
-srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; pwd ; ls"; rc=$?; printf '%s\n' "$rc" > __OUTPUT_DIR__/output/exit_code.txt; (exit "$rc")
+srun --export=ALL --mpi=pmix -N1 --container-image=https://docker/url --container-mounts=__OUTPUT_DIR__/output:/cloudai_run_results,__OUTPUT_DIR__/install:/cloudai_install,__OUTPUT_DIR__/output bash -c "source __OUTPUT_DIR__/output/env_vars.sh; pwd ; ls"

--- a/tests/workloads/slurm_container/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/slurm_container/test_command_gen_strategy_slurm.py
@@ -18,14 +18,24 @@ from typing import cast
 
 import pytest
 
-from cloudai.core import TestRun
+from cloudai.core import TestRun, TestScenario
 from cloudai.models.workload import NsysConfiguration
-from cloudai.systems.slurm import SlurmSystem
+from cloudai.systems.slurm import SingleSbatchRunner, SlurmSystem
 from cloudai.workloads.slurm_container import (
     SlurmContainerCmdArgs,
     SlurmContainerCommandGenStrategy,
     SlurmContainerTestDefinition,
 )
+from cloudai.workloads.slurm_container.slurm_container import EXIT_CODE_FILE_NAME
+
+
+def _wrapped_command(command: str) -> str:
+    return (
+        f"( {command} ); "
+        r"rc=\$?; "
+        rf"printf '%s\n' \"\$rc\" > /cloudai_run_results/{EXIT_CODE_FILE_NAME}; "
+        r"exit \"\$rc\""
+    )
 
 
 @pytest.fixture
@@ -52,7 +62,9 @@ def test_default(slurm_system: SlurmSystem, test_run: TestRun) -> None:
         f"--no-container-mount-home"
     )
 
-    assert cmd == f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; cmd"'
+    assert cmd == (
+        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; {_wrapped_command("cmd")}"'
+    )
 
 
 def test_with_nsys(slurm_system: SlurmSystem, test_run: TestRun) -> None:
@@ -70,7 +82,10 @@ def test_with_nsys(slurm_system: SlurmSystem, test_run: TestRun) -> None:
         f"--no-container-mount-home"
     )
 
-    assert cmd == f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; nsys profile cmd"'
+    assert cmd == (
+        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; '
+        f'{_wrapped_command("nsys profile cmd")}"'
+    )
 
 
 def test_with_extra_srun_args(slurm_system: SlurmSystem, test_run: TestRun) -> None:
@@ -91,4 +106,23 @@ def test_with_extra_srun_args(slurm_system: SlurmSystem, test_run: TestRun) -> N
         f"{' '.join(extra_args)}"
     )
 
-    assert cmd == f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; cmd"'
+    assert cmd == (
+        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; {_wrapped_command("cmd")}"'
+    )
+
+
+def test_single_sbatch_writes_exit_code_to_per_test_output(slurm_system: SlurmSystem, test_run: TestRun) -> None:
+    test_run.output_path = slurm_system.output_path / "single-batch"
+    test_run.output_path.mkdir(parents=True)
+    scenario = TestScenario(name="tc", test_runs=[test_run])
+    runner = SingleSbatchRunner(
+        mode="run",
+        system=slurm_system,
+        test_scenario=scenario,
+        output_path=slurm_system.output_path,
+    )
+
+    block = runner.get_single_tr_block(test_run)
+
+    assert f"{test_run.output_path.absolute()}:/cloudai_run_results" in block
+    assert f"/cloudai_run_results/{EXIT_CODE_FILE_NAME}" in block

--- a/tests/workloads/slurm_container/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/slurm_container/test_command_gen_strategy_slurm.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shlex
 from typing import cast
 
 import pytest
@@ -29,12 +30,12 @@ from cloudai.workloads.slurm_container import (
 from cloudai.workloads.slurm_container.slurm_container import EXIT_CODE_FILE_NAME
 
 
-def _wrapped_command(command: str) -> str:
+def _status_capture(test_run: TestRun) -> str:
+    exit_code_path = shlex.quote(str((test_run.output_path / EXIT_CODE_FILE_NAME).absolute()))
     return (
-        f"( {command} ); "
-        r"rc=\$?; "
-        rf"printf '%s\n' \"\$rc\" > /cloudai_run_results/{EXIT_CODE_FILE_NAME}; "
-        r"exit \"\$rc\""
+        "; rc=$?; "
+        f"""printf '%s\\n' "$rc" > {exit_code_path}; """
+        """(exit "$rc")"""
     )
 
 
@@ -63,7 +64,8 @@ def test_default(slurm_system: SlurmSystem, test_run: TestRun) -> None:
     )
 
     assert cmd == (
-        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; {_wrapped_command("cmd")}"'
+        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; cmd"'
+        f"{_status_capture(test_run)}"
     )
 
 
@@ -83,8 +85,8 @@ def test_with_nsys(slurm_system: SlurmSystem, test_run: TestRun) -> None:
     )
 
     assert cmd == (
-        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; '
-        f'{_wrapped_command("nsys profile cmd")}"'
+        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; nsys profile cmd"'
+        f"{_status_capture(test_run)}"
     )
 
 
@@ -107,7 +109,8 @@ def test_with_extra_srun_args(slurm_system: SlurmSystem, test_run: TestRun) -> N
     )
 
     assert cmd == (
-        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; {_wrapped_command("cmd")}"'
+        f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; cmd"'
+        f"{_status_capture(test_run)}"
     )
 
 
@@ -125,4 +128,19 @@ def test_single_sbatch_writes_exit_code_to_per_test_output(slurm_system: SlurmSy
     block = runner.get_single_tr_block(test_run)
 
     assert f"{test_run.output_path.absolute()}:/cloudai_run_results" in block
-    assert f"/cloudai_run_results/{EXIT_CODE_FILE_NAME}" in block
+    assert str((test_run.output_path / EXIT_CODE_FILE_NAME).absolute()) in block
+    assert f"/cloudai_run_results/{EXIT_CODE_FILE_NAME}" not in block
+
+
+def test_multi_task_run_records_one_aggregate_srun_status(slurm_system: SlurmSystem, test_run: TestRun) -> None:
+    tdef = cast(SlurmContainerTestDefinition, test_run.test)
+    tdef.extra_srun_args = ["--ntasks=2"]
+    tdef.cmd_args.cmd = r"bash -c 'exit \$SLURM_PROCID'"
+    cgs = SlurmContainerCommandGenStrategy(slurm_system, test_run)
+
+    cmd = cgs.gen_srun_command()
+    exit_code_path = str((test_run.output_path / EXIT_CODE_FILE_NAME).absolute())
+
+    assert "--ntasks=2" in cmd
+    assert r"""bash -c 'exit \$SLURM_PROCID'"; rc=$?;""" in cmd
+    assert cmd.count(exit_code_path) == 1

--- a/tests/workloads/slurm_container/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/slurm_container/test_command_gen_strategy_slurm.py
@@ -45,7 +45,7 @@ def test_run() -> TestRun:
         name="sc",
         description="desc",
         test_template_name="tt",
-        cmd_args=SlurmContainerCmdArgs(docker_image_url="docker://url", cmd="cmd"),
+        cmd_args=SlurmContainerCmdArgs(docker_image_url="docker://url", cmd="cmd", check_exit_code=True),
     )
     tr = TestRun(name="name", test=tdef, num_nodes=1, nodes=[])
     return tr
@@ -67,6 +67,16 @@ def test_default(slurm_system: SlurmSystem, test_run: TestRun) -> None:
         f'{srun_part} bash -c "source {(test_run.output_path / "env_vars.sh").absolute()}; cmd"'
         f"{_status_capture(test_run)}"
     )
+
+
+def test_exit_code_check_disabled_does_not_capture_status(slurm_system: SlurmSystem, test_run: TestRun) -> None:
+    tdef = cast(SlurmContainerTestDefinition, test_run.test)
+    tdef.cmd_args.check_exit_code = False
+    cgs = SlurmContainerCommandGenStrategy(slurm_system, test_run)
+
+    cmd = cgs.gen_srun_command()
+
+    assert EXIT_CODE_FILE_NAME not in cmd
 
 
 def test_with_nsys(slurm_system: SlurmSystem, test_run: TestRun) -> None:

--- a/tests/workloads/slurm_container/test_slurm_container.py
+++ b/tests/workloads/slurm_container/test_slurm_container.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from cloudai.core import TestRun
+from cloudai.workloads.slurm_container import SlurmContainerCmdArgs, SlurmContainerTestDefinition
+from cloudai.workloads.slurm_container.slurm_container import EXIT_CODE_FILE_NAME
+
+
+class TestSlurmContainerSuccessCheck:
+    def setup_method(self) -> None:
+        self.tdef = SlurmContainerTestDefinition(
+            name="sc",
+            description="desc",
+            test_template_name="SlurmContainer",
+            cmd_args=SlurmContainerCmdArgs(docker_image_url="docker://url", cmd="bash /scripts/run.sh"),
+        )
+
+    def _write_exit_code(self, tr: TestRun, exit_code: str) -> None:
+        tr.output_path.mkdir(parents=True, exist_ok=True)
+        (tr.output_path / EXIT_CODE_FILE_NAME).write_text(exit_code, encoding="utf-8")
+
+    def test_missing_exit_code_fails(self, base_tr: TestRun) -> None:
+        result = self.tdef.was_run_successful(base_tr)
+
+        assert not result.is_successful
+        assert EXIT_CODE_FILE_NAME in result.error_message
+        assert "not found" in result.error_message
+
+    @pytest.mark.parametrize(
+        ("exit_code", "is_successful"),
+        [
+            ("0", True),
+            ("0\n", True),
+            ("1", False),
+            ("42", False),
+            ("137", False),
+        ],
+    )
+    def test_exit_code_is_honored(self, base_tr: TestRun, exit_code: str, is_successful: bool) -> None:
+        self._write_exit_code(base_tr, exit_code)
+
+        result = self.tdef.was_run_successful(base_tr)
+
+        assert result.is_successful is is_successful
+        if not is_successful:
+            assert exit_code.strip() in result.error_message
+
+    def test_malformed_exit_code_is_reported(self, base_tr: TestRun) -> None:
+        self._write_exit_code(base_tr, "not-a-number")
+
+        result = self.tdef.was_run_successful(base_tr)
+
+        assert not result.is_successful
+        assert "Could not parse exit code" in result.error_message
+
+    def test_unreadable_exit_code_is_reported(self, base_tr: TestRun) -> None:
+        self._write_exit_code(base_tr, "0")
+
+        with patch("pathlib.Path.read_text", side_effect=PermissionError("permission denied")):
+            result = self.tdef.was_run_successful(base_tr)
+
+        assert not result.is_successful
+        assert "Could not read exit code file" in result.error_message
+
+    def test_undecodable_exit_code_is_reported(self, base_tr: TestRun) -> None:
+        base_tr.output_path.mkdir(parents=True, exist_ok=True)
+        (base_tr.output_path / EXIT_CODE_FILE_NAME).write_bytes(b"\xff\xfe\x00")
+
+        result = self.tdef.was_run_successful(base_tr)
+
+        assert not result.is_successful
+        assert "Could not read exit code file" in result.error_message

--- a/tests/workloads/slurm_container/test_slurm_container.py
+++ b/tests/workloads/slurm_container/test_slurm_container.py
@@ -29,8 +29,26 @@ class TestSlurmContainerSuccessCheck:
             name="sc",
             description="desc",
             test_template_name="SlurmContainer",
+            cmd_args=SlurmContainerCmdArgs(
+                docker_image_url="docker://url",
+                cmd="bash /scripts/run.sh",
+                check_exit_code=True,
+            ),
+        )
+
+    def test_exit_code_check_disabled_by_default(self, base_tr: TestRun) -> None:
+        tdef = SlurmContainerTestDefinition(
+            name="sc",
+            description="desc",
+            test_template_name="SlurmContainer",
             cmd_args=SlurmContainerCmdArgs(docker_image_url="docker://url", cmd="bash /scripts/run.sh"),
         )
+        self._write_exit_code(base_tr, "42")
+
+        result = tdef.was_run_successful(base_tr)
+
+        assert getattr(tdef.cmd_args, "check_exit_code", None) is False
+        assert result.is_successful
 
     def _write_exit_code(self, tr: TestRun, exit_code: str) -> None:
         tr.output_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Grade the run via was_run_successful() - now based on the per-test exit_code.txt file (non-zero = FAILED).

## Summary
Every run of SlurmContainer workload was reported **PASSED** in the scenario summary regardless of what the
container actually did. Grade the run from the container real exit code, which CloudAI already records in `slurm-job.toml`

Implement `was_run_successful()` to grade each run from the container command's actual exit code. The generated command writes the exit code to a per-test `exit_code.txt` file, allowing accurate reporting in both regular and single-sbatch modes without changes to user scripts or container images.

## Test Plan

<details> <summary>Scenario TOML </summary>

```
name = "Verify.SlurmContainer.StatusCheck"
job_status_check = false

[[Tests]]
id = "Verify.SlurmContainer.Pass"
name = "slurmcontainer-pass"
description = "Should be reported PASSED (exit 0)"
test_template_name = "SlurmContainer"
num_nodes = 1
time_limit = "00:05:00"
extra_srun_args = "--ntasks-per-node=1"

  [Tests.cmd_args]
  docker_image_url = "nvcr.io#nvidia/cuda:12.9.1-devel-ubuntu24.04"
  cmd = "bash -c 'echo PASS-CASE; exit 0'"

[[Tests]]
id = "Verify.SlurmContainer.Fail"
name = "slurmcontainer-fail"
description = "Should be reported FAILED (exit 42)"
test_template_name = "SlurmContainer"
num_nodes = 1
time_limit = "00:05:00"
extra_srun_args = "--ntasks-per-node=1"

  [Tests.cmd_args]
  docker_image_url = "nvcr.io#nvidia/cuda:12.9.1-devel-ubuntu24.04"
  cmd = "bash -c 'echo FAIL-CASE; exit 42'"
```
</details>

<details>
<summary>CloudAI run</summary>

```

[INFO] System Name: ...
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: Verify.SlurmContainer.StatusCheck
[INFO] Checking if workloads components are installed.
[INFO] Test Scenario: Verify.SlurmContainer.StatusCheck

Section Name: Verify.SlurmContainer.Pass
  Test Name: slurmcontainer-pass
  Description: Should be reported PASSED (exit 0)
  No dependencies
Section Name: Verify.SlurmContainer.Fail
  Test Name: slurmcontainer-fail
  Description: Should be reported FAILED (exit 42)
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Scenario results will be stored at: results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03
[INFO] Starting test: Verify.SlurmContainer.Pass (results at: results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03/Verify.SlurmContainer.Pass/0)
[INFO] Running test: Verify.SlurmContainer.Pass
[INFO] Submitted slurm job: 74658
[INFO] Starting test: Verify.SlurmContainer.Fail (results at: results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03/Verify.SlurmContainer.Fail/0)
[INFO] Running test: Verify.SlurmContainer.Fail
[INFO] Submitted slurm job: 74659
[INFO] Job completed: Verify.SlurmContainer.Pass (iteration 1 of 1)
[ERROR] Job 74659 for test Verify.SlurmContainer.Fail failed: Container command exited with code 42.
[INFO] Job completed: Verify.SlurmContainer.Fail (iteration 1 of 1)
[INFO] Generated scenario report at results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03/Verify.SlurmContainer.StatusCheck.html
[INFO] Scenario results                                                                                                                    
╔════════════════════════════╤════════╤════════════════════════════════════════════════════════════════════════════════════════════╗
║ Case                       │ Status │ Details                                                                                    ║
╟────────────────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────────╢
║ Verify.SlurmContainer.Pass │ PASSED │ results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03/Verify.SlurmContainer.Pass/0 ║
╟────────────────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────────╢
║ Verify.SlurmContainer.Fail │ FAILED │ results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03/Verify.SlurmContainer.Fail/0 ║
║                            │        │ Container command exited with code 42.                                                     ║
╚════════════════════════════╧════════╧════════════════════════════════════════════════════════════════════════════════════════════╝

[INFO] Created tarball at results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-50-03.tgz
[INFO] All jobs are complete.

```

</details>

<details>
<summary>CloudAI run --single-sbatch</summary>

```
[INFO] System Name: ...
[INFO] Scheduler: slurm
[INFO] Test Scenario Name: Verify.SlurmContainer.StatusCheck
[INFO] Checking if workloads components are installed.
[INFO] Test Scenario: Verify.SlurmContainer.StatusCheck

Section Name: Verify.SlurmContainer.Pass
  Test Name: slurmcontainer-pass
  Description: Should be reported PASSED (exit 0)
  No dependencies
Section Name: Verify.SlurmContainer.Fail
  Test Name: slurmcontainer-fail
  Description: Should be reported FAILED (exit 42)
  No dependencies
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SingleSbatchRunner
[INFO] Scenario results will be stored at: results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-45-31
[INFO] Submitted slurm job: 74656
[INFO] Generated scenario report at results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-45-31/Verify.SlurmContainer.StatusCheck.html
[INFO] Scenario results                                                                                                                    
╔════════════════════════════╤════════╤════════════════════════════════════════════════════════════════════════════════════════════╗
║ Case                       │ Status │ Details                                                                                    ║
╟────────────────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────────╢
║ Verify.SlurmContainer.Pass │ PASSED │ results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-45-31/Verify.SlurmContainer.Pass/0 ║
╟────────────────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────────╢
║ Verify.SlurmContainer.Fail │ FAILED │ results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-45-31/Verify.SlurmContainer.Fail/0 ║
║                            │        │ Container command exited with code 42.                                                     ║
╚════════════════════════════╧════════╧════════════════════════════════════════════════════════════════════════════════════════════╝

[INFO] Created tarball at results/Verify.SlurmContainer.StatusCheck_2026-08-04_12-45-31.tgz
[INFO] All jobs are complete.
```

</details>

<details>
<summary>PyTest (SlurmContainer)</summary>

```
uv run --extra dev pytest tests/workloads/slurm_container/ -v
==================================================================================================================== test session starts ====================================================================================================================
platform linux -- Python 3.14.6, pytest-9.0.3, pluggy-1.6.0 -- /auto/mtrswgwork/mmalagowski/workspace/cloudai-fix-slurmcontainer/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /auto/mtrswgwork/mmalagowski/workspace/cloudai-fix-slurmcontainer
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.12.1, deadfixtures-3.1.0
collected 13 items                                                                                                                                                                                                                                          

tests/workloads/slurm_container/test_command_gen_strategy_slurm.py::test_default PASSED                                                                                                                                                               [  7%]
tests/workloads/slurm_container/test_command_gen_strategy_slurm.py::test_with_nsys PASSED                                                                                                                                                             [ 15%]
tests/workloads/slurm_container/test_command_gen_strategy_slurm.py::test_with_extra_srun_args PASSED                                                                                                                                                  [ 23%]
tests/workloads/slurm_container/test_command_gen_strategy_slurm.py::test_single_sbatch_writes_exit_code_to_per_test_output PASSED                                                                                                                     [ 30%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_missing_exit_code_fails PASSED                                                                                                                          [ 38%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_exit_code_is_honored[0-True] PASSED                                                                                                                     [ 46%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_exit_code_is_honored[0\n-True] PASSED                                                                                                                   [ 53%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_exit_code_is_honored[1-False] PASSED                                                                                                                    [ 61%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_exit_code_is_honored[42-False] PASSED                                                                                                                   [ 69%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_exit_code_is_honored[137-False] PASSED                                                                                                                  [ 76%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_malformed_exit_code_is_reported PASSED                                                                                                                  [ 84%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_unreadable_exit_code_is_reported PASSED                                                                                                                 [ 92%]
tests/workloads/slurm_container/test_slurm_container.py::TestSlurmContainerSuccessCheck::test_undecodable_exit_code_is_reported PASSED                                                                                                                [100%]

==================================================================================================================== 13 passed in 0.30s ====================================================================================================================
```

</details>

<details>
<summary>PyTest (all)</summary>

```
...
tests/workloads/ucc_test/test_report_gen_strategy.py ..                                                                                                                                                                                               [ 96%]
tests/workloads/vllm/test_command_gen_strategy_slurm.py ........................                                                                                                                                                                      [ 97%]
tests/workloads/vllm/test_job_status_retrieval_strategy.py .......                                                                                                                                                                                    [ 97%]
tests/workloads/vllm/test_report_gen_strategy.py .....................                                                                                                                                                                                [ 99%]
tests/workloads/vllm/test_workload.py ................                                                                                                                                                                                                [100%]

===================================================================================================== 1819 passed, 5 skipped, 510 deselected in 28.25s ======================================================================================================
```

</details>

## Additional Notes

None
