### PR TITLE
MBridge: emit moe_flex_dispatcher_backend to the launcher

### DIFF
--- a/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
+++ b/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
@@ -143,6 +143,13 @@ class MegatronBridgeCmdArgs(CmdArgs):
 
     # Perf/tuning
     moe_a2a_overlap: Optional[Union[bool, List[bool]]] = Field(default=None)
+    moe_flex_dispatcher_backend: Optional[Union[str, List[str]]] = Field(
+        default=None,
+        description=(
+            "MoE flex dispatcher backend: deepep, hybridep, ncclep, or the literal string 'None' to "
+            "request the alltoall dispatcher. Omit the field entirely to keep the recipe's backend."
+        ),
+    )
     max_steps: Optional[int] = Field(default=10)
     recompute_num_layers: Optional[Union[int, List[int]]] = Field(default=None)
     activation_offload_layers: Optional[Union[int, List[int]]] = Field(default=None)

--- a/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
+++ b/src/cloudai/workloads/megatron_bridge/slurm_command_gen_strategy.py
@@ -619,6 +619,11 @@ class MegatronBridgeSlurmCommandGenStrategy(SlurmCommandGenStrategy):
         # Misc
         if "moe_a2a_overlap" in fields_set:
             add_field("moe_a2a_overlap", "--moe_a2a_overlap", bool(args.moe_a2a_overlap))
+        add_field(
+            "moe_flex_dispatcher_backend",
+            "--moe_flex_dispatcher_backend",
+            args.moe_flex_dispatcher_backend,
+        )
         add_field("max_steps", "-ms", args.max_steps)
         add_field("recompute_num_layers", "-rl", args.recompute_num_layers)
         add_field("activation_offload_layers", "-ol", args.activation_offload_layers)

--- a/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
+++ b/tests/workloads/megatron_bridge/test_command_gen_strategy_slurm.py
@@ -499,3 +499,28 @@ class TestMegatronBridgeSlurmCommandGenStrategy:
         cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
         wrapper_content = self._wrapper_content(cmd_gen)
         assert "-vp None" in wrapper_content
+
+    @pytest.mark.parametrize("backend", ["hybridep", "deepep", "ncclep", "None"])
+    def test_moe_flex_dispatcher_backend_emitted(
+        self,
+        configured_slurm_system: SlurmSystem,
+        make_test_run: Callable[..., TestRun],
+        backend: str,
+    ) -> None:
+        tr = make_test_run(
+            cmd_args_overrides={"moe_flex_dispatcher_backend": backend},
+            output_subdir=f"out_flex_{backend}",
+        )
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+        wrapper_content = self._wrapper_content(cmd_gen)
+        assert f"--moe_flex_dispatcher_backend {backend}" in wrapper_content
+
+    def test_moe_flex_dispatcher_backend_not_emitted_when_unset(
+        self,
+        configured_slurm_system: SlurmSystem,
+        make_test_run: Callable[..., TestRun],
+    ) -> None:
+        tr = make_test_run(output_subdir="out_flex_unset")
+        cmd_gen = MegatronBridgeSlurmCommandGenStrategy(configured_slurm_system, tr)
+        wrapper_content = self._wrapper_content(cmd_gen)
+        assert "--moe_flex_dispatcher_backend" not in wrapper_content


### PR DESCRIPTION
## Problem

`moe_flex_dispatcher_backend` never reached the launcher. DSE swept it; the command ignored it. The launcher always used the recipe's backend.

Two causes, both fixed by declaring the field:

- Not declared on `MegatronBridgeCmdArgs`. Survived only via `extra="allow"` (`models/workload.py:33`), and no `add_field` call existed for it.
- `setattr` on an undeclared field writes to `__pydantic_extra__` without touching `model_fields_set`, so the gate at `slurm_command_gen_strategy.py:527-530` would have dropped it anyway.

It still entered the action space, because `param_space` sweeps any list-valued key (`_core/test_scenario.py:172-190`).

## Impact

All six `gpt_oss_120b` DSE TOMLs sweep it as `["None", "hybridep"]`. Doubled the search space for zero effect.

## Changes

Declare the field as `Optional[Union[str, List[str]]]`, DSE-able like its neighbours. Emit it in `_build_launcher_parts`.

`"None"` is a real value, not a bug — Megatron-Bridge maps it to the alltoall dispatcher (`scripts/performance/argument_parser.py:870-878`). Omitting the field keeps the recipe backend via its `-1` sentinel, so TOMLs that don't set it are unaffected.

## Tests

Five new in `test_command_gen_strategy_slurm.py`: four parametrized over `hybridep`, `deepep`, `ncclep`, `None`; one asserting absence when unset. All four emission tests fail on `main` before the change.

| Gate | Result |
|---|---|
| `pytest tests/` | 1919 passed, 5 skipped (baseline 1914) |
| `ruff check` / `format` | clean |
| `vulture --min-confidence 100` | clean |
| `pyright` | 5 errors, identical to baseline (pre-existing `pydantic` import) |

12 functional lines, 25 test lines.

## Not in this PR

The `vp` emission path has a related defect — a TOML `vp = 1` is rewritten to literal `-vp None` at `slurm_command_gen_strategy.py:603-610`, discarding a deliberate value. A fix was drafted and withdrawn: it keyed off the TOML's `pp`, but Megatron validates against the *effective* `pp`, which can come from the recipe. It also silently switched 13 configs onto the interleaved pipeline schedule, changing what they benchmark. Being redesigned as a config-level change instead.

CLOUDAI-151. Found via Redmine SW #5256635.
