### PR TITLE
Allow --system-config to be set via CLOUDAI_SYSTEM_CONFIG env var

### DIFF
--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -88,8 +88,9 @@ def common_options(f):
         "--system-config",
         "system_cfg",
         required=True,
+        envvar="CLOUDAI_SYSTEM_CONFIG",
         type=click.Path(exists=True, resolve_path=True, path_type=Path),
-        help="System config path.",
+        help="System config path. Can also be set via the CLOUDAI_SYSTEM_CONFIG environment variable.",
     )(f)
     f = click.option(
         "--tests-dir",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,47 @@ def test_tests_dir_is_optional(tmp_path: Path):
     assert "Missing option '--tests-dir'" not in result.output
 
 
+def test_system_config_can_be_set_via_env_var(tmp_path: Path):
+    system_cfg, scenario_cfg = tmp_path / "system.toml", tmp_path / "scenario.toml"
+    system_cfg.touch()
+    scenario_cfg.touch()
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["run", "--test-scenario", str(scenario_cfg)],
+        env={"CLOUDAI_SYSTEM_CONFIG": str(system_cfg)},
+    )
+    assert "Missing option '--system-config'" not in result.output
+
+
+def test_system_config_flag_takes_precedence_over_env_var(tmp_path: Path):
+    system_cfg, other_cfg, scenario_cfg = (
+        tmp_path / "system.toml",
+        tmp_path / "other.toml",
+        tmp_path / "scenario.toml",
+    )
+    system_cfg.touch()
+    other_cfg.touch()
+    scenario_cfg.touch()
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["run", "--system-config", str(system_cfg), "--test-scenario", str(scenario_cfg)],
+        env={"CLOUDAI_SYSTEM_CONFIG": str(other_cfg)},
+    )
+    assert "Missing 'scheduler' key" in result.output
+    assert str(system_cfg) in result.output
+    assert str(other_cfg) not in result.output
+
+
+@pytest.mark.parametrize("subcommand", ["install", "uninstall", "dry-run", "run", "generate-report"])
+def test_system_config_env_var_documented_in_help(subcommand: str):
+    runner = CliRunner()
+    result = runner.invoke(main, [subcommand, "--help"])
+    assert result.exit_code == 0
+    assert "CLOUDAI_SYSTEM_CONFIG" in result.output
+
+
 @pytest.mark.parametrize("subcommand", ["install", "uninstall", "dry-run", "run", "generate-report"])
 def test_hook_dir_is_available_on_run_commands(subcommand: str):
     runner = CliRunner()


### PR DESCRIPTION
## Summary

- `--system-config` can now be set via a `CLOUDAI_SYSTEM_CONFIG` environment variable instead of always passing the flag explicitly.
- The `--system-config` flag still takes precedence when both are set. The requirement that one of them is provided is unchanged (`click`'s `envvar=` mechanism satisfies `required=True`).
- Suggested by @podkidyshev as a small quality-of-life improvement while discussing the parser work tracked in #985.
- Change is a single option definition in `src/cloudai/cli/cli.py`'s `common_options`, so it applies to `install`, `uninstall`, `dry-run`, `run`, and `generate-report` uniformly. `verify-configs` does not use `--system-config` and is unaffected.

## Test Plan

Added 3 tests to `tests/test_cli.py`: env-var-only resolution, flag-takes-precedence-over-env-var, and env var documented in `--help` across all 5 subcommands.

```
$ uv run pytest tests/test_cli.py -v
...
tests/test_cli.py::test_system_config_can_be_set_via_env_var PASSED
tests/test_cli.py::test_system_config_flag_takes_precedence_over_env_var PASSED
tests/test_cli.py::test_system_config_env_var_documented_in_help[install] PASSED
tests/test_cli.py::test_system_config_env_var_documented_in_help[uninstall] PASSED
tests/test_cli.py::test_system_config_env_var_documented_in_help[dry-run] PASSED
tests/test_cli.py::test_system_config_env_var_documented_in_help[run] PASSED
tests/test_cli.py::test_system_config_env_var_documented_in_help[generate-report] PASSED
...
39 passed in 0.05s
```

Also ran a real end-to-end `dry-run` using the env var instead of the flag, against the bundled sleep scenario:

```
$ CLOUDAI_SYSTEM_CONFIG="$(pwd)/conf/common/system/standalone_system.toml" uv run cloudai dry-run \
    --tests-dir conf/common/test \
    --test-scenario conf/common/test_scenario/sleep.toml
...
[INFO] Scenario results
╔════════════════╤════════╤════════════════════════════════════════════════════╗
║ Case           │ Status │ Details                                            ║
╟────────────────┼────────┼────────────────────────────────────────────────────╢
║ Tests.sleep1   │ PASSED │ results/.../Tests.sleep1/0                         ║
║ Tests.sleep5   │ PASSED │ results/.../Tests.sleep5/0                         ║
║ Tests.sleep5_2 │ PASSED │ results/.../Tests.sleep5_2/0                       ║
║ Tests.sleep20  │ PASSED │ results/.../Tests.sleep20/0                        ║
╚════════════════╧════════╧════════════════════════════════════════════════════╝
[INFO] All jobs are complete.
```

Also ran full suite (`uv run pytest -q`, 1806 passed), `ruff check`, `ruff format --check`, and `pyright`, all clean.

## Additional Notes

None.