### PR TITLE
Record pass/fail status in the scenario HTML report

### DIFF
--- a/src/cloudai/reporter.py
+++ b/src/cloudai/reporter.py
@@ -43,6 +43,8 @@ class ReportItem:
     description: str
     logs_path: Optional[str] = None
     nodes: Optional[str] = None
+    is_successful: Optional[bool] = None
+    error_message: str = ""
 
     @classmethod
     def from_test_runs(cls, test_runs: list[TestRun], results_root: Path) -> list["ReportItem"]:
@@ -53,6 +55,9 @@ class ReportItem:
                 ri.logs_path = f"./{tr.output_path.relative_to(results_root)}"
             if metadata := load_system_metadata(tr.output_path, results_root):
                 ri.nodes = metadata.slurm.node_list
+            status = tr.test.was_run_successful(tr)
+            ri.is_successful = status.is_successful
+            ri.error_message = status.error_message
             report_items.append(ri)
 
         return report_items

--- a/src/cloudai/util/general-report.jinja2
+++ b/src/cloudai/util/general-report.jinja2
@@ -1,10 +1,18 @@
 {% extends "base-report.jinja2" %}
 
+{% block extra_head %}
+<style>
+    .status-passed { color: var(--nv-green-strong); font-weight: 600; }
+    .status-failed { color: #c0392b; font-weight: 600; }
+</style>
+{% endblock %}
+
 {% block content %}
 <table>
     <tr>
         <th>Test</th>
         <th>Description</th>
+        <th>Status</th>
         <th>Results</th>
         <th>Nodes</th>
     </tr>
@@ -12,6 +20,13 @@
     <tr>
         <td>{{ item.name }}</td>
         <td>{{ item.description }}</td>
+        {% if item.is_successful is none %}
+            <td>Unknown</td>
+        {% elif item.is_successful %}
+            <td class="status-passed">PASSED</td>
+        {% else %}
+            <td class="status-failed">FAILED{% if item.error_message %}<br>{{ item.error_message }}{% endif %}</td>
+        {% endif %}
         {% if item.logs_path %}
             <td><a href="{{ item.logs_path }}">logs</a></td>
         {% else %}

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -336,6 +336,80 @@ class TestSlurmReportItem:
         [report_item] = ReportItem.from_test_runs([tr], slurm_system.output_path)
         assert report_item.nodes == slurm_metadata.slurm.node_list
 
+    def test_records_passing_status(self, slurm_system: SlurmSystem, monkeypatch: pytest.MonkeyPatch) -> None:
+        from cloudai.core import JobStatusResult
+
+        run_dir = slurm_system.output_path / "run_dir"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        tr = TestRun(
+            name="run_dir",
+            test=NCCLTestDefinition(
+                name="nccl",
+                description="NCCL test",
+                test_template_name="NcclTest",
+                cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+            ),
+            num_nodes=1,
+            nodes=["node1"],
+            output_path=run_dir,
+        )
+        monkeypatch.setattr(type(tr.test), "was_run_successful", lambda self, tr: JobStatusResult(True, ""))
+
+        [report_item] = ReportItem.from_test_runs([tr], slurm_system.output_path)
+        assert report_item.is_successful is True
+        assert report_item.error_message == ""
+
+    def test_records_failing_status_and_message(
+        self, slurm_system: SlurmSystem, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from cloudai.core import JobStatusResult
+
+        run_dir = slurm_system.output_path / "run_dir"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        tr = TestRun(
+            name="run_dir",
+            test=NCCLTestDefinition(
+                name="nccl",
+                description="NCCL test",
+                test_template_name="NcclTest",
+                cmd_args=NCCLCmdArgs(docker_image_url="fake://url/nccl"),
+            ),
+            num_nodes=1,
+            nodes=["node1"],
+            output_path=run_dir,
+        )
+        monkeypatch.setattr(
+            type(tr.test), "was_run_successful", lambda self, tr: JobStatusResult(False, "command failed")
+        )
+
+        [report_item] = ReportItem.from_test_runs([tr], slurm_system.output_path)
+        assert report_item.is_successful is False
+        assert report_item.error_message == "command failed"
+
+
+def test_scenario_report_shows_pass_fail_status(
+    slurm_system: SlurmSystem, benchmark_tr: TestRun, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for the bug where the saved HTML report never recorded pass/fail,
+    only the terminal summary did."""
+    from cloudai.core import JobStatusResult
+
+    monkeypatch.setattr(
+        type(benchmark_tr.test), "was_run_successful", lambda self, tr: JobStatusResult(False, "command failed")
+    )
+
+    reporter = StatusReporter(
+        slurm_system,
+        TestScenario(name="test-scenario", test_runs=[benchmark_tr]),
+        slurm_system.output_path,
+        ReportConfig(),
+    )
+    reporter.generate()
+
+    report_html = (slurm_system.output_path / "test-scenario.html").read_text()
+    assert "FAILED" in report_html
+    assert "command failed" in report_html
+
 
 def test_report_order() -> None:
     reports = Registry().ordered_scenario_reports()


### PR DESCRIPTION
## Summary

Fixes #1026.

- `ReportItem` (the object `general-report.jinja2` renders) only carried
  `name`/`description`/`logs_path`/`nodes`, no status field, so the saved
  `<scenario>.html` could only ever show a logs link, never pass/fail.
- The real check already exists: `StatusReporter.print_summary()` calls
  `tr.test.was_run_successful(tr)` per test to build the terminal table, it
  just never got threaded into the persisted HTML.
- This PR reuses that same call in `ReportItem.from_test_runs()` (new
  `is_successful`/`error_message` fields) and renders a PASSED/FAILED badge
  in the template, matching how `JUnitReporter` (#998) already reuses
  `was_run_successful()` for `junit.xml`. Not a new pattern, applying the
  existing one to the one report that was missing it.

**Before** (real `sleep-scenario.html` row, current `main`):

```html
<td>Tests.sleep1</td>
<td>sleep test</td>
<td><a href="./Tests.sleep1/0">logs</a></td>
```

**After** (same run, this branch):

```html
<td>Tests.sleep1</td>
<td>sleep test</td>
<td class="status-passed">PASSED</td>
<td><a href="./Tests.sleep1/0">logs</a></td>
```

A failing test renders `<td class="status-failed">FAILED<br>{error message}</td>`.

If `is_successful` is ever `None` (shouldn't happen in practice since
`from_test_runs` always calls `was_run_successful`, but kept as a safe
default rather than assuming), the cell renders `Unknown` instead of
guessing pass or fail.

**Compatibility:** this adds a 5th `<th>Status</th>` column to the table
(was 4). Nothing in this repo parses `sleep-scenario.html` by column
position, this is a human-facing report, but flagging it since it's a
visible structural change to an existing artifact.

## Test Plan

- Added `TestSlurmReportItem.test_records_passing_status` and
  `test_records_failing_status_and_message` (`tests/test_reporter.py`),
  monkeypatching `was_run_successful` the same way the existing
  `test_junit_reporter_generates_testcases_with_status_logs_and_duration`
  test does.
- Added `test_scenario_report_shows_pass_fail_status`, an end-to-end
  regression test that runs `StatusReporter.generate()` against a failing
  test run and asserts the saved HTML contains `FAILED` and the error
  message, the exact gap from #1026.
- Full suite: `uv run pytest -q` (1917 passed, 5 skipped).
- `uv run pre-commit run --all-files` (pyright, ruff check, ruff format,
  vulture, import-linter, taplo) all clean.
- Manual repro matching the issue: ran the bundled Sleep scenario for real
  (`cloudai run --system-config conf/common/system/standalone_system.toml
  --tests-dir conf/common/test --test-scenario
  conf/common/test_scenario/sleep.toml`) against both the pre-fix and
  post-fix code, the before/after snippet above is copied directly from
  those two real runs, not reconstructed from memory.

## Additional Notes

Kept scoped to `ReportItem`/`general-report.jinja2` only, no changes to
`StatusReporter.print_summary()`'s existing terminal-table logic, and no
attempt to deduplicate the two `was_run_successful()` call sites, that
would be a separate refactor, not needed to fix this bug.

AI was used for context and guidance while investigating and drafting this
change.
