### PR TITLE
[MBridge] configurable wandb version

### DIFF
--- a/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
+++ b/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
@@ -58,6 +58,7 @@ class MegatronBridgeCmdArgs(CmdArgs):
     wandb_entity_name: Optional[str] = Field(default=None)
     wandb_experiment_name: Optional[str] = Field(default=None)
     wandb_save_dir: Optional[str] = Field(default=None)
+    wandb_version: str = Field(default="0.28.1", description="W&B version installed in the launcher environment.")
 
     # Retries
     max_retries: Optional[int] = Field(default=1)

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -89,6 +89,7 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         full_cmd = self._wrap_launcher_for_job_id_and_quiet_output(
             " ".join(parts),
             launcher_python,
+            args.wandb_version,
             pre_hook_sbatch_path=pre_hook_sbatch_path,
             base_slurm_params=base_slurm_params,
             capture_nodelist=capture_nodelist,
@@ -292,6 +293,7 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         self,
         launcher_cmd: str,
         launcher_python: str,
+        wandb_version: str,
         pre_hook_sbatch_path: Optional[Path] = None,
         base_slurm_params: str = "",
         capture_nodelist: bool = False,
@@ -378,9 +380,9 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
             *pre_hook_lines,
             ': >"$LOG"',
             "WANDB_INSTALL_RC=0",
-            f'{shlex.quote(launcher_python)} -m pip install wandb numpy==1.26.4 >>"$LOG" 2>&1 || WANDB_INSTALL_RC=$?',
+            f'{shlex.quote(launcher_python)} -m pip install wandb=={wandb_version} numpy==1.26.4 >>"$LOG" 2>&1 || WANDB_INSTALL_RC=$?',  # noqa: E501
             'if [ "${WANDB_INSTALL_RC}" -ne 0 ]; then',
-            '  echo "Failed to install runtime deps (wandb, numpy==1.26.4) in launcher venv (exit ${WANDB_INSTALL_RC})." >&2',  # noqa: E501
+            f'  echo "Failed to install runtime deps (wandb=={wandb_version}, numpy==1.26.4) in launcher venv (exit ${{WANDB_INSTALL_RC}})." >&2',  # noqa: E501
             '  tail -n 40 "$LOG" >&2 || true',
             '  exit "${WANDB_INSTALL_RC}"',
             "fi",

--- a/tests/ref_data/megatron-bridge.sbatch
+++ b/tests/ref_data/megatron-bridge.sbatch
@@ -11,9 +11,9 @@ exec > >(tee -a "$WRAPPER_STDOUT") 2> >(tee -a "$WRAPPER_STDERR" >&2)
 
 : >"$LOG"
 WANDB_INSTALL_RC=0
-__INSTALL_DIR__/Run__main-venv/bin/python -m pip install wandb numpy==1.26.4 >>"$LOG" 2>&1 || WANDB_INSTALL_RC=$?
+__INSTALL_DIR__/Run__main-venv/bin/python -m pip install wandb==0.28.1 numpy==1.26.4 >>"$LOG" 2>&1 || WANDB_INSTALL_RC=$?
 if [ "${WANDB_INSTALL_RC}" -ne 0 ]; then
-  echo "Failed to install runtime deps (wandb, numpy==1.26.4) in launcher venv (exit ${WANDB_INSTALL_RC})." >&2
+  echo "Failed to install runtime deps (wandb==0.28.1, numpy==1.26.4) in launcher venv (exit ${WANDB_INSTALL_RC})." >&2
   tail -n 40 "$LOG" >&2 || true
   exit "${WANDB_INSTALL_RC}"
 fi

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -267,10 +267,18 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
 
-        assert "-m pip install wandb numpy==1.26.4" in wrapper_content
-        wandb_idx = wrapper_content.index("-m pip install wandb")
+        assert "-m pip install wandb==0.28.1 numpy==1.26.4" in wrapper_content
+        wandb_idx = wrapper_content.index("-m pip install wandb==0.28.1")
         launcher_idx = wrapper_content.index("setup_experiment.py")
         assert wandb_idx < launcher_idx
+
+    def test_wrapper_uses_configured_wandb_version(
+        self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
+    ) -> None:
+        tr = make_test_run(cmd_args_overrides={"wandb_version": "0.27.2"})
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+
+        assert "-m pip install wandb==0.27.2 numpy==1.26.4" in self._wrapper_content(cmd_gen)
 
     def test_wrapper_exits_when_wandb_install_fails(
         self, configured_slurm_system: SlurmSystem, make_test_run: Callable[..., TestRun]
@@ -281,7 +289,7 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
 
         assert 'if [ "${WANDB_INSTALL_RC}" -ne 0 ]; then' in wrapper_content
         assert (
-            'echo "Failed to install runtime deps (wandb, numpy==1.26.4) in launcher venv (exit '
+            'echo "Failed to install runtime deps (wandb==0.28.1, numpy==1.26.4) in launcher venv (exit '
             '${WANDB_INSTALL_RC})." >&2'
         ) in wrapper_content
         assert 'exit "${WANDB_INSTALL_RC}"' in wrapper_content


### PR DESCRIPTION
## Summary

`wandb` package broke backwards compatibility that MBridge implementation used. This is fixed by pinning wandb to the latest safe version and letting it be configurable, so that users aren't blocked when MBridge implementation switches to the new version

## Test Plan
- Automated CI
- Manual runs using different MBridge versions: 0.3.0 and 0.4.0

## Additional Notes
N/A
