### PR TITLE
fix(ai_dynamo): accept CloudAI bool True for multi-worker flags

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -362,11 +362,11 @@ _compute_worker_allocation_vllm() {
     prefill_config["workers-per-node"]=1
     prefill_config["gpu-offset"]=${decode_config["gpus-per-worker"]}
   else
-    if [[ "${prefill_config["multiple-workers-per-node"]}" != "true" ]]; then
+    if [[ "${prefill_config["multiple-workers-per-node"],,}" != "true" ]]; then
       prefill_config["gpus-per-worker"]=$num_gpus
     fi
 
-    if [[ "${decode_config["multiple-workers-per-node"]}" != "true" ]]; then
+    if [[ "${decode_config["multiple-workers-per-node"],,}" != "true" ]]; then
       decode_config["gpus-per-worker"]=$num_gpus
     fi
 
@@ -1124,7 +1124,7 @@ _resolve_aiperf_server_metrics_urls() {
     done
   done
 
-  if [[ "${dynamo_args["dcgm-exporter-enabled"]}" == "True" || "${dynamo_args["dcgm-exporter-enabled"]}" == "true" ]]; then
+  if [[ "${dynamo_args["dcgm-exporter-enabled"],,}" == "true" ]]; then
     local dcgm_nodes="${decode_config["node-list"]:-},${prefill_config["node-list"]:-}"
     for node in $dcgm_nodes; do
       [[ -z "$node" ]] && continue


### PR DESCRIPTION
## Summary
- Fix case-sensitive boolean checks for \`multiple-workers-per-node\` on prefill and decode workers in \`ai_dynamo.sh\`.
- CloudAI passes Python \`True\`/\`False\` (capitalized) via Slurm CLI args; the script only accepted lowercase \`true\`, so multi-worker topology was never applied (\`gpus-per-worker\` stayed at 4, \`workers-per-node\` stayed at 1).
- Use bash \`,,\` lowercase expansion for case-insensitive comparison; align \`dcgm-exporter-enabled\` with the same pattern.


## Test Plan
- [V] Deploy ai_dynamo with \`multiple-workers-per-node = true\` on prefill (disagg tp2 topology).
- [V] Confirm logs show \`PREFILL: workers per node: 2\` and \`Launching 2 prefill worker(s)\` per node (not 1).
- [V] Confirm \`Initialized: prefill 26/26\` (13 nodes × 2 workers) for MLPerf disagg 405B config.
## Additional Notes
Observed on GB200 CloudAI runs: CLI had \`--prefill-multiple-workers-per-node True\` but script logged \`workers per node: 1\`."