### PR TITLE
[Agents] register reward functions through entry-points

### DIFF
--- a/doc/USER_GUIDE.rst
+++ b/doc/USER_GUIDE.rst
@@ -206,6 +206,31 @@ action, typically seeded by ``random_seed``.
 
 Custom agents may extend the ``BaseAgentConfig`` and offer more parameters to configure.
 
+Custom reward functions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+External Python packages can expose reward functions to CloudAI through the
+``cloudai.reward_functions`` entry point group. For example, a package can register a function in its
+``pyproject.toml`` as follows:
+
+.. code-block:: toml
+
+   [project.entry-points."cloudai.reward_functions"]
+   my_reward = "my_package.rewards:my_reward"
+
+The exported object must be callable with a ``list[float]`` containing the configured metric values and return a
+``float`` reward. Entry point reward functions are discovered when CloudAI starts but imported only when they are
+selected or listed. Select one by setting ``agent_reward_function`` to its entry point name:
+
+.. code-block:: toml
+
+   [[Tests]]
+   id = "Tests.1"
+   test_name = "nccl_test_all_reduce"
+   agent_reward_function = "my_reward"
+
+Run ``cloudai list reward-functions`` to list built-in and entry point reward functions.
+
 DSE parameter exclusions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/USER_GUIDE.rst
+++ b/doc/USER_GUIDE.rst
@@ -206,31 +206,6 @@ action, typically seeded by ``random_seed``.
 
 Custom agents may extend the ``BaseAgentConfig`` and offer more parameters to configure.
 
-Custom reward functions
-~~~~~~~~~~~~~~~~~~~~~~~
-
-External Python packages can expose reward functions to CloudAI through the
-``cloudai.reward_functions`` entry point group. For example, a package can register a function in its
-``pyproject.toml`` as follows:
-
-.. code-block:: toml
-
-   [project.entry-points."cloudai.reward_functions"]
-   my_reward = "my_package.rewards:my_reward"
-
-The exported object must be callable with a ``list[float]`` containing the configured metric values and return a
-``float`` reward. Entry point reward functions are discovered when CloudAI starts but imported only when they are
-selected or listed. Select one by setting ``agent_reward_function`` to its entry point name:
-
-.. code-block:: toml
-
-   [[Tests]]
-   id = "Tests.1"
-   test_name = "nccl_test_all_reduce"
-   agent_reward_function = "my_reward"
-
-Run ``cloudai list reward-functions`` to list built-in and entry point reward functions.
-
 DSE parameter exclusions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, List, Set, Tuple, Type
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, List, Set, Tuple, Type, cast
 
 if TYPE_CHECKING:
     from ..configurator.base_agent import BaseAgent
@@ -59,6 +59,7 @@ class Registry(metaclass=Singleton):
     scenario_reports: ClassVar[dict[str, type[Reporter]]] = {}
     report_configs: ClassVar[dict[str, ReportConfig]] = {}
     reward_functions_map: ClassVar[dict[str, RewardFunction]] = {}
+    reward_function_entrypoints_map: ClassVar[dict[str, Any]] = {}
     command_gen_strategies_map: ClassVar[dict[tuple[Type[System], Type[TestDefinition]], Type[CommandGenStrategy]]] = {}
     json_gen_strategies_map: ClassVar[dict[tuple[Type[System], Type[TestDefinition]], Type[JsonGenStrategy]]] = {}
     grading_strategies_map: ClassVar[dict[Tuple[Type[System], Type[TestDefinition]], Type[GradingStrategy]]] = {}
@@ -283,19 +284,50 @@ class Registry(metaclass=Singleton):
         return sorted(self.scenario_reports.items(), key=lambda kv: report_order(kv[0]))
 
     def add_reward_function(self, name: str, value: RewardFunction) -> None:
-        if name in self.reward_functions_map:
+        if self.has_reward_function(name):
             raise ValueError(f"Duplicating implementation for '{name}', use 'update()' for replacement.")
         self.update_reward_function(name, value)
 
     def update_reward_function(self, name: str, value: RewardFunction) -> None:
         self.reward_functions_map[name] = value
+        self.reward_function_entrypoints_map.pop(name, None)
+
+    def add_entrypoint_reward_function(self, name: str, value: Any) -> None:
+        """Add a lazily loaded entry point reward function mapping."""
+        if self.has_reward_function(name):
+            raise ValueError(f"Duplicating implementation for '{name}', use 'update()' for replacement.")
+        self.reward_function_entrypoints_map[name] = value
+
+    def has_reward_function(self, name: str) -> bool:
+        """Return whether a reward function is registered or available as a lazy entry point."""
+        return name in self.reward_functions_map or name in self.reward_function_entrypoints_map
+
+    def reward_function_names(self) -> list[str]:
+        """Return all registered reward function names, including unresolved entry points."""
+        return sorted(set(self.reward_functions_map) | set(self.reward_function_entrypoints_map))
 
     def get_reward_function(self, name: str) -> RewardFunction:
-        if name not in self.reward_functions_map:
-            raise KeyError(
-                f"Reward function '{name}' not found. Available functions: {list(self.reward_functions_map.keys())}"
+        """Resolve a reward function by name, loading entry point functions on first use."""
+        if name in self.reward_functions_map:
+            return self.reward_functions_map[name]
+
+        if name not in self.reward_function_entrypoints_map:
+            raise KeyError(f"Reward function '{name}' not found. Available functions: {self.reward_function_names()}")
+
+        ep = self.reward_function_entrypoints_map[name]
+        reward_function = ep.load()
+        reward_function = cast(RewardFunction, reward_function)
+
+        if not callable(reward_function):
+            warnings.warn(
+                f"Skipping entrypoint: {name} -> {ep.value} object={reward_function} (not callable)", stacklevel=2
             )
-        return self.reward_functions_map[name]
+            raise TypeError(
+                f"Entry point reward function '{name}' resolved to {reward_function}, which is not callable."
+            )
+
+        self.update_reward_function(name, reward_function)
+        return reward_function
 
     def add_command_gen_strategy(
         self, system_type: Type[System], tdef_type: Type[TestDefinition], value: Type[CommandGenStrategy]

--- a/src/cloudai/_core/registry.py
+++ b/src/cloudai/_core/registry.py
@@ -293,21 +293,17 @@ class Registry(metaclass=Singleton):
         self.reward_function_entrypoints_map.pop(name, None)
 
     def add_entrypoint_reward_function(self, name: str, value: Any) -> None:
-        """Add a lazily loaded entry point reward function mapping."""
         if self.has_reward_function(name):
             raise ValueError(f"Duplicating implementation for '{name}', use 'update()' for replacement.")
         self.reward_function_entrypoints_map[name] = value
 
     def has_reward_function(self, name: str) -> bool:
-        """Return whether a reward function is registered or available as a lazy entry point."""
         return name in self.reward_functions_map or name in self.reward_function_entrypoints_map
 
     def reward_function_names(self) -> list[str]:
-        """Return all registered reward function names, including unresolved entry points."""
         return sorted(set(self.reward_functions_map) | set(self.reward_function_entrypoints_map))
 
     def get_reward_function(self, name: str) -> RewardFunction:
-        """Resolve a reward function by name, loading entry point functions on first use."""
         if name in self.reward_functions_map:
             return self.reward_functions_map[name]
 
@@ -315,8 +311,7 @@ class Registry(metaclass=Singleton):
             raise KeyError(f"Reward function '{name}' not found. Available functions: {self.reward_function_names()}")
 
         ep = self.reward_function_entrypoints_map[name]
-        reward_function = ep.load()
-        reward_function = cast(RewardFunction, reward_function)
+        reward_function = cast(RewardFunction, ep.load())
 
         if not callable(reward_function):
             warnings.warn(

--- a/src/cloudai/cli/cli.py
+++ b/src/cloudai/cli/cli.py
@@ -272,7 +272,7 @@ def verify_configs(configs_dir: Path, tests_dir: Path):
 
 
 @main.command()
-@click.argument("type", type=click.Choice(["reports", "agents"], case_sensitive=False))
+@click.argument("type", type=click.Choice(["reports", "agents", "reward-functions"], case_sensitive=False))
 @click.option("-v", "--verbose", is_flag=True, default=False, help="Verbose output.")
 def list(type: str, verbose: bool):
     """List available in Registry items."""

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -631,5 +631,14 @@ def handle_list_registered_items(item_type: str, verbose: bool) -> int:
             if verbose:
                 string += f"{agent.__doc__}"
             print(string)
+    elif item_type.lower() == "reward-functions":
+        print("Available reward functions:")
+        for idx, name in enumerate(registry.reward_function_names(), start=1):
+            reward_function = registry.get_reward_function(name)
+            callable_name = getattr(reward_function, "__name__", type(reward_function).__name__)
+            string = f'{idx}. "{name}" function={callable_name}'
+            if verbose:
+                string += f"{getattr(reward_function, '__doc__', None) or ''}"
+            print(string)
 
     return 0

--- a/src/cloudai/cli/handlers.py
+++ b/src/cloudai/cli/handlers.py
@@ -614,7 +614,7 @@ def load_tomls_by_type(tomls: List[Path]) -> dict[str, List[Path]]:
     return files
 
 
-def handle_list_registered_items(item_type: str, verbose: bool) -> int:
+def handle_list_registered_items(item_type: str, verbose: bool) -> int:  # noqa: C901
     registry = Registry()
     if item_type.lower() == "reports":
         print("Available scenario reports:")
@@ -638,7 +638,9 @@ def handle_list_registered_items(item_type: str, verbose: bool) -> int:
             callable_name = getattr(reward_function, "__name__", type(reward_function).__name__)
             string = f'{idx}. "{name}" function={callable_name}'
             if verbose:
-                string += f"{getattr(reward_function, '__doc__', None) or ''}"
+                documentation = getattr(reward_function, "__doc__", None)
+                if documentation:
+                    string += f" {documentation}"
             print(string)
 
     return 0

--- a/src/cloudai/registration.py
+++ b/src/cloudai/registration.py
@@ -25,6 +25,14 @@ def register_entrypoint_agents():
         Registry().add_entrypoint_agent(ep.name, ep)
 
 
+def register_entrypoint_reward_functions():
+    from cloudai.core import Registry
+
+    eps = entry_points(group="cloudai.reward_functions")
+    for ep in eps:
+        Registry().add_entrypoint_reward_function(ep.name, ep)
+
+
 def register_all():
     """Register all workloads, systems, runners, installers, and strategies."""
     from cloudai.configurator.grid_search import GridSearchAgent
@@ -377,3 +385,4 @@ def register_all():
     Registry().add_reward_function("ai_dynamo_log_scale", ai_dynamo_log_scale_reward)
 
     register_entrypoint_agents()
+    register_entrypoint_reward_functions()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,14 @@ def test_version():
     assert "CloudAI, version" in result.output
 
 
+def test_list_reward_functions_verbose():
+    runner = CliRunner()
+    result = runner.invoke(main, ["list", "reward-functions", "--verbose"])
+
+    assert result.exit_code == 0
+    assert "Available reward functions:" in result.output
+
+
 def test_tests_dir_is_optional(tmp_path: Path):
     system_cfg, scenario_cfg = tmp_path / "system.toml", tmp_path / "scenario.toml"
     system_cfg.touch()

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -162,8 +162,8 @@ def test_compute_reward_invalid(base_tr: TestRun):
 
     assert "Reward function 'nonexistent' not found" in str(exc_info.value)
     assert (
-        "Available functions: ['inverse', 'negative', 'identity', "
-        "'ai_dynamo_weighted_normalized', 'ai_dynamo_ratio_normalized', 'ai_dynamo_log_scale']" in str(exc_info.value)
+        "Available functions: ['ai_dynamo_log_scale', 'ai_dynamo_ratio_normalized', "
+        "'ai_dynamo_weighted_normalized', 'identity', 'inverse', 'negative']" in str(exc_info.value)
     )
 
 

--- a/tests/test_cloudaigym.py
+++ b/tests/test_cloudaigym.py
@@ -161,10 +161,16 @@ def test_compute_reward_invalid(base_tr: TestRun):
         CloudAIGymEnv(test_run=base_tr, runner=MagicMock(), rewards=RewardOverrides())
 
     assert "Reward function 'nonexistent' not found" in str(exc_info.value)
-    assert (
-        "Available functions: ['ai_dynamo_log_scale', 'ai_dynamo_ratio_normalized', "
-        "'ai_dynamo_weighted_normalized', 'identity', 'inverse', 'negative']" in str(exc_info.value)
-    )
+    error = str(exc_info.value)
+    expected_names = {
+        "ai_dynamo_log_scale",
+        "ai_dynamo_ratio_normalized",
+        "ai_dynamo_weighted_normalized",
+        "identity",
+        "inverse",
+        "negative",
+    }
+    assert all(f"'{name}'" in error for name in expected_names)
 
 
 def test_tr_output_path(setup_env: tuple[TestRun, BaseRunner]):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,7 +38,7 @@ from cloudai.core import (
 )
 from cloudai.models.scenario import ReportConfig
 from cloudai.models.workload import TestDefinition
-from cloudai.registration import register_entrypoint_agents
+from cloudai.registration import register_entrypoint_agents, register_entrypoint_reward_functions
 
 
 class MyTestDefinition(TestDefinition):
@@ -476,3 +476,150 @@ def test_lazy_entrypoint_agent_avoids_import_order_circular_import(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "CircularImportAgent"
+
+
+def test_entrypoint_reward_function_registration_is_lazy():
+    def reward(values: list[float]) -> float:
+        return sum(values)
+
+    class MockEP:
+        name = "lazy_reward"
+        value = "reward_package:reward"
+
+        def __init__(self):
+            self.load_count = 0
+
+        def load(self):
+            self.load_count += 1
+            return reward
+
+    registry = Registry()
+    old_reward = registry.reward_functions_map.pop("lazy_reward", None)
+    old_ep = registry.reward_function_entrypoints_map.pop("lazy_reward", None)
+    ep = MockEP()
+
+    try:
+        with patch("cloudai.registration.entry_points", return_value=[ep]) as mocked_entry_points:
+            register_entrypoint_reward_functions()
+
+        mocked_entry_points.assert_called_once_with(group="cloudai.reward_functions")
+        assert ep.load_count == 0
+        assert registry.has_reward_function("lazy_reward")
+        assert "lazy_reward" in registry.reward_function_names()
+        assert registry.get_reward_function("lazy_reward") is reward
+        assert ep.load_count == 1
+        assert registry.get_reward_function("lazy_reward") is reward
+        assert ep.load_count == 1
+        assert "lazy_reward" not in registry.reward_function_entrypoints_map
+    finally:
+        registry.reward_functions_map.pop("lazy_reward", None)
+        registry.reward_function_entrypoints_map.pop("lazy_reward", None)
+        if old_reward is not None:
+            registry.update_reward_function("lazy_reward", old_reward)
+        if old_ep is not None:
+            registry.add_entrypoint_reward_function("lazy_reward", old_ep)
+
+
+def test_entrypoint_reward_function_type_verified():
+    class MockEP:
+        name = "invalid_reward"
+        value = "reward_package:not_callable"
+
+        def load(self):
+            return 42
+
+    registry = Registry()
+    old_reward = registry.reward_functions_map.pop("invalid_reward", None)
+    old_ep = registry.reward_function_entrypoints_map.pop("invalid_reward", None)
+
+    try:
+        registry.add_entrypoint_reward_function("invalid_reward", MockEP())
+        with (
+            pytest.warns(UserWarning, match="not callable"),
+            pytest.raises(TypeError, match="not callable"),
+        ):
+            registry.get_reward_function("invalid_reward")
+    finally:
+        registry.reward_functions_map.pop("invalid_reward", None)
+        registry.reward_function_entrypoints_map.pop("invalid_reward", None)
+        if old_reward is not None:
+            registry.update_reward_function("invalid_reward", old_reward)
+        if old_ep is not None:
+            registry.add_entrypoint_reward_function("invalid_reward", old_ep)
+
+
+def test_entrypoint_reward_function_duplicate_and_update_behavior():
+    class MockEP:
+        value = "reward_package:reward"
+
+        def load(self):
+            return lambda values: sum(values)
+
+    registry = Registry()
+    names = ["concrete_reward", "entrypoint_reward"]
+    old_rewards = {name: registry.reward_functions_map.pop(name, None) for name in names}
+    old_eps = {name: registry.reward_function_entrypoints_map.pop(name, None) for name in names}
+
+    def replacement(values: list[float]) -> float:
+        return sum(values)
+
+    try:
+        registry.add_reward_function("concrete_reward", replacement)
+        with pytest.raises(ValueError, match="Duplicating implementation"):
+            registry.add_entrypoint_reward_function("concrete_reward", MockEP())
+
+        registry.add_entrypoint_reward_function("entrypoint_reward", MockEP())
+        with pytest.raises(ValueError, match="Duplicating implementation"):
+            registry.add_entrypoint_reward_function("entrypoint_reward", MockEP())
+        with pytest.raises(ValueError, match="Duplicating implementation"):
+            registry.add_reward_function("entrypoint_reward", replacement)
+
+        registry.update_reward_function("entrypoint_reward", replacement)
+        assert registry.get_reward_function("entrypoint_reward") is replacement
+        assert "entrypoint_reward" not in registry.reward_function_entrypoints_map
+    finally:
+        for name in names:
+            registry.reward_functions_map.pop(name, None)
+            registry.reward_function_entrypoints_map.pop(name, None)
+            if old_rewards[name] is not None:
+                registry.update_reward_function(name, old_rewards[name])  # type: ignore
+            if old_eps[name] is not None:
+                registry.add_entrypoint_reward_function(name, old_eps[name])
+
+
+def test_lazy_entrypoint_reward_function_avoids_import_order_circular_import(tmp_path):
+    package_dir = tmp_path / "external_reward_pkg"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text(
+        'from .reward_module import circular_import_reward\n\n__all__ = ["circular_import_reward"]\n'
+    )
+    (package_dir / "reward_module.py").write_text(
+        "from cloudai.core import Registry\n\ndef circular_import_reward(values):\n    return float(sum(values))\n"
+    )
+    dist_info_dir = tmp_path / "external_reward_pkg-1.0.dist-info"
+    dist_info_dir.mkdir()
+    (dist_info_dir / "METADATA").write_text("Name: external-reward-pkg\nVersion: 1.0\n")
+    (dist_info_dir / "entry_points.txt").write_text(
+        "[cloudai.reward_functions]\n"
+        "circular_import_reward = external_reward_pkg.reward_module:circular_import_reward\n"
+    )
+
+    env = os.environ.copy()
+    src_path = str((Path(__file__).resolve().parents[1] / "src").resolve())
+    pythonpath = os.pathsep.join([str(tmp_path), src_path, env.get("PYTHONPATH", "")])
+    env["PYTHONPATH"] = pythonpath
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from external_reward_pkg import reward_module; print(reward_module.circular_import_reward([1, 2]))",
+        ],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "3.0"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -553,7 +553,7 @@ def test_entrypoint_reward_function_duplicate_and_update_behavior():
         value = "reward_package:reward"
 
         def load(self):
-            return lambda values: sum(values)
+            return sum
 
     registry = Registry()
     names = ["concrete_reward", "entrypoint_reward"]
@@ -613,7 +613,8 @@ def test_lazy_entrypoint_reward_function_avoids_import_order_circular_import(tmp
         [
             sys.executable,
             "-c",
-            "from external_reward_pkg import reward_module; print(reward_module.circular_import_reward([1, 2]))",
+            "from cloudai.core import Registry; "
+            "print(Registry().get_reward_function('circular_import_reward')([1, 2]))",
         ],
         check=False,
         env=env,


### PR DESCRIPTION
## Summary
Allow packages to register reward functions through entrypoints in pyproject.toml

## Test Plan
- Automated CI
- Built a package with custom reward functions and verified the registration

## Additional Notes
N/A
