### PR TITLE
MegatronRun: support "true"/"false" string convention for bare CLI flags

### DIFF
--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -80,14 +80,20 @@ class MegatronRunCmdArgs(CmdArgs):
 
     @property
     def cmd_args(self) -> dict[str, Union[str, list[str]]]:
+        # Fields with default="" are boolean flags; extra fields (model_extra) are also boolean by convention.
+        bool_flags = {k for k, f in MegatronRunCmdArgs.model_fields.items() if f.default == ""}
+        extra_keys = set(self.model_extra or {})
         args = self.model_dump(exclude_none=True, exclude={"docker_image_url", "run_script"})
         result: dict[str, Union[str, list[str]]] = {}
         for k, v in args.items():
             flag = f"--{k.replace('_', '-')}"
-            if v == "false":
-                continue
-            elif v in ("true", ""):
-                result[flag] = ""
+            if k in bool_flags or k in extra_keys:
+                if v == "false":
+                    continue
+                elif v in ("true", ""):
+                    result[flag] = ""
+                else:
+                    result[flag] = v
             else:
                 result[flag] = v
         return result

--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -17,7 +17,7 @@
 import re
 from os.path import expandvars
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import toml
 from pydantic import Field, field_validator, model_validator
@@ -79,12 +79,12 @@ class MegatronRunCmdArgs(CmdArgs):
         return self
 
     @property
-    def cmd_args(self) -> dict[str, Union[str, list[str]]]:
+    def cmd_args(self) -> dict[str, Any]:
         # Fields with default="" are boolean flags; extra fields (model_extra) are also boolean by convention.
         bool_flags = {k for k, f in MegatronRunCmdArgs.model_fields.items() if f.default == ""}
         extra_keys = set(self.model_extra or {})
         args = self.model_dump(exclude_none=True, exclude={"docker_image_url", "run_script"})
-        result: dict[str, Union[str, list[str]]] = {}
+        result: dict[str, Any] = {}
         for k, v in args.items():
             flag = f"--{k.replace('_', '-')}"
             if k in bool_flags or k in extra_keys:
@@ -93,9 +93,9 @@ class MegatronRunCmdArgs(CmdArgs):
                 elif v in ("true", ""):
                     result[flag] = ""
                 else:
-                    result[flag] = str(v)
+                    result[flag] = v
             else:
-                result[flag] = str(v)
+                result[flag] = v
         return result
 
 
@@ -106,7 +106,7 @@ class MegatronRunTestDefinition(TestDefinition):
     _docker_image: Optional[DockerImage] = None
 
     @property
-    def cmd_args_dict(self) -> dict[str, Union[str, list[str]]]:
+    def cmd_args_dict(self) -> dict[str, Any]:
         return self.cmd_args.cmd_args
 
     @property

--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -81,7 +81,10 @@ class MegatronRunCmdArgs(CmdArgs):
     @property
     def cmd_args(self) -> dict[str, Any]:
         # Fields with default="" are boolean flags; extra fields (model_extra) are also boolean by convention.
-        bool_flags = {k for k, f in MegatronRunCmdArgs.model_fields.items() if f.default == ""}
+        # recompute_activations is also a bare flag (default=None so it can be omitted entirely).
+        bool_flags = {k for k, f in MegatronRunCmdArgs.model_fields.items() if f.default == ""} | {
+            "recompute_activations"
+        }
         extra_keys = set(self.model_extra or {})
         args = self.model_dump(exclude_none=True, exclude={"docker_image_url", "run_script"})
         result: dict[str, Any] = {}

--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -17,7 +17,7 @@
 import re
 from os.path import expandvars
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Tuple
 
 import toml
 from pydantic import Field, field_validator, model_validator

--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -81,8 +81,16 @@ class MegatronRunCmdArgs(CmdArgs):
     @property
     def cmd_args(self) -> dict[str, Union[str, list[str]]]:
         args = self.model_dump(exclude_none=True, exclude={"docker_image_url", "run_script"})
-        args = {f"--{k.replace('_', '-')}": v for k, v in args.items()}
-        return args
+        result: dict[str, Union[str, list[str]]] = {}
+        for k, v in args.items():
+            flag = f"--{k.replace('_', '-')}"
+            if v == "false":
+                continue
+            elif v in ("true", ""):
+                result[flag] = ""
+            else:
+                result[flag] = v
+        return result
 
 
 class MegatronRunTestDefinition(TestDefinition):

--- a/src/cloudai/workloads/megatron_run/megatron_run.py
+++ b/src/cloudai/workloads/megatron_run/megatron_run.py
@@ -93,9 +93,9 @@ class MegatronRunCmdArgs(CmdArgs):
                 elif v in ("true", ""):
                     result[flag] = ""
                 else:
-                    result[flag] = v
+                    result[flag] = str(v)
             else:
-                result[flag] = v
+                result[flag] = str(v)
         return result
 
 


### PR DESCRIPTION
Currently the only way to emit a bare CLI flag in MegatronRun is to set
the parameter to `""`. This makes it impossible for a DSE search space
to ever disable a boolean flag — there is no value that means "skip this flag."

This PR adds a string convention to `MegatronRunCmdArgs.cmd_args`:
- `"true"` → emits the bare flag (e.g. `--mock-data`)
- `"false"` → skips the flag entirely
- `""` → emits the bare flag (backward compatible, existing TOMLs unchanged)

This allows DSE configs to use `["true", "false"]` as a search space to
toggle boolean flags on/off across trials.

Existing TOMLs using `= ""` continue to work without modification.
