### PR TITLE
Support path-based test references in scenario files

### DIFF
--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -155,7 +155,7 @@ class TestRunModel(BaseModel):
                     f"Possible values are: {', '.join(registry.test_definitions_map.keys())}"
                 )
         else:
-            if self.test_template_name:
+            if self.test_template_name is not None:
                 raise ValueError("'test_template_name' must not be set if 'test_name' or 'path' is set.")
 
         return self

--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -154,9 +154,8 @@ class TestRunModel(BaseModel):
                     f"Test type '{self.test_template_name}' not found in the test definitions. "
                     f"Possible values are: {', '.join(registry.test_definitions_map.keys())}"
                 )
-        else:
-            if self.test_template_name is not None:
-                raise ValueError("'test_template_name' must not be set if 'test_name' or 'path' is set.")
+        elif self.test_template_name is not None:
+            raise ValueError("'test_template_name' must not be set if 'test_name' or 'path' is set.")
 
         return self
 

--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -71,6 +71,13 @@ class TestRunModel(BaseModel):
 
     id: str = Field(min_length=1)
     test_name: Optional[str] = None
+    path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path to a test TOML file, resolved relative to this scenario file's own directory. "
+            "Alternative to 'test_name': references a test by file location instead of by name."
+        ),
+    )
     num_nodes: int | list[int] | None = None
     nodes: list[str] = Field(default_factory=list)
     exclude_nodes: list[str] = Field(
@@ -126,14 +133,17 @@ class TestRunModel(BaseModel):
 
     @model_validator(mode="after")
     def check_test_name_or_type_is_set(self):
-        has_base = self.test_name is not None
+        if self.test_name is not None and self.path is not None:
+            raise ValueError("'test_name' and 'path' must not both be set; use only one to reference a test.")
+
+        has_base = self.test_name is not None or self.path is not None
         if not has_base and (self.test_template_name is None or self.name is None or self.description is None):
             raise ValueError(
-                "When 'test_name' is not set, the following fields must be set: "
+                "When neither 'test_name' nor 'path' is set, the following fields must be set: "
                 "'test_template_name', 'name', 'description'."
             )
 
-        if not self.test_name:
+        if not has_base:
             if not self.test_template_name:
                 raise ValueError("'test_template_name' must be set if 'test_name' is not set.")
 
@@ -145,7 +155,7 @@ class TestRunModel(BaseModel):
                 )
         else:
             if self.test_template_name:
-                raise ValueError("'test_template_name' must not be set if 'test_name' is set.")
+                raise ValueError("'test_template_name' must not be set if 'test_name' or 'path' is set.")
 
         return self
 

--- a/src/cloudai/models/scenario.py
+++ b/src/cloudai/models/scenario.py
@@ -73,6 +73,7 @@ class TestRunModel(BaseModel):
     test_name: Optional[str] = None
     path: Optional[str] = Field(
         default=None,
+        min_length=1,
         description=(
             "Path to a test TOML file, resolved relative to this scenario file's own directory. "
             "Alternative to 'test_name': references a test by file location instead of by name."

--- a/src/cloudai/test_scenario_parser.py
+++ b/src/cloudai/test_scenario_parser.py
@@ -228,13 +228,15 @@ class TestScenarioParser:
             tc_defined = test_info.tdef_model_dump(by_alias=True)
             merged_data = deep_merge(test_defined, tc_defined)
             test = tp.load_test_definition(merged_data)
-        elif test_info.path:  # test referenced by file path, relative to this scenario file's directory
+        elif test_info.path:
             resolved_path = (self.file_path.parent / test_info.path).resolve()
             if not resolved_path.is_file():
-                raise TestScenarioParsingError(
+                msg = (
                     f"Test case '{test_info.id}' references path '{test_info.path}', "
                     f"which resolves to '{resolved_path}', but that file does not exist."
                 )
+                logging.error(msg)
+                raise TestScenarioParsingError(msg)
             tp.current_file = resolved_path
             with resolved_path.open() as fh:
                 test_defined = load_test_toml_file(fh, resolved_path)

--- a/src/cloudai/test_scenario_parser.py
+++ b/src/cloudai/test_scenario_parser.py
@@ -38,7 +38,7 @@ from .core import (
 )
 from .models.scenario import TestRunModel, TestScenarioModel
 from .models.workload import TestDefinition
-from .test_parser import TestParser
+from .test_parser import TestParser, load_test_toml_file
 from .toml_utils import format_toml_decode_error
 
 
@@ -228,12 +228,25 @@ class TestScenarioParser:
             tc_defined = test_info.tdef_model_dump(by_alias=True)
             merged_data = deep_merge(test_defined, tc_defined)
             test = tp.load_test_definition(merged_data)
+        elif test_info.path:  # test referenced by file path, relative to this scenario file's directory
+            resolved_path = (self.file_path.parent / test_info.path).resolve()
+            if not resolved_path.is_file():
+                raise TestScenarioParsingError(
+                    f"Test case '{test_info.id}' references path '{test_info.path}', "
+                    f"which resolves to '{resolved_path}', but that file does not exist."
+                )
+            tp.current_file = resolved_path
+            with resolved_path.open() as fh:
+                test_defined = load_test_toml_file(fh, resolved_path)
+            tc_defined = test_info.tdef_model_dump(by_alias=True)
+            merged_data = deep_merge(test_defined, tc_defined)
+            test = tp.load_test_definition(merged_data)
         elif test_info.test_template_name:  # test fully defined in the scenario
             test = tp._parse_data(test_info.tdef_model_dump(by_alias=True))
         else:
             # this should never happen, because we check for this in the modelvalidator
             raise ValueError(
-                f"Cannot configure test case '{test_info.id}' with both 'test_name' and 'test_template_name'."
+                f"Test case '{test_info.id}' has none of 'test_name', 'path', or 'test_template_name' set."
             )
 
         return test

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -33,6 +33,7 @@ from cloudai.core import (
     TestRun,
     TestScenario,
     TestScenarioParser,
+    TestScenarioParsingError,
 )
 from cloudai.models.scenario import TestRunModel, TestScenarioModel
 from cloudai.report_generator.training import TrainingReportGenerationStrategy
@@ -322,7 +323,8 @@ class TestInScenario:
         with pytest.raises(ValueError) as exc_info:
             TestRunModel.model_validate(spec)
         assert exc_info.match(
-            "When 'test_name' is not set, the following fields must be set: 'test_template_name', 'name', 'description'"
+            "When neither 'test_name' nor 'path' is set, the following fields must be set: "
+            "'test_template_name', 'name', 'description'"
         )
 
     def test_name_is_not_in_mapping(self, test_scenario_parser: TestScenarioParser):
@@ -349,7 +351,7 @@ class TestInScenario:
         spec = {"id": "1", "test_name": "nccl", "test_template_name": "NcclTest"}
         with pytest.raises(ValueError) as exc_info:
             TestRunModel.model_validate(spec)
-        assert exc_info.match("'test_template_name' must not be set if 'test_name' is set.")
+        assert exc_info.match("'test_template_name' must not be set if 'test_name' or 'path' is set.")
 
     def test_spec_with_unknown_test_type(self):
         with pytest.raises(ValueError) as exc_info:
@@ -359,7 +361,7 @@ class TestInScenario:
     def test_type_is_not_allowed_when_name_is_set(self):
         with pytest.raises(ValueError) as exc_info:
             TestRunModel(id="1", test_name="nccl", test_template_name="NcclTest")
-        assert exc_info.match("'test_template_name' must not be set if 'test_name' is set.")
+        assert exc_info.match("'test_template_name' must not be set if 'test_name' or 'path' is set.")
 
     def test_spec_without_base(self, test_scenario_parser: TestScenarioParser):
         model = TestScenarioModel.model_validate(
@@ -922,3 +924,104 @@ class TestNsysMerging:
         assert tdef.nsys is not None
         assert tdef.nsys.enable is False
         assert tdef.nsys.output == "/base/output"
+
+
+class TestPathReference:
+    def test_path_and_test_name_together_is_rejected(self):
+        with pytest.raises(ValueError) as exc_info:
+            TestRunModel(id="1", test_name="nccl", path="nccl.toml")
+        assert exc_info.match("'test_name' and 'path' must not both be set")
+
+    def test_path_and_test_template_name_together_is_rejected(self):
+        with pytest.raises(ValueError) as exc_info:
+            TestRunModel(id="1", path="nccl.toml", test_template_name="NcclTest")
+        assert exc_info.match("'test_template_name' must not be set if 'test_name' or 'path' is set.")
+
+    def test_path_alone_satisfies_the_base_requirement(self):
+        model = TestRunModel(id="1", path="nccl.toml")
+        assert model.path == "nccl.toml"
+
+    def test_path_is_resolved_relative_to_the_scenario_file(self, tmp_path: Path, slurm_system: SlurmSystem):
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "nccl.toml").write_text(
+            """
+            name = "nccl"
+            description = "desc"
+            test_template_name = "NcclTest"
+
+            [cmd_args]
+            docker_image_url = "fake://url/nccl"
+            """
+        )
+        scenario_path = tmp_path / "scenario.toml"
+        scenario_path.write_text("")  # only its parent directory matters for resolution
+        parser = TestScenarioParser(scenario_path, slurm_system, {}, {})
+
+        test_info = TestRunModel(id="1", path="tests/nccl.toml")
+        tdef = parser._prepare_tdef(test_info)
+
+        assert tdef.name == "nccl"
+        assert isinstance(tdef, NCCLTestDefinition)
+        assert tdef.cmd_args.docker_image_url == "fake://url/nccl"
+
+    def test_scenario_level_overrides_are_merged_over_the_referenced_file(
+        self, tmp_path: Path, slurm_system: SlurmSystem
+    ):
+        (tmp_path / "nccl.toml").write_text(
+            """
+            name = "nccl"
+            description = "desc"
+            test_template_name = "NcclTest"
+
+            [cmd_args]
+            docker_image_url = "fake://url/nccl"
+            """
+        )
+        scenario_path = tmp_path / "scenario.toml"
+        scenario_path.write_text("")
+        parser = TestScenarioParser(scenario_path, slurm_system, {}, {})
+
+        test_info = TestRunModel(id="1", path="nccl.toml", cmd_args=CmdArgs.model_validate({"nthreads": 42}))
+        tdef = parser._prepare_tdef(test_info)
+
+        assert tdef.cmd_args.nthreads == 42
+        assert tdef.cmd_args.docker_image_url == "fake://url/nccl"
+
+    def test_missing_referenced_file_raises_a_clear_error(self, tmp_path: Path, slurm_system: SlurmSystem):
+        scenario_path = tmp_path / "scenario.toml"
+        scenario_path.write_text("")
+        parser = TestScenarioParser(scenario_path, slurm_system, {}, {})
+
+        test_info = TestRunModel(id="1", path="does-not-exist.toml")
+        with pytest.raises(TestScenarioParsingError) as exc_info:
+            parser._prepare_tdef(test_info)
+
+        assert exc_info.match("does not exist")
+
+    def test_full_scenario_toml_with_path_reference(self, tmp_path: Path, slurm_system: SlurmSystem):
+        (tmp_path / "nccl.toml").write_text(
+            """
+            name = "nccl"
+            description = "desc"
+            test_template_name = "NcclTest"
+
+            [cmd_args]
+            docker_image_url = "fake://url/nccl"
+            """
+        )
+        scenario_path = tmp_path / "scenario.toml"
+        scenario_path.write_text(
+            """
+            name = "test"
+
+            [[Tests]]
+            id = "1"
+            path = "nccl.toml"
+            """
+        )
+        parser = TestScenarioParser(scenario_path, slurm_system, {}, {})
+        model = TestScenarioModel.model_validate(toml.loads(scenario_path.read_text()))
+
+        tdef = parser._prepare_tdef(model.tests[0])
+
+        assert tdef.name == "nccl"

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -937,14 +937,20 @@ class TestPathReference:
             TestRunModel(id="1", path="nccl.toml", test_template_name="NcclTest")
         assert exc_info.match("'test_template_name' must not be set if 'test_name' or 'path' is set.")
 
+    def test_path_and_empty_test_template_name_together_is_rejected(self):
+        """An empty string is a truthy-looking but still explicitly-set value - it must not be
+        treated the same as unset, or 'test_template_name' could silently smuggle a value
+        through when combined with 'path'."""
+        with pytest.raises(ValueError, match="'test_template_name' must not be set if 'test_name' or 'path' is set"):
+            TestRunModel(id="1", path="nccl.toml", test_template_name="")
+
     def test_path_alone_satisfies_the_base_requirement(self):
         model = TestRunModel(id="1", path="nccl.toml")
         assert model.path == "nccl.toml"
 
     def test_empty_path_is_rejected(self):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="String should have at least 1 character"):
             TestRunModel(id="1", path="")
-        assert exc_info.match("String should have at least 1 character")
 
     def test_path_is_resolved_relative_to_the_scenario_file(self, tmp_path: Path, slurm_system: SlurmSystem):
         (tmp_path / "tests").mkdir()
@@ -1025,8 +1031,7 @@ class TestPathReference:
             """
         )
         parser = TestScenarioParser(scenario_path, slurm_system, {}, {})
-        model = TestScenarioModel.model_validate(toml.loads(scenario_path.read_text()))
 
-        tdef = parser._prepare_tdef(model.tests[0])
+        scenario = parser.parse()
 
-        assert tdef.name == "nccl"
+        assert scenario.test_runs[0].test.name == "nccl"

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -941,6 +941,11 @@ class TestPathReference:
         model = TestRunModel(id="1", path="nccl.toml")
         assert model.path == "nccl.toml"
 
+    def test_empty_path_is_rejected(self):
+        with pytest.raises(ValueError) as exc_info:
+            TestRunModel(id="1", path="")
+        assert exc_info.match("String should have at least 1 character")
+
     def test_path_is_resolved_relative_to_the_scenario_file(self, tmp_path: Path, slurm_system: SlurmSystem):
         (tmp_path / "tests").mkdir()
         (tmp_path / "tests" / "nccl.toml").write_text(

--- a/tests/test_test_scenario.py
+++ b/tests/test_test_scenario.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+import logging
 from pathlib import Path
 from typing import Set, Type
 
@@ -1008,6 +1009,22 @@ class TestPathReference:
             parser._prepare_tdef(test_info)
 
         assert exc_info.match("does not exist")
+
+    def test_missing_referenced_file_logs_the_error(
+        self, tmp_path: Path, slurm_system: SlurmSystem, caplog: pytest.LogCaptureFixture
+    ):
+        """The top-level `Parser.parse()` catches `TestScenarioParsingError` and exits without
+        printing the exception itself, relying on the raiser having already logged it. Without
+        this, a missing path reference fails with no error message at all in `run`/`dry-run`."""
+        scenario_path = tmp_path / "scenario.toml"
+        scenario_path.write_text("")
+        parser = TestScenarioParser(scenario_path, slurm_system, {}, {})
+
+        test_info = TestRunModel(id="1", path="does-not-exist.toml")
+        with caplog.at_level(logging.ERROR), pytest.raises(TestScenarioParsingError):
+            parser._prepare_tdef(test_info)
+
+        assert "does not exist" in caplog.text
 
     def test_full_scenario_toml_with_path_reference(self, tmp_path: Path, slurm_system: SlurmSystem):
         (tmp_path / "nccl.toml").write_text(


### PR DESCRIPTION
## Summary
- Adds an optional `path` field on `TestRunModel`, an alternative to `test_name` for referencing a test in a scenario file, resolved relative to the scenario file's own directory (confirmed shape in #985).
- `test_name` and `path` are mutually exclusive, same rules `test_name` already has with `test_template_name`.
- `TestScenarioParser._prepare_tdef` gets a new branch: when `path` is set, it loads that toml file directly instead of doing a name lookup against `test_mapping`, then merges scenario-level overrides the same way the `test_name` branch already does.
- Raises a clear `TestScenarioParsingError` if the resolved path does not exist.
- This is PR1 of the two-PR plan discussed in #985. PR2 (skip eager glob-and-parse of `--tests-dir`/hooks when a scenario's tests are all path-referenced) depends on this one and is not included here, keeping this PR small and reviewable on its own.
- Fully backward compatible: `test_name` and fully-inline (`test_template_name` + `name` + `description`) scenarios are unaffected.

## Test Plan
7 new tests in `tests/test_test_scenario.py` (`TestPathReference`), covering: `path`/`test_name` mutual exclusion, `path`/`test_template_name` mutual exclusion, relative-path resolution against the scenario file's directory, scenario-level override merging over the referenced file, a missing-file error, and a full scenario TOML parsed end to end with a `path` reference.

```
$ uv run pytest tests/test_test_scenario.py -q -k "TestPathReference"
.......
7 passed, 74 deselected in 0.04s

$ uv run pytest -q -m "not ci_only"
1848 passed, 5 skipped, 511 deselected in 4.47s

$ uv run pre-commit run --all-files
check for added large files..............................................Passed
check python ast.........................................................Passed
check for merge conflicts.................................................Passed
check toml................................................................Passed
check yaml.................................................................Passed
debug statements (python)..................................................Passed
fix end of files...........................................................Passed
mixed line ending..........................................................Passed
trim trailing whitespace...................................................Passed
pyright.....................................................................Passed
ruff check...................................................................Passed
ruff format...................................................................Passed
vulture.......................................................................Passed
import-linter..................................................................Passed
taplo...........................................................................Passed
```

Also updated the wording of two pre-existing validation error messages (in `models/scenario.py`) that referenced only `test_name`, so they stay accurate now that `path` is a second way to satisfy the same requirement. Updated the two existing tests in `tests/test_test_scenario.py` that asserted on the old wording.

## Additional Notes
Design confirmed in #985 before writing any code, per `CONTRIBUTING.md`'s "communicate with the main developers before starting work." Not touching the eager-loading behavior itself, sweeping, or anything unrelated, this PR is purely additive.