### PR TITLE
MBridge: constrain virtual pipeline size against pipeline parallelism

### DIFF
--- a/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
+++ b/src/cloudai/workloads/megatron_bridge/megatron_bridge.py
@@ -550,6 +550,32 @@ class MegatronBridgeTestDefinition(TestDefinition):
                     sorted(valid_pp_vp_combinations),
                 )
 
+        # Constraint 19: Virtual pipelining requires a real pipeline (pp > 1)
+        # vp of None or 1 means virtual pipelining is off, one chunk per rank is not an interleaved schedule
+        effective_vp = vp if (vp is not None and vp > 1) else None
+        constraint19 = not (effective_vp is not None and pp <= 1)
+        if not constraint19:
+            logging.error(
+                "Constraint 19 failed: vp > 1 requires pp > 1. pp=%s vp=%s. "
+                "Either use pp >= 2 or disable virtual pipelining with vp=1.",
+                pp,
+                vp,
+            )
+
+        # Constraint 20: EP all-to-all overlap with pp > 1 requires a virtual pipeline size
+        # Only applies when overlap is explicitly requested; a recipe may enable it independently, but
+        # assuming so would reject the many MoE configs that never use it
+        is_moe = epv is not None and epv > 1
+        constraint20 = not (a2a_overlap and is_moe and pp > 1 and effective_vp is None)
+        if not constraint20:
+            logging.error(
+                "Constraint 20 failed: moe_a2a_overlap with pp > 1 requires vp >= 2. ep=%s pp=%s vp=%s. "
+                "Either set vp to at least 2, use pp=1, or disable moe_a2a_overlap.",
+                epv,
+                pp,
+                vp,
+            )
+
         return bool(
             constraint1
             and constraint2
@@ -569,6 +595,8 @@ class MegatronBridgeTestDefinition(TestDefinition):
             and constraint16
             and constraint17
             and constraint18
+            and constraint19
+            and constraint20
         )
 
     def was_run_successful(self, tr: TestRun) -> JobStatusResult:

--- a/tests/workloads/megatron_bridge/test_workload.py
+++ b/tests/workloads/megatron_bridge/test_workload.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from cloudai.core import GitRepo, TestRun
+from cloudai.workloads.megatron_bridge import MegatronBridgeCmdArgs, MegatronBridgeTestDefinition
+
+
+def _megatron_bridge_tdef() -> MegatronBridgeTestDefinition:
+    """
+    Build a test definition whose fixed arguments satisfy every parallelism constraint.
+
+    num_gpus=128 with tp=cp=et=1 and mb=1, gb=128 keeps num_gpus % (tp*pp*cp), num_gpus % (et*ep*pp) and
+    gb % (mb*dp) at zero for every (ep, pp) pair exercised below, so each case isolates the pipelining rules.
+    """
+    return MegatronBridgeTestDefinition(
+        name="mb",
+        description="desc",
+        test_template_name="MegatronBridge",
+        cmd_args=MegatronBridgeCmdArgs(
+            hf_token="dummy_token",
+            model_family_name="qwen3",
+            model_recipe_name="30b_a3b",
+            num_gpus=128,
+            tp=1,
+            cp=1,
+            et=1,
+            mb=1,
+            gb=128,
+        ),
+        git_repos=[GitRepo(url="https://github.com/NVIDIA-NeMo/Megatron-Bridge.git", commit="r0.2.0")],
+    )
+
+
+@pytest.mark.parametrize(
+    "ep,pp,vp,a2a,res",
+    [
+        (32, 1, None, False, True),  # no pipeline and no virtual pipeline
+        (32, 1, 1, False, True),  # vp=1 is off, command gen rewrites it to -vp None
+        (32, 1, 2, False, False),  # vp > 1 needs pp > 1
+        (32, 1, 4, False, False),  # vp > 1 needs pp > 1
+        (32, 2, None, True, False),  # overlap with pp > 1 needs vp >= 2
+        (32, 2, 1, True, False),  # vp=1 is off, so it does not satisfy the overlap requirement
+        (32, 2, 2, True, True),  # pipeline interleaved over 2 chunks
+        (32, 4, 4, True, True),  # pipeline interleaved over 4 chunks
+        (32, 2, None, False, True),  # without overlap, pp > 1 does not require a virtual pipeline
+        (32, 2, 1, False, True),  # without overlap, vp=1 at pp > 1 is allowed
+        (None, 2, 1, True, True),  # unset ep is not MoE
+        (1, 2, 1, True, True),  # ep=1 is not MoE
+    ],
+)
+def test_constraint_check_virtual_pipeline_and_moe_pipelining(
+    ep: int | None,
+    pp: int,
+    vp: int | None,
+    a2a: bool,
+    res: bool,
+    tmp_path: Path,
+) -> None:
+    tdef = _megatron_bridge_tdef()
+    tdef.cmd_args.ep = ep
+    tdef.cmd_args.pp = pp
+    tdef.cmd_args.vp = vp
+    tdef.cmd_args.moe_a2a_overlap = a2a
+    tr = TestRun(name="tr", test=tdef, num_nodes=1, nodes=[], output_path=tmp_path)
+
+    assert tdef.constraint_check(tr, None) is res


### PR DESCRIPTION
## Problem

Two Megatron rules had no pre-submit check. DSE could submit jobs guaranteed to die at model init — step spent, job queued, crash during setup.

- **Virtual pipelining needs a real pipeline.** `parallel_state.py` raises "pipeline-model-parallel size should be greater than 1 with interleaved schedule" when `vp` is set at `pp = 1`.
- **EP A2A overlap with pipelining needs a virtual pipeline size.** `transformer_config.py` asserts `virtual_pipeline_model_parallel_size is not None` when `pp > 1`.

## Changes

Constraints 19 and 20 in `MegatronBridgeTestDefinition.constraint_check`.

Both treat `vp` of `None` **or `1`** as off. That matches the command generator, which rewrites `vp == 1` into `-vp None` (`slurm_command_gen_strategy.py:603-610`). One chunk per rank is not an interleaved schedule. Treating `vp = 1` as "set" would pass configs that then fail at runtime.

## Why C20 is gated on the overlap argument

A recipe can enable overlap without the config asking. Assuming every MoE config might be overlapped looks safer and is wrong — measured against the CloudAIx config tree, unconditional rejects points in **34 files** versus **9** when gated, and the extra 25 are configs that never request overlap at all.

Constraints only apply to DSE sweeps: `constraint_check` is reached from `cloudai_gym.py:155` and `single_sbatch_runner.py:136`/`:229`, all inside `all_combinations` loops. Fixed single-configuration benchmarks never evaluate it.

The tradeoff, stated plainly: a config setting `moe_a2a_overlap = false` whose recipe enables overlap anyway still reaches the cluster and fails. CloudAI cannot see the recipe's setting. Tracked upstream at [Megatron-Bridge #6006](https://github.com/NVIDIA-NeMo/Megatron-Bridge/issues/6006).

## Tests

New `tests/workloads/megatron_bridge/test_workload.py` — first coverage for `constraint_check`, which had none across all 18 constraints.

12-row parametrized table. Includes the rows that must still **pass**: `pp > 1` with `vp` off and no overlap requested.

`num_gpus=128`, not 64, so `num_gpus % (et*ep*pp) == 0` holds throughout and each row isolates its rule instead of tripping Constraint 7.

Verified discriminating: against pre-change source, exactly the expected-False rows fail, each `assert True is False` — not a construction or import error.

| Gate | Result |
|---|---|
| `pytest tests/` | 1926 passed, 5 skipped (baseline 1914) |
| `ruff check` / `format` | clean |
| `vulture --min-confidence 100` | clean |
| `pytest --dead-fixtures` | clean |
| `pyright` | 5 errors, identical to baseline (pre-existing `pydantic` import) |

28 functional lines, 79 test lines.

## Not in this PR

No change to how `vp` is emitted. A fix was drafted and withdrawn: it keyed off the TOML's `pp`, but Megatron validates the *effective* `pp`, which can come from the recipe. It also silently moved 13 configs onto the interleaved schedule, changing what they benchmark and breaking one outright.

Found while root-causing Redmine SW #5256635.
