### PR TITLE
Make Sleep's was_run_successful check the real exit code

### DIFF
--- a/src/cloudai/workloads/sleep/sleep.py
+++ b/src/cloudai/workloads/sleep/sleep.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 
-from cloudai.core import Installable
+from cloudai.core import Installable, JobStatusResult, TestRun
 from cloudai.models.workload import CmdArgs, TestDefinition
+
+EXIT_CODE_FILE_NAME = "exit_code.txt"
 
 
 class SleepCmdArgs(CmdArgs):
@@ -34,3 +36,30 @@ class SleepTestDefinition(TestDefinition):
     @property
     def installables(self) -> list[Installable]:
         return []
+
+    def was_run_successful(self, tr: TestRun) -> JobStatusResult:
+        exit_code_path = tr.output_path / EXIT_CODE_FILE_NAME
+        if not exit_code_path.is_file():
+            # Not every system's command-gen strategy captures an exit code yet
+            # (currently only standalone does); fall back to the previous
+            # behavior rather than fail runs that never had a chance to produce
+            # this file.
+            return JobStatusResult(is_successful=True)
+
+        exit_code_text = exit_code_path.read_text().strip()
+        try:
+            exit_code = int(exit_code_text)
+        except ValueError:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"Could not parse exit code from {exit_code_path}: {exit_code_text!r}.",
+            )
+
+        if exit_code != 0:
+            stderr_path = tr.output_path / "stderr.txt"
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"sleep exited with code {exit_code}. Check {stderr_path} for details.",
+            )
+
+        return JobStatusResult(is_successful=True)

--- a/src/cloudai/workloads/sleep/sleep.py
+++ b/src/cloudai/workloads/sleep/sleep.py
@@ -46,7 +46,14 @@ class SleepTestDefinition(TestDefinition):
             # this file.
             return JobStatusResult(is_successful=True)
 
-        exit_code_text = exit_code_path.read_text().strip()
+        try:
+            exit_code_text = exit_code_path.read_text().strip()
+        except (OSError, UnicodeDecodeError) as e:
+            return JobStatusResult(
+                is_successful=False,
+                error_message=f"Could not read exit code file {exit_code_path}: {e}.",
+            )
+
         try:
             exit_code = int(exit_code_text)
         except ValueError:

--- a/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
@@ -40,7 +40,7 @@ class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
             trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)
             toml.dump(trd.model_dump(), f)
 
-    def gen_exec_command(self, store: bool = True) -> str:
+    def gen_exec_command(self, *, store: bool = True) -> str:
         if store:
             self.store_test_run()
         stdout_path = self.test_run.output_path / "stdout.txt"

--- a/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shlex
 from typing import cast
 
 import toml
@@ -21,7 +22,7 @@ import toml
 from cloudai.core import CommandGenStrategy
 from cloudai.models.scenario import TestRunDetails
 
-from .sleep import SleepTestDefinition
+from .sleep import EXIT_CODE_FILE_NAME, SleepTestDefinition
 
 
 class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
@@ -31,13 +32,22 @@ class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
         tdef: SleepTestDefinition = cast(SleepTestDefinition, self.test_run.test)
         return f"sleep {tdef.cmd_args.seconds}"
 
-    def store_test_run(self) -> None:
+    def store_test_run(self, full_cmd: str) -> None:
         test_cmd = self._generate_sleep_command()
         self.test_run.output_path.mkdir(parents=True, exist_ok=True)
         with (self.test_run.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w", encoding="utf-8") as f:
-            trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=test_cmd)
+            trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)
             toml.dump(trd.model_dump(), f)
 
     def gen_exec_command(self) -> str:
-        self.store_test_run()
-        return self._generate_sleep_command()
+        stdout_path = self.test_run.output_path / "stdout.txt"
+        stderr_path = self.test_run.output_path / "stderr.txt"
+        exit_code_path = self.test_run.output_path / EXIT_CODE_FILE_NAME
+
+        full_cmd = (
+            f"{self._generate_sleep_command()} "
+            f"> {shlex.quote(str(stdout_path))} 2> {shlex.quote(str(stderr_path))}; "
+            f"echo $? > {shlex.quote(str(exit_code_path))}"
+        )
+        self.store_test_run(full_cmd)
+        return full_cmd

--- a/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
+++ b/src/cloudai/workloads/sleep/standalone_command_gen_strategy.py
@@ -32,22 +32,23 @@ class SleepStandaloneCommandGenStrategy(CommandGenStrategy):
         tdef: SleepTestDefinition = cast(SleepTestDefinition, self.test_run.test)
         return f"sleep {tdef.cmd_args.seconds}"
 
-    def store_test_run(self, full_cmd: str) -> None:
+    def store_test_run(self) -> None:
         test_cmd = self._generate_sleep_command()
+        full_cmd = self.gen_exec_command(store=False)
         self.test_run.output_path.mkdir(parents=True, exist_ok=True)
         with (self.test_run.output_path / self.TEST_RUN_DUMP_FILE_NAME).open("w", encoding="utf-8") as f:
             trd = TestRunDetails.from_test_run(self.test_run, test_cmd=test_cmd, full_cmd=full_cmd)
             toml.dump(trd.model_dump(), f)
 
-    def gen_exec_command(self) -> str:
+    def gen_exec_command(self, store: bool = True) -> str:
+        if store:
+            self.store_test_run()
         stdout_path = self.test_run.output_path / "stdout.txt"
         stderr_path = self.test_run.output_path / "stderr.txt"
         exit_code_path = self.test_run.output_path / EXIT_CODE_FILE_NAME
 
-        full_cmd = (
+        return (
             f"{self._generate_sleep_command()} "
             f"> {shlex.quote(str(stdout_path))} 2> {shlex.quote(str(stderr_path))}; "
             f"echo $? > {shlex.quote(str(exit_code_path))}"
         )
-        self.store_test_run(full_cmd)
-        return full_cmd

--- a/tests/workloads/sleep/test_command_gen_strategy_standalone.py
+++ b/tests/workloads/sleep/test_command_gen_strategy_standalone.py
@@ -22,6 +22,7 @@ from cloudai.core import CommandGenStrategy, TestRun
 from cloudai.models.scenario import TestRunDetails
 from cloudai.systems.standalone import StandaloneSystem
 from cloudai.workloads.sleep import SleepCmdArgs, SleepStandaloneCommandGenStrategy, SleepTestDefinition
+from cloudai.workloads.sleep.sleep import EXIT_CODE_FILE_NAME
 
 
 def test_gen_exec_command_writes_test_run_details(tmp_path: Path, standalone_system: StandaloneSystem) -> None:
@@ -36,10 +37,13 @@ def test_gen_exec_command_writes_test_run_details(tmp_path: Path, standalone_sys
     strategy = SleepStandaloneCommandGenStrategy(standalone_system, tr)
     command = strategy.gen_exec_command()
 
-    assert command == "sleep 60"
+    assert command == (
+        f"sleep 60 > {tr.output_path / 'stdout.txt'} 2> {tr.output_path / 'stderr.txt'}; "
+        f"echo $? > {tr.output_path / EXIT_CODE_FILE_NAME}"
+    )
 
     dump_path = tr.output_path / CommandGenStrategy.TEST_RUN_DUMP_FILE_NAME
     assert dump_path.is_file()
     details = TestRunDetails.model_validate(toml.load(dump_path))
     assert details.test_cmd == "sleep 60"
-    assert details.full_cmd == "sleep 60"
+    assert details.full_cmd == command

--- a/tests/workloads/sleep/test_sleep.py
+++ b/tests/workloads/sleep/test_sleep.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from unittest.mock import patch
 
 from cloudai.core import TestRun
 from cloudai.workloads.sleep import SleepCmdArgs, SleepTestDefinition
@@ -70,3 +71,26 @@ def test_was_run_successful_with_unparseable_exit_code(tmp_path: Path) -> None:
 
     assert result.is_successful is False
     assert "Could not parse exit code" in result.error_message
+
+
+def test_was_run_successful_with_unreadable_exit_code_file(tmp_path: Path) -> None:
+    tr = _sleep_test_run(tmp_path)
+    tr.output_path.mkdir(parents=True)
+    (tr.output_path / EXIT_CODE_FILE_NAME).write_text("0\n")
+
+    with patch("pathlib.Path.read_text", side_effect=PermissionError("permission denied")):
+        result = tr.test.was_run_successful(tr)
+
+    assert result.is_successful is False
+    assert "Could not read exit code file" in result.error_message
+
+
+def test_was_run_successful_with_undecodable_exit_code_file(tmp_path: Path) -> None:
+    tr = _sleep_test_run(tmp_path)
+    tr.output_path.mkdir(parents=True)
+    (tr.output_path / EXIT_CODE_FILE_NAME).write_bytes(b"\xff\xfe\x00")
+
+    result = tr.test.was_run_successful(tr)
+
+    assert result.is_successful is False
+    assert "Could not read exit code file" in result.error_message

--- a/tests/workloads/sleep/test_sleep.py
+++ b/tests/workloads/sleep/test_sleep.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from cloudai.core import TestRun
+from cloudai.workloads.sleep import SleepCmdArgs, SleepTestDefinition
+from cloudai.workloads.sleep.sleep import EXIT_CODE_FILE_NAME
+
+
+def _sleep_test_run(tmp_path: Path) -> TestRun:
+    tdef = SleepTestDefinition(
+        name="sleep_test",
+        description="Simple sleep test",
+        test_template_name="Sleep",
+        cmd_args=SleepCmdArgs(seconds=1),
+    )
+    return TestRun(name="sleep-job", test=tdef, num_nodes=1, nodes=[], output_path=tmp_path / "output")
+
+
+def test_was_run_successful_without_exit_code_file_assumes_success(tmp_path: Path) -> None:
+    """Systems that don't yet capture an exit code (Slurm, LSF, Kubernetes) keep the old behavior."""
+    tr = _sleep_test_run(tmp_path)
+
+    result = tr.test.was_run_successful(tr)
+
+    assert result.is_successful is True
+
+
+def test_was_run_successful_with_zero_exit_code(tmp_path: Path) -> None:
+    tr = _sleep_test_run(tmp_path)
+    tr.output_path.mkdir(parents=True)
+    (tr.output_path / EXIT_CODE_FILE_NAME).write_text("0\n")
+
+    result = tr.test.was_run_successful(tr)
+
+    assert result.is_successful is True
+
+
+def test_was_run_successful_with_nonzero_exit_code(tmp_path: Path) -> None:
+    tr = _sleep_test_run(tmp_path)
+    tr.output_path.mkdir(parents=True)
+    (tr.output_path / EXIT_CODE_FILE_NAME).write_text("1\n")
+
+    result = tr.test.was_run_successful(tr)
+
+    assert result.is_successful is False
+    assert "exited with code 1" in result.error_message
+
+
+def test_was_run_successful_with_unparseable_exit_code(tmp_path: Path) -> None:
+    tr = _sleep_test_run(tmp_path)
+    tr.output_path.mkdir(parents=True)
+    (tr.output_path / EXIT_CODE_FILE_NAME).write_text("not-a-number\n")
+
+    result = tr.test.was_run_successful(tr)
+
+    assert result.is_successful is False
+    assert "Could not parse exit code" in result.error_message


### PR DESCRIPTION
## Summary
- `SleepTestDefinition` never overrode `was_run_successful()`, so it fell back to the base `TestDefinition` default, which unconditionally returns `is_successful=True` — no check of exit code, output, or anything else
- Every other workload I checked (`fio.py`, `vllm.py`, `nccl.py`, `nixl_ep.py`, `dynamo_mocker.py`, `nemo_run.py`, `sglang.py`) implements a real `was_run_successful()`. Sleep did not
- `SleepStandaloneCommandGenStrategy.gen_exec_command()` now redirects stdout/stderr to files and captures the real exit code, following the same pattern `FioStandaloneCommandGenStrategy` already uses for stdout/stderr redirection
- `SleepTestDefinition.was_run_successful()` reads that exit code file. If it's absent (Slurm/LSF/Kubernetes command-gen strategies don't capture one yet), it falls back to the previous always-true behavior — additive, not a behavior change for those systems
- Scoped to standalone: I don't have Slurm/LSF/Kubernetes systems available to verify a fix there, so those still have the same underlying gap in principle; the issue documents it generally for whoever picks that up

Separately noticed, **out of scope for this PR**: even with `was_run_successful` now correctly returning `FAILED`, `handle_dry_run_and_run`'s non-DSE path (`src/cloudai/cli/handlers.py`) unconditionally returns `0` regardless of job outcome, so the overall `cloudai run` process exit code still doesn't reflect a failed test. That's a broader gap affecting every workload's exit code, not Sleep-specific, and not addressed here.

## How this was found
Found while validating CloudAI through a small wrapper project, [CloudAI Autotune](https://github.com/shreyaskommuri/CloudAI-Autotune). I was running a real (non-dry-run) `cloudai run` through Autotune to check whether a genuinely-failing command would be surfaced correctly — it wasn't. Reproduced directly against `cloudai run` too (not just through the wrapper). Filed as #980.

Issue: #980

## Test Plan
- `uv run pytest -q` — 1767 passed, 18 skipped
- `uv run ruff check` / `uv run ruff format --check` on the changed files — clean
- Manually re-ran the exact broken repro from the issue against this fix: a standalone Sleep test with `seconds = -1` (which fails with `sleep: illegal option -- 1`, exit code 1). Before this fix: results table showed `PASSED`. After: results table correctly shows `FAILED` with `sleep exited with code 1. Check .../stderr.txt for details.`

AI was used for context and guidance while investigating, implementing, and testing this fix.