### PR TITLE
fix(megatron_bridge): forward static extra_env_vars via -E

### DIFF
--- a/doc/workloads/megatron_bridge.rst
+++ b/doc/workloads/megatron_bridge.rst
@@ -84,6 +84,27 @@ Test-in-Scenario example:
      domain = "llm"
      compute_dtype = "fp8_mx"
 
+Executor Environment Variables
+------------------------------
+
+By default, CloudAI forwards ``extra_env_vars`` as ``-cb export KEY=VALUE``
+commands. This preserves compatibility with Megatron-Bridge releases such as
+v0.3.0 that do not support ``-E/--env`` and allows values to reference job-shell
+variables such as ``$SLURM_PROCID``.
+
+For a newer Megatron-Bridge version, variables that must be registered in the
+NeMo-Run executor's ``env_vars`` and ``container_env`` can be explicitly set
+under ``cmd_args.executor_env_vars``:
+
+.. code-block:: toml
+
+   [cmd_args.executor_env_vars]
+   GPU_METRICS_NODES = "0,1"
+
+Each entry is passed to Megatron-Bridge as a repeated ``-E KEY=VALUE`` argument.
+Values are forwarded literally and may contain commas. Do not use this option
+with a Megatron-Bridge version that predates ``-E/--env``.
+
 Chakra / Kineto Tracing
 -----------------------
 

--- a/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
+++ b/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
@@ -36,6 +36,13 @@ class MegatronBridgeCmdArgs(CmdArgs):
     enable_vboost: bool | None = Field(default=False)
     dryrun: bool | None = Field(default=False)
     enable_nsys: bool | None = Field(default=False)
+    executor_env_vars: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Environment variables passed through Megatron-Bridge -E/--env into NeMo-Run executor "
+            "env_vars/container_env. Requires a Megatron-Bridge version that supports -E."
+        ),
+    )
 
     # Domain / model overrides (argument_parser main + model)
     domain: Optional[str] = Field(default=None, description="Domain: llm, vlm, or qwen3vl (default llm).")

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -214,17 +214,31 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         with log_file.open("w") as f:
             f.write(f"{command}\n")
 
-    def _build_custom_bash_env_exports(self) -> list[str]:
-        """
-        Build repeated -cb entries that export env vars inside the launched Slurm job shell.
+    @staticmethod
+    def _needs_job_shell_expansion(value: str) -> bool:
+        """Return True when value must be evaluated in the job shell (not stored literally)."""
+        return any(tok in value for tok in ("$", "`"))
 
-        We quote each full `export KEY=value` command so `$SLURM_*` and commas survive
-        argument parsing on the submit node and are expanded/interpreted in the job shell.
+    def _build_env_forwarding_args(self) -> list[str]:
         """
-        exports: list[str] = []
+        Forward ``extra_env_vars`` into Megatron-Bridge / NeMo-Run.
+
+        Static values use ``-E KEY=VALUE`` so they land in NeMo-Run ``env_vars`` and
+        ``container_env`` (required for consumers like nsys ``GPU_METRICS_NODES``).
+        ``-E`` also preserves commas in values, unlike ``--custom_env_vars`` / ``-ce``.
+
+        Values that need job-shell expansion (``$SLURM_*``, ``$((...))``,
+        ``${PYTHONPATH}``, command substitution, etc.) still use ``-cb export ...``
+        so they expand on the compute job rather than being stored as literals.
+        """
+        parts: list[str] = []
         for key, value in sorted(self.final_env_vars.items()):
-            exports.extend(["-cb", shlex.quote(f"export {key}={value}")])
-        return exports
+            value_str = str(value)
+            if self._needs_job_shell_expansion(value_str):
+                parts.extend(["-cb", shlex.quote(f"export {key}={value_str}")])
+            else:
+                parts.extend(["-E", shlex.quote(f"{key}={value_str}")])
+        return parts
 
     def _container_runtime_env_exports(self) -> list[str]:
         """
@@ -236,8 +250,9 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         environment **before** the Megatron-Bridge launcher calls ``sbatch`` so that
         Slurm inherits them into the job and ``srun`` passes them to the container
         runtime.  Exporting them in the wrapper script (which runs on the submit
-        node) achieves this.  The same variables are still passed via ``-cb`` as
-        well, so they are also set inside the container for any runtime readers.
+        node) achieves this.  The same variables are still forwarded via ``-E`` /
+        ``-cb`` as well, so they are also set inside the container for any runtime
+        readers.
         """
         lines: list[str] = []
         for key, value in sorted(self.final_env_vars.items()):
@@ -543,10 +558,9 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if mounts:
             add("-cm", ",".join(mounts))
 
-        # Pass extra env variables as `-cb export KEY=value` commands to avoid Megatron-Bridge's
-        # --custom_env_vars parser limitation for comma-containing values.
+        # Forward extra env vars via -E (NeMo container_env) or -cb (job-shell expansion).
         if self.final_env_vars:
-            parts.extend(self._build_custom_bash_env_exports())
+            parts.extend(self._build_env_forwarding_args())
 
         # Model flags (Megatron-Bridge main-branch API)
         add_field("domain", "--domain", args.domain)

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -235,7 +235,10 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         for key, value in sorted(self.final_env_vars.items()):
             value_str = str(value)
             if self._needs_job_shell_expansion(value_str):
-                parts.extend(["-cb", shlex.quote(f"export {key}={value_str}")])
+                # Quote the RHS so whitespace in the value is preserved when the job
+                # shell runs `export`. Double quotes still allow $VAR / $((...)) expansion.
+                shell_value = value_str.replace('"', '\\"')
+                parts.extend(["-cb", shlex.quote(f'export {key}="{shell_value}"')])
             else:
                 parts.extend(["-E", shlex.quote(f"{key}={value_str}")])
         return parts

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -237,7 +237,9 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             if self._needs_job_shell_expansion(value_str):
                 # Quote the RHS so whitespace in the value is preserved when the job
                 # shell runs `export`. Double quotes still allow $VAR / $((...)) expansion.
-                shell_value = value_str.replace('"', '\\"')
+                # Escape backslashes before quotes so a trailing '\' cannot escape the
+                # closing '"' and so embedded '\"' sequences stay valid.
+                shell_value = value_str.replace("\\", "\\\\").replace('"', '\\"')
                 parts.extend(["-cb", shlex.quote(f'export {key}="{shell_value}"')])
             else:
                 parts.extend(["-E", shlex.quote(f"{key}={value_str}")])

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -214,35 +214,24 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         with log_file.open("w") as f:
             f.write(f"{command}\n")
 
-    @staticmethod
-    def _needs_job_shell_expansion(value: str) -> bool:
-        """Return True when value must be evaluated in the job shell (not stored literally)."""
-        return any(tok in value for tok in ("$", "`"))
-
-    def _build_env_forwarding_args(self) -> list[str]:
+    def _build_custom_bash_env_exports(self) -> list[str]:
         """
-        Forward ``extra_env_vars`` into Megatron-Bridge / NeMo-Run.
+        Build repeated -cb entries that export env vars inside the launched Slurm job shell.
 
-        Static values use ``-E KEY=VALUE`` so they land in NeMo-Run ``env_vars`` and
-        ``container_env`` (required for consumers like nsys ``GPU_METRICS_NODES``).
-        ``-E`` also preserves commas in values, unlike ``--custom_env_vars`` / ``-ce``.
-
-        Values that need job-shell expansion (``$SLURM_*``, ``$((...))``,
-        ``${PYTHONPATH}``, command substitution, etc.) still use ``-cb export ...``
-        so they expand on the compute job rather than being stored as literals.
+        We quote each full `export KEY=value` command so `$SLURM_*` and commas survive
+        argument parsing on the submit node and are expanded/interpreted in the job shell.
         """
-        parts: list[str] = []
+        exports: list[str] = []
         for key, value in sorted(self.final_env_vars.items()):
-            value_str = str(value)
-            if self._needs_job_shell_expansion(value_str):
-                # Quote the RHS so whitespace in the value is preserved when the job
-                # shell runs `export`. Double quotes still allow $VAR / $((...)) expansion.
-                # Escape backslashes before quotes so a trailing '\' cannot escape the
-                # closing '"' and so embedded '\"' sequences stay valid.
-                shell_value = value_str.replace("\\", "\\\\").replace('"', '\\"')
-                parts.extend(["-cb", shlex.quote(f'export {key}="{shell_value}"')])
-            else:
-                parts.extend(["-E", shlex.quote(f"{key}={value_str}")])
+            exports.extend(["-cb", shlex.quote(f"export {key}={value}")])
+        return exports
+
+    @staticmethod
+    def _build_executor_env_args(executor_env_vars: dict[str, str]) -> list[str]:
+        """Build repeated ``-E KEY=VALUE`` entries for NeMo-Run executor environment variables."""
+        parts: list[str] = []
+        for key, value in sorted(executor_env_vars.items()):
+            parts.extend(["-E", shlex.quote(f"{key}={value}")])
         return parts
 
     def _container_runtime_env_exports(self) -> list[str]:
@@ -255,9 +244,8 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         environment **before** the Megatron-Bridge launcher calls ``sbatch`` so that
         Slurm inherits them into the job and ``srun`` passes them to the container
         runtime.  Exporting them in the wrapper script (which runs on the submit
-        node) achieves this.  The same variables are still forwarded via ``-E`` /
-        ``-cb`` as well, so they are also set inside the container for any runtime
-        readers.
+        node) achieves this.  The same variables are still passed via ``-cb`` as
+        well, so they are also set inside the container for any runtime readers.
         """
         lines: list[str] = []
         for key, value in sorted(self.final_env_vars.items()):
@@ -563,9 +551,15 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         if mounts:
             add("-cm", ",".join(mounts))
 
-        # Forward extra env vars via -E (NeMo container_env) or -cb (job-shell expansion).
+        # Preserve extra_env_vars compatibility with Megatron-Bridge versions that
+        # predate -E/--env by forwarding them as job-shell exports.
         if self.final_env_vars:
-            parts.extend(self._build_env_forwarding_args())
+            parts.extend(self._build_custom_bash_env_exports())
+
+        # Explicit opt-in for variables that must be registered in NeMo-Run's
+        # executor env_vars/container_env. Requires Megatron-Bridge -E support.
+        if args.executor_env_vars:
+            parts.extend(self._build_executor_env_args(args.executor_env_vars))
 
         # Model flags (Megatron-Bridge main-branch API)
         add_field("domain", "--domain", args.domain)

--- a/tests/ref_data/megatron-bridge.sbatch
+++ b/tests/ref_data/megatron-bridge.sbatch
@@ -19,7 +19,7 @@ if [ "${WANDB_INSTALL_RC}" -ne 0 ]; then
 fi
 
 LAUNCH_RC=0
-NEMORUN_HOME="__OUTPUT_DIR__/output" __INSTALL_DIR__/Run__main-venv/bin/python __INSTALL_DIR__/Megatron-Bridge__main/scripts/performance/setup_experiment.py -p main -t 00:20:00 -i __OUTPUT_DIR__/output/megatron_bridge_image.sqsh -hf dummy_token -ng 8 -gn 8 -cm __INSTALL_DIR__/Megatron-Bridge__main:/opt/Megatron-Bridge -E CUDA_VISIBLE_DEVICES=0,1,2,3 -E NCCL_DEBUG=INFO -m qwen3 -mr 30b_a3b --detach false --save_config_filepath /nemo_run/configs/ConfigContainer.yaml --additional_slurm_params 'gpus-per-node=8;gres=gpu:8' logger.tensorboard_dir=/nemo_run/tb_logs logger.log_timers_to_tensorboard=true logger.log_throughput_to_tensorboard=true logger.log_memory_to_tensorboard=true >>"$LOG" 2>&1 || LAUNCH_RC=$?
+NEMORUN_HOME="__OUTPUT_DIR__/output" __INSTALL_DIR__/Run__main-venv/bin/python __INSTALL_DIR__/Megatron-Bridge__main/scripts/performance/setup_experiment.py -p main -t 00:20:00 -i __OUTPUT_DIR__/output/megatron_bridge_image.sqsh -hf dummy_token -ng 8 -gn 8 -cm __INSTALL_DIR__/Megatron-Bridge__main:/opt/Megatron-Bridge -cb 'export CUDA_VISIBLE_DEVICES=0,1,2,3' -cb 'export NCCL_DEBUG=INFO' -m qwen3 -mr 30b_a3b --detach false --save_config_filepath /nemo_run/configs/ConfigContainer.yaml --additional_slurm_params 'gpus-per-node=8;gres=gpu:8' logger.tensorboard_dir=/nemo_run/tb_logs logger.log_timers_to_tensorboard=true logger.log_throughput_to_tensorboard=true logger.log_memory_to_tensorboard=true >>"$LOG" 2>&1 || LAUNCH_RC=$?
 
 
 JOB_ID=""

--- a/tests/ref_data/megatron-bridge.sbatch
+++ b/tests/ref_data/megatron-bridge.sbatch
@@ -19,7 +19,7 @@ if [ "${WANDB_INSTALL_RC}" -ne 0 ]; then
 fi
 
 LAUNCH_RC=0
-NEMORUN_HOME="__OUTPUT_DIR__/output" __INSTALL_DIR__/Run__main-venv/bin/python __INSTALL_DIR__/Megatron-Bridge__main/scripts/performance/setup_experiment.py -p main -t 00:20:00 -i __OUTPUT_DIR__/output/megatron_bridge_image.sqsh -hf dummy_token -ng 8 -gn 8 -cm __INSTALL_DIR__/Megatron-Bridge__main:/opt/Megatron-Bridge -cb 'export CUDA_VISIBLE_DEVICES=0,1,2,3' -cb 'export NCCL_DEBUG=INFO' -m qwen3 -mr 30b_a3b --detach false --save_config_filepath /nemo_run/configs/ConfigContainer.yaml --additional_slurm_params 'gpus-per-node=8;gres=gpu:8' logger.tensorboard_dir=/nemo_run/tb_logs logger.log_timers_to_tensorboard=true logger.log_throughput_to_tensorboard=true logger.log_memory_to_tensorboard=true >>"$LOG" 2>&1 || LAUNCH_RC=$?
+NEMORUN_HOME="__OUTPUT_DIR__/output" __INSTALL_DIR__/Run__main-venv/bin/python __INSTALL_DIR__/Megatron-Bridge__main/scripts/performance/setup_experiment.py -p main -t 00:20:00 -i __OUTPUT_DIR__/output/megatron_bridge_image.sqsh -hf dummy_token -ng 8 -gn 8 -cm __INSTALL_DIR__/Megatron-Bridge__main:/opt/Megatron-Bridge -E CUDA_VISIBLE_DEVICES=0,1,2,3 -E NCCL_DEBUG=INFO -m qwen3 -mr 30b_a3b --detach false --save_config_filepath /nemo_run/configs/ConfigContainer.yaml --additional_slurm_params 'gpus-per-node=8;gres=gpu:8' logger.tensorboard_dir=/nemo_run/tb_logs logger.log_timers_to_tensorboard=true logger.log_throughput_to_tensorboard=true logger.log_memory_to_tensorboard=true >>"$LOG" 2>&1 || LAUNCH_RC=$?
 
 
 JOB_ID=""

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -279,6 +279,23 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "-cb 'export PYTHONPATH=\"/opt/Megatron Bridge:${PYTHONPATH}\"'" in wrapper_content
 
+    def test_shell_expanding_env_vars_escape_backslashes(
+        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
+    ) -> None:
+        tr = make_test_run(output_subdir="out_shell_env_bs")
+        tdef = cast(MegatronBridgeTestDefinition, tr.test)
+        tdef.extra_env_vars = {
+            # Trailing '\' must not escape the closing '"' of the export RHS.
+            "CUSTOM_PATH": "C:\\cache\\:${HOME}\\",
+            # Embedded quotes must become \\" after backslash escaping.
+            "LABEL": 'prefix\\"suffix:${TAG}',
+        }
+
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+        wrapper_content = self._wrapper_content(cmd_gen)
+        assert "-cb 'export CUSTOM_PATH=\"C:\\\\cache\\\\:${HOME}\\\\\"'" in wrapper_content
+        assert "-cb 'export LABEL=\"prefix\\\\\\\"suffix:${TAG}\"'" in wrapper_content
+
     def test_container_runtime_env_vars_exported_in_wrapper_script(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
     ) -> None:

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -227,18 +227,40 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "--cuda_graph_scope moe_router,moe_preprocess" in wrapper_content
 
-    def test_env_vars_are_forwarded_via_custom_bash_cmds(
+    def test_static_env_vars_are_forwarded_via_E(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
     ) -> None:
         tr = make_test_run()
         tdef = cast(MegatronBridgeTestDefinition, tr.test)
-        tdef.extra_env_vars = {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "NCCL_DEBUG": "INFO"}
+        tdef.extra_env_vars = {
+            "CUDA_VISIBLE_DEVICES": "0,1,2,3",
+            "NCCL_DEBUG": "INFO",
+            "GPU_METRICS_NODES": "0,1",
+        }
 
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "--custom_env_vars" not in wrapper_content
-        assert "-cb 'export CUDA_VISIBLE_DEVICES=0,1,2,3'" in wrapper_content
-        assert "-cb 'export NCCL_DEBUG=INFO'" in wrapper_content
+        assert "-E CUDA_VISIBLE_DEVICES=0,1,2,3" in wrapper_content
+        assert "-E NCCL_DEBUG=INFO" in wrapper_content
+        assert "-E GPU_METRICS_NODES=0,1" in wrapper_content
+
+    def test_shell_expanding_env_vars_are_forwarded_via_cb(
+        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
+    ) -> None:
+        tr = make_test_run(output_subdir="out_shell_env")
+        tdef = cast(MegatronBridgeTestDefinition, tr.test)
+        tdef.extra_env_vars = {
+            "PYTHONPATH": "/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}",
+            "NCCL_MNNVL_CLIQUE_ID": "$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))",
+            "NCCL_DEBUG": "INFO",
+        }
+
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+        wrapper_content = self._wrapper_content(cmd_gen)
+        assert "-cb 'export PYTHONPATH=/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}'" in wrapper_content
+        assert "-cb 'export NCCL_MNNVL_CLIQUE_ID=$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))'" in wrapper_content
+        assert "-E NCCL_DEBUG=INFO" in wrapper_content
 
     def test_container_runtime_env_vars_exported_in_wrapper_script(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
@@ -264,10 +286,10 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         assert mvd_idx < launcher_idx, "MELLANOX_VISIBLE_DEVICES must be exported before the launcher"
         assert nvd_idx < launcher_idx, "NVIDIA_VISIBLE_DEVICES must be exported before the launcher"
 
-        assert "-cb 'export MELLANOX_VISIBLE_DEVICES=0,1,4,5'" in wrapper_content
-        assert "-cb 'export NVIDIA_VISIBLE_DEVICES=all'" in wrapper_content
-        assert "-cb 'export NCCL_IB_HCA=roce_p0_r0,roce_p0_r1,roce_p0_r2,roce_p0_r3'" in wrapper_content
-        assert "-cb 'export NCCL_DEBUG=INFO'" in wrapper_content
+        assert "-E MELLANOX_VISIBLE_DEVICES=0,1,4,5" in wrapper_content
+        assert "-E NVIDIA_VISIBLE_DEVICES=all" in wrapper_content
+        assert "-E NCCL_IB_HCA=roce_p0_r0,roce_p0_r1,roce_p0_r2,roce_p0_r3" in wrapper_content
+        assert "-E NCCL_DEBUG=INFO" in wrapper_content
 
         assert "export NCCL_IB_HCA=" not in wrapper_content.split("setup_experiment.py")[0]
         assert "export NCCL_DEBUG=" not in wrapper_content.split("setup_experiment.py")[0]

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -227,72 +227,36 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "--cuda_graph_scope moe_router,moe_preprocess" in wrapper_content
 
-    def test_static_env_vars_are_forwarded_via_E(
+    def test_env_vars_are_forwarded_via_custom_bash_cmds(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
     ) -> None:
         tr = make_test_run()
         tdef = cast(MegatronBridgeTestDefinition, tr.test)
-        tdef.extra_env_vars = {
-            "CUDA_VISIBLE_DEVICES": "0,1,2,3",
-            "NCCL_DEBUG": "INFO",
-            "GPU_METRICS_NODES": "0,1",
-        }
+        tdef.extra_env_vars = {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "NCCL_DEBUG": "INFO"}
+
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+        wrapper_content = self._wrapper_content(cmd_gen)
+        assert "--custom_env_vars" not in wrapper_content
+        assert "-cb 'export CUDA_VISIBLE_DEVICES=0,1,2,3'" in wrapper_content
+        assert "-cb 'export NCCL_DEBUG=INFO'" in wrapper_content
+        assert " -E " not in f" {wrapper_content} "
+
+    def test_executor_env_vars_are_forwarded_via_E(
+        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
+    ) -> None:
+        tr = make_test_run(
+            output_subdir="out_executor_env",
+            cmd_args_overrides={"executor_env_vars": {"GPU_METRICS_NODES": "0,1", "NCCL_DEBUG": "INFO"}},
+        )
 
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "--custom_env_vars" not in wrapper_content
         assert " -ce " not in f" {wrapper_content} "
-        assert "-cb" not in wrapper_content
-        assert "-E CUDA_VISIBLE_DEVICES=0,1,2,3" in wrapper_content
-        assert "-E NCCL_DEBUG=INFO" in wrapper_content
         assert "-E GPU_METRICS_NODES=0,1" in wrapper_content
-
-    def test_shell_expanding_env_vars_are_forwarded_via_cb(
-        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
-    ) -> None:
-        tr = make_test_run(output_subdir="out_shell_env")
-        tdef = cast(MegatronBridgeTestDefinition, tr.test)
-        tdef.extra_env_vars = {
-            "PYTHONPATH": "/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}",
-            "NCCL_MNNVL_CLIQUE_ID": "$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))",
-            "NCCL_DEBUG": "INFO",
-        }
-
-        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
-        wrapper_content = self._wrapper_content(cmd_gen)
-        assert "-cb 'export PYTHONPATH=\"/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}\"'" in wrapper_content
-        assert "-cb 'export NCCL_MNNVL_CLIQUE_ID=\"$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))\"'" in wrapper_content
         assert "-E NCCL_DEBUG=INFO" in wrapper_content
-
-    def test_shell_expanding_env_vars_with_whitespace_are_quoted(
-        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
-    ) -> None:
-        tr = make_test_run(output_subdir="out_shell_env_ws")
-        tdef = cast(MegatronBridgeTestDefinition, tr.test)
-        tdef.extra_env_vars = {
-            "PYTHONPATH": "/opt/Megatron Bridge:${PYTHONPATH}",
-        }
-
-        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
-        wrapper_content = self._wrapper_content(cmd_gen)
-        assert "-cb 'export PYTHONPATH=\"/opt/Megatron Bridge:${PYTHONPATH}\"'" in wrapper_content
-
-    def test_shell_expanding_env_vars_escape_backslashes(
-        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
-    ) -> None:
-        tr = make_test_run(output_subdir="out_shell_env_bs")
-        tdef = cast(MegatronBridgeTestDefinition, tr.test)
-        tdef.extra_env_vars = {
-            # Trailing '\' must not escape the closing '"' of the export RHS.
-            "CUSTOM_PATH": "C:\\cache\\:${HOME}\\",
-            # Embedded quotes must become \\" after backslash escaping.
-            "LABEL": 'prefix\\"suffix:${TAG}',
-        }
-
-        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
-        wrapper_content = self._wrapper_content(cmd_gen)
-        assert "-cb 'export CUSTOM_PATH=\"C:\\\\cache\\\\:${HOME}\\\\\"'" in wrapper_content
-        assert '-cb \'export LABEL="prefix\\\\\\"suffix:${TAG}"\'' in wrapper_content
+        assert "-cb 'export GPU_METRICS_NODES=0,1'" not in wrapper_content
+        assert "-cb 'export NCCL_DEBUG=INFO'" not in wrapper_content
 
     def test_container_runtime_env_vars_exported_in_wrapper_script(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
@@ -318,10 +282,10 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         assert mvd_idx < launcher_idx, "MELLANOX_VISIBLE_DEVICES must be exported before the launcher"
         assert nvd_idx < launcher_idx, "NVIDIA_VISIBLE_DEVICES must be exported before the launcher"
 
-        assert "-E MELLANOX_VISIBLE_DEVICES=0,1,4,5" in wrapper_content
-        assert "-E NVIDIA_VISIBLE_DEVICES=all" in wrapper_content
-        assert "-E NCCL_IB_HCA=roce_p0_r0,roce_p0_r1,roce_p0_r2,roce_p0_r3" in wrapper_content
-        assert "-E NCCL_DEBUG=INFO" in wrapper_content
+        assert "-cb 'export MELLANOX_VISIBLE_DEVICES=0,1,4,5'" in wrapper_content
+        assert "-cb 'export NVIDIA_VISIBLE_DEVICES=all'" in wrapper_content
+        assert "-cb 'export NCCL_IB_HCA=roce_p0_r0,roce_p0_r1,roce_p0_r2,roce_p0_r3'" in wrapper_content
+        assert "-cb 'export NCCL_DEBUG=INFO'" in wrapper_content
 
         assert "export NCCL_IB_HCA=" not in wrapper_content.split("setup_experiment.py")[0]
         assert "export NCCL_DEBUG=" not in wrapper_content.split("setup_experiment.py")[0]

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -258,9 +258,26 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
 
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
-        assert "-cb 'export PYTHONPATH=/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}'" in wrapper_content
-        assert "-cb 'export NCCL_MNNVL_CLIQUE_ID=$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))'" in wrapper_content
+        assert (
+            "-cb 'export PYTHONPATH=\"/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}\"'" in wrapper_content
+        )
+        assert (
+            "-cb 'export NCCL_MNNVL_CLIQUE_ID=\"$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))\"'" in wrapper_content
+        )
         assert "-E NCCL_DEBUG=INFO" in wrapper_content
+
+    def test_shell_expanding_env_vars_with_whitespace_are_quoted(
+        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
+    ) -> None:
+        tr = make_test_run(output_subdir="out_shell_env_ws")
+        tdef = cast(MegatronBridgeTestDefinition, tr.test)
+        tdef.extra_env_vars = {
+            "PYTHONPATH": "/opt/Megatron Bridge:${PYTHONPATH}",
+        }
+
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+        wrapper_content = self._wrapper_content(cmd_gen)
+        assert "-cb 'export PYTHONPATH=\"/opt/Megatron Bridge:${PYTHONPATH}\"'" in wrapper_content
 
     def test_container_runtime_env_vars_exported_in_wrapper_script(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -241,6 +241,8 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "--custom_env_vars" not in wrapper_content
+        assert " -ce " not in f" {wrapper_content} "
+        assert "-cb" not in wrapper_content
         assert "-E CUDA_VISIBLE_DEVICES=0,1,2,3" in wrapper_content
         assert "-E NCCL_DEBUG=INFO" in wrapper_content
         assert "-E GPU_METRICS_NODES=0,1" in wrapper_content

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -258,12 +258,8 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
 
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
-        assert (
-            "-cb 'export PYTHONPATH=\"/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}\"'" in wrapper_content
-        )
-        assert (
-            "-cb 'export NCCL_MNNVL_CLIQUE_ID=\"$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))\"'" in wrapper_content
-        )
+        assert "-cb 'export PYTHONPATH=\"/opt/Megatron-Bridge/3rdparty/Megatron-LM:${PYTHONPATH}\"'" in wrapper_content
+        assert "-cb 'export NCCL_MNNVL_CLIQUE_ID=\"$(( ($SLURM_PROCID)  / ($CLIQUE_SIZE) ))\"'" in wrapper_content
         assert "-E NCCL_DEBUG=INFO" in wrapper_content
 
     def test_shell_expanding_env_vars_with_whitespace_are_quoted(
@@ -294,7 +290,7 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "-cb 'export CUSTOM_PATH=\"C:\\\\cache\\\\:${HOME}\\\\\"'" in wrapper_content
-        assert "-cb 'export LABEL=\"prefix\\\\\\\"suffix:${TAG}\"'" in wrapper_content
+        assert '-cb \'export LABEL="prefix\\\\\\"suffix:${TAG}"\'' in wrapper_content
 
     def test_container_runtime_env_vars_exported_in_wrapper_script(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]


### PR DESCRIPTION
Register TOML extra_env_vars in NeMo-Run container_env so consumers like nsys GPU_METRICS_NODES see them at container start. Keep -cb only for values that need job-shell expansion.

## Summary
- Forward Megatron-Bridge TOML extra_env_vars via -E into NeMo-Run container_env
  (needed for nsys GPU_METRICS_NODES and similar early consumers).
- Keep -cb only for job-shell expansion ($SLURM_*, arithmetic, ${PYTHONPATH}, etc.).
- Avoid -ce because comma-splitting breaks values like 0,1,2.

## Test Plan
- [x] Unit tests for -E / -cb / container-runtime env forwarding
- [ ] Profiled run with GPU_METRICS_NODES in extra_env_vars (no MBridge patch)
- [ ] Confirm PYTHONPATH=${PYTHONPATH} patterns still expand via -cb

## Additional Notes
My original problem was populating GPU_METRICS_NODES but i preffred a more wholistic solution that just handling GPU_METRICS_NODES
