### PR TITLE
ai_dynamo.sh: launch workers before the ingress readiness wait

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.sh
@@ -1393,12 +1393,14 @@ function main()
     launch_etcd &
     launch_nats &
     wait_for_etcd
-    launch_ingress
-    if _is_sglang_dsr1; then
-      launch_sgl_http_server
-    fi
   fi
 
+  # Workers launch BEFORE the ingress: launch_ingress blocks in
+  # wait_for_router, and the router only becomes ready once a worker
+  # registers — on a combined frontend+worker node the old order serialized
+  # the whole ROUTER_START_TIMEOUT (120 s of failing readiness curls) in
+  # front of every worker start. Workers only need etcd/nats (waited above)
+  # and the lmcache config from setup_lmcache; they never talk to the router.
   if _is_decode_node; then
     log "Node ID: $SLURM_NODEID, Role: decode"
     log_node_role "$(_current_node_name)" "decode"
@@ -1412,6 +1414,10 @@ function main()
   fi
 
   if _is_frontend_node; then
+    launch_ingress
+    if _is_sglang_dsr1; then
+      launch_sgl_http_server
+    fi
     sleep 10
 
     launch_workloads &


### PR DESCRIPTION
## Summary

On a combined frontend+worker node (e.g. a single-node aggregate
deployment), `main()` calls `launch_ingress` before the decode/prefill
blocks are reached. `launch_ingress` blocks in `wait_for_router` — but the
router cannot become ready until a worker registers, and no worker has been
launched yet. The wait therefore always burns its entire
`ROUTER_START_TIMEOUT` budget (120 s of failing readiness curls), every
combined-node run pays a guaranteed 2-minute startup tax, and the log ends
up with a misleading `Router did not become ready` ERROR for a router that
is actually fine.

This PR reorders `main()`: workers launch first, then the ingress. Workers
only need etcd/nats (already waited on above) and the lmcache config from
`setup_lmcache`; they register via etcd and never talk to the router — so
nothing about worker startup depends on the ingress. With the new order,
the router readiness wait overlaps worker/engine initialization instead of
serializing in front of it, and it completes as soon as a worker registers
rather than timing out.

Behavior is unchanged where the old order was already correct:

- **Multi-node:** worker-only nodes skip the frontend blocks entirely;
  ordering across nodes was already concurrent.
- **sglang DSR1:** `launch_sgl_http_server` moves together with
  `launch_ingress`, keeping their relative order.
- **Phase restarts** via `routerctl.sh` are untouched.

## Test Plan

- **Environment:** internal Slurm cluster (DGX nodes), ai_dynamo workload
  in single-node aggregate mode (combined frontend+worker), vLLM workers
  with LMCache.
- The reordered script has been running in our production benchmarking
  harness since 2026-07-14, across dozens of single-node combined runs
  (multi-hour benchmark sweeps): startup no longer serializes the 120 s
  router wait in front of worker launch, the `Router did not become ready`
  ERROR is gone, and the router readiness completes once the first worker
  registers.
- Multi-node paths were verified by inspection: the frontend blocks are
  gated on `_is_frontend_node`, which worker-only nodes never enter, so the
  diff is a no-op for them.

## Additional Notes

The root cause is a circular wait, not a slow router: `wait_for_router`
cannot succeed before a worker exists, so any ordering that puts it ahead
of worker launch on the same node converts the timeout into a fixed startup
cost. If a future change makes the router ready without workers, the new
order still holds (the wait just returns early).