### PR TITLE
fix(test_scenario): stop apply_params_set writing NUM_NODES into cmd_args

### DIFF
--- a/src/cloudai/_core/test_scenario.py
+++ b/src/cloudai/_core/test_scenario.py
@@ -217,6 +217,10 @@ class TestRun:
         for key, value in full_action.items():
             if key.startswith("extra_env_vars."):
                 tdef.extra_env_vars[key[len("extra_env_vars.") :]] = value
+            elif key == "NUM_NODES":
+                # Handled below via new_tr.num_nodes; cmd_args has no such field, and CmdArgs'
+                # extra="allow" would otherwise let this create a phantom attribute on it.
+                continue
             else:
                 attrs = key.split(".")
                 obj = tdef.cmd_args

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -335,6 +335,7 @@ def test_params_set(setup_env: tuple[TestRun, Runner], num_nodes: int):
                 assert new_tr.test.extra_env_vars[key[len("extra_env_vars.") :]] == value
             elif key == "NUM_NODES":
                 assert new_tr.num_nodes == value
+                assert "NUM_NODES" not in cmd_args
             else:
                 assert cmd_args[key] == value
 


### PR DESCRIPTION
## Summary

`TestRun.param_space` (`src/cloudai/_core/test_scenario.py`) adds a `"NUM_NODES"` key to the
action space whenever `num_nodes` is a sweep list. `apply_params_set` then does two things
with that key: a generic per-key loop applies every action key to `tdef.cmd_args` via
`setattr`, and an explicit branch right after separately assigns it to `new_tr.num_nodes`.
Both fire on `"NUM_NODES"`. Because `CmdArgs` is `ConfigDict(extra="allow")`, the generic
loop's `setattr(tdef.cmd_args, "NUM_NODES", value)` does not raise: it silently creates a
phantom `NUM_NODES` field on `cmd_args` that shows up in `cmd_args.model_dump()` and in any
persisted `TestRunDetails` dump, even though the workload itself never declared or accepted
that field. `new_tr.num_nodes` is still set correctly by the explicit branch, so the actual
job dispatch is unaffected, only the recorded/reported config is wrong.

Fix: skip `"NUM_NODES"` in the generic loop, since the explicit branch already owns it.

## Test Plan

- `tests/test_cloudaigym.py::test_params_set` exercised every `num_nodes` sweep shape
  (`1`, `[1, 2]`, `[3]`) already, but never asserted the field was absent from `cmd_args`.
  Added that assertion; confirmed it fails on `main` (`AssertionError: 'NUM_NODES' in
  {...}`) and passes with this change.
- `uv run pytest` (Python 3.14): full suite green except two pre-existing failures in
  `tests/test_base_installer.py::TestPrepareOutputDir` unrelated to this change (they assert
  a chmod-000 directory is unwritable, which does not hold when the test runs as root).
- `uv run pytest -m ci_only`, `--dead-fixtures`, and `coverage report --include='tests/*'
  --fail-under=97.00` (98.92% here) all pass.
- `uv run pre-commit run --files src/cloudai/_core/test_scenario.py tests/test_cloudaigym.py`
  (pyright, ruff, vulture, import-linter, taplo) passes; controlled the same command on
  pristine `main` first to confirm a clean baseline.
