### PR TITLE
Allow AI Dynamo tests to configure Hugging Face cache path

### DIFF
--- a/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
+++ b/src/cloudai/workloads/ai_dynamo/ai_dynamo.py
@@ -397,6 +397,7 @@ class AIDynamoCmdArgs(CmdArgs):
     docker_image_url: str
     startup_cmd: str | None = None
     startup_cmd_docker_image: str | None = None
+    hf_home_path: Path | None = None
     storage_cache_dir: Optional[str | list[str]] = Field(default="/tmp", serialization_alias="storage_cache_dir")
     dynamo: AIDynamoArgs
     hicache: dict | None = None
@@ -407,6 +408,13 @@ class AIDynamoCmdArgs(CmdArgs):
     aiperf_phases: list[AIPerfPhase] | None = None
     aiperf_accuracy: AIPerfAccuracy | None = None
     workloads: str = "genai_perf.sh"
+
+    @field_validator("hf_home_path")
+    @classmethod
+    def validate_hf_home_path(cls, value: Path | None) -> Path | None:
+        if value is not None and not value.is_absolute():
+            raise ValueError("hf_home_path must be an absolute path")
+        return value
 
     @field_validator("workloads", mode="before")
     @classmethod

--- a/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/ai_dynamo/slurm_command_gen_strategy.py
@@ -47,8 +47,12 @@ class AIDynamoSlurmCommandGenStrategy(SlurmCommandGenStrategy):
     def td(self) -> AIDynamoTestDefinition:
         return cast(AIDynamoTestDefinition, self.test_run.test)
 
+    @property
+    def hf_home_path(self) -> Path:
+        return self.td.cmd_args.hf_home_path or self.system.hf_home_path
+
     def _container_mounts(self) -> list[str]:
-        result = [f"{self.system.hf_home_path.absolute()}:{self.CONTAINER_MOUNT_HF_HOME}"]
+        result = [f"{self.hf_home_path.absolute()}:{self.CONTAINER_MOUNT_HF_HOME}"]
 
         logging.info(f"storage_cache_dir: {self.td.cmd_args.storage_cache_dir}")
         if self.td.cmd_args.storage_cache_dir:

--- a/tests/workloads/ai_dynamo/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/ai_dynamo/test_command_gen_strategy_slurm.py
@@ -132,6 +132,25 @@ def test_container_mounts(strategy: AIDynamoSlurmCommandGenStrategy, test_run: T
     assert mounts == expected
 
 
+def test_container_mounts_use_configured_hf_home(
+    strategy: AIDynamoSlurmCommandGenStrategy, test_run: TestRun, tmp_path: Path
+) -> None:
+    hf_home_path = tmp_path / "local-hf"
+    test_run.test.cmd_args.hf_home_path = hf_home_path
+
+    mounts = strategy._container_mounts()
+
+    assert mounts[0] == f"{hf_home_path.absolute()}:{strategy.CONTAINER_MOUNT_HF_HOME}"
+
+
+def test_hf_home_path_must_be_absolute(cmd_args: AIDynamoCmdArgs) -> None:
+    data = cmd_args.model_dump(by_alias=True)
+    data["hf_home_path"] = "local-hf"
+
+    with pytest.raises(ValueError, match="hf_home_path must be an absolute path"):
+        AIDynamoCmdArgs.model_validate(data)
+
+
 def test_installables_include_top_level_git_repos(cmd_args: AIDynamoCmdArgs) -> None:
     repo = GitRepo(url="https://github.com/example/custom-tools.git", commit="main")
     tdef = AIDynamoTestDefinition(


### PR DESCRIPTION
## Motivation

AI Dynamo currently always mounts the system-level Hugging Face cache. This prevents individual tests from using a cache populated on node-local storage through `startup_cmd`.

A per-test override enables faster node-local model loading without changing shared system configuration or affecting existing workloads.

## Summary

- Add optional `hf_home_path` to AI Dynamo command arguments.
- Require the configured path to be absolute.
- Mount the per-test path as the container HF home when provided.
- Preserve the system-level HF home as the default.
- Add tests for path validation and mount selection.

## Test plan

Tests + manual run.

## Notes

The configured HF home directory must exist before container startup. `startup_cmd` can populate its cache contents before the AI Dynamo workload starts.