### PR TITLE
Add default metric handling to OSU_Bench reporter

### DIFF
--- a/src/cloudai/workloads/osu_bench/report_generation_strategy.py
+++ b/src/cloudai/workloads/osu_bench/report_generation_strategy.py
@@ -23,7 +23,7 @@ from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from cloudai.core import ReportGenerationStrategy
+from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 from cloudai.util.lazy_imports import lazy
 
 if TYPE_CHECKING:
@@ -147,6 +147,13 @@ class OSUBenchReportGenerationStrategy(ReportGenerationStrategy):
     def can_handle_directory(self) -> bool:
         df = extract_osu_bench_data(self.results_file)
         return not df.empty
+
+    def get_metric(self, metric: str) -> MetricValue:
+        df = extract_osu_bench_data(self.results_file)
+        if df.empty or metric != "default" or "avg_lat" not in df.columns:
+            return METRIC_ERROR
+
+        return float(lazy.np.mean(df["avg_lat"]))
 
     def generate_report(self) -> None:
         if not self.can_handle_directory():

--- a/src/cloudai/workloads/osu_bench/report_generation_strategy.py
+++ b/src/cloudai/workloads/osu_bench/report_generation_strategy.py
@@ -21,7 +21,7 @@ import re
 from enum import Enum
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from cloudai.core import METRIC_ERROR, MetricValue, ReportGenerationStrategy
 from cloudai.util.lazy_imports import lazy
@@ -140,6 +140,8 @@ def extract_osu_bench_data(stdout_file: Path) -> pd.DataFrame:
 class OSUBenchReportGenerationStrategy(ReportGenerationStrategy):
     """Report generation strategy for OSU Bench."""
 
+    metrics: ClassVar[list[str]] = ["default", "avg_lat"]
+
     @property
     def results_file(self) -> Path:
         return self.test_run.output_path / "stdout.txt"
@@ -149,15 +151,18 @@ class OSUBenchReportGenerationStrategy(ReportGenerationStrategy):
         return not df.empty
 
     def get_metric(self, metric: str) -> MetricValue:
+        if metric not in self.metrics:
+            return METRIC_ERROR
+
         df = extract_osu_bench_data(self.results_file)
-        if df.empty or metric != "default" or "avg_lat" not in df.columns:
+        if df.empty or "avg_lat" not in df.columns:
             return METRIC_ERROR
 
         return float(lazy.np.mean(df["avg_lat"]))
 
     def generate_report(self) -> None:
-        if not self.can_handle_directory():
+        df = extract_osu_bench_data(self.results_file)
+        if df.empty:
             return
 
-        df = extract_osu_bench_data(self.results_file)
         df.to_csv(self.test_run.output_path / "osu_bench.csv", index=False)

--- a/tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py
@@ -15,10 +15,16 @@
 # limitations under the License.
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
-from cloudai.workloads.osu_bench.report_generation_strategy import extract_osu_bench_data
+from cloudai.core import METRIC_ERROR, TestRun
+from cloudai.systems.slurm import SlurmSystem
+from cloudai.workloads.osu_bench.report_generation_strategy import (
+    OSUBenchReportGenerationStrategy,
+    extract_osu_bench_data,
+)
 
 OSU_MULTIPLE_BW = """\
 # OSU MPI Multiple Bandwidth / Message Rate Test v7.4
@@ -110,6 +116,23 @@ def test_osu_multi_latency_short_header_parsing(tmp_path: Path) -> None:
     assert df.shape == (6, 2)
     assert df["size"].tolist() == [1, 2, 4, 8, 16, 32]
     assert df["avg_lat"].tolist() == pytest.approx([1.88, 1.84, 1.88, 1.91, 1.87, 2.01])
+
+
+def test_get_metric_returns_mean_latency(tmp_path: Path, slurm_system: SlurmSystem) -> None:
+    (tmp_path / "stdout.txt").write_text(OSU_ALLGATHER_LAT)
+    tr = TestRun(name="osu", test=Mock(), num_nodes=2, nodes=[], output_path=tmp_path)
+    strategy = OSUBenchReportGenerationStrategy(slurm_system, tr)
+
+    assert strategy.get_metric("default") == pytest.approx((2.81 + 104.30) / 2)
+
+
+def test_get_metric_returns_error_for_unsupported_metric_or_output(tmp_path: Path, slurm_system: SlurmSystem) -> None:
+    (tmp_path / "stdout.txt").write_text(OSU_BW)
+    tr = TestRun(name="osu", test=Mock(), num_nodes=2, nodes=[], output_path=tmp_path)
+    strategy = OSUBenchReportGenerationStrategy(slurm_system, tr)
+
+    assert strategy.get_metric("default") is METRIC_ERROR
+    assert strategy.get_metric("avg_lat") is METRIC_ERROR
 
 
 def test_extract_osu_bench_data_file_not_found_returns_empty_dataframe(tmp_path: Path) -> None:

--- a/tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py
+++ b/tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py
@@ -118,12 +118,13 @@ def test_osu_multi_latency_short_header_parsing(tmp_path: Path) -> None:
     assert df["avg_lat"].tolist() == pytest.approx([1.88, 1.84, 1.88, 1.91, 1.87, 2.01])
 
 
-def test_get_metric_returns_mean_latency(tmp_path: Path, slurm_system: SlurmSystem) -> None:
+@pytest.mark.parametrize("metric", OSUBenchReportGenerationStrategy.metrics)
+def test_get_metric_returns_mean_latency(metric: str, tmp_path: Path, slurm_system: SlurmSystem) -> None:
     (tmp_path / "stdout.txt").write_text(OSU_ALLGATHER_LAT)
     tr = TestRun(name="osu", test=Mock(), num_nodes=2, nodes=[], output_path=tmp_path)
     strategy = OSUBenchReportGenerationStrategy(slurm_system, tr)
 
-    assert strategy.get_metric("default") == pytest.approx((2.81 + 104.30) / 2)
+    assert strategy.get_metric(metric) == pytest.approx((2.81 + 104.30) / 2)
 
 
 def test_get_metric_returns_error_for_unsupported_metric_or_output(tmp_path: Path, slurm_system: SlurmSystem) -> None:
@@ -131,8 +132,9 @@ def test_get_metric_returns_error_for_unsupported_metric_or_output(tmp_path: Pat
     tr = TestRun(name="osu", test=Mock(), num_nodes=2, nodes=[], output_path=tmp_path)
     strategy = OSUBenchReportGenerationStrategy(slurm_system, tr)
 
-    assert strategy.get_metric("default") is METRIC_ERROR
-    assert strategy.get_metric("avg_lat") is METRIC_ERROR
+    for metric in strategy.metrics:
+        assert strategy.get_metric(metric) is METRIC_ERROR
+    assert strategy.get_metric("unsupported") is METRIC_ERROR
 
 
 def test_extract_osu_bench_data_file_not_found_returns_empty_dataframe(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Update OSUBenchReportGenerationStrategy to support DSE get_metric(). Previous implementation was missing 'default' metric. Now, the average latency (avg_lat) is the selected metric.

## Test Plan
Tested DSE of 6 benchmarks, all sucessfully report the avg_latency.
```logtalk
[INFO] Initializing Runner [RUN] mode
[INFO] Creating SlurmRunner
[INFO] Running step 1 (of 6) with action {'benchmark': 'osu_allreduce', 'message_size': '1024:1024'}
[INFO] Job completed: Tests.1 (iteration 1 of 1)
[INFO] Step 1: Observation: [4.31], Reward: 0.2320

[INFO] Running step 2 (of 6) with action {'benchmark': 'osu_allreduce', 'message_size': '2:'}
[INFO] Job completed: Tests.2 (iteration 1 of 1)
[INFO] Step 2: Observation: [17.9195], Reward: 0.0558

[INFO] Running step 3 (of 6) with action {'benchmark': 'osu_allreduce', 'message_size': '64:512'}
[INFO] Job completed: Tests.3 (iteration 1 of 1)
[INFO] Step 3: Observation: [3.875], Reward: 0.2581

[INFO] Running step 4 (of 6) with action {'benchmark': 'osu_allgather', 'message_size': '1024:1024'}
[INFO] Job completed: Tests.4 (iteration 1 of 1)
[INFO] Step 4: Observation: [4.31], Reward: 0.2320

[INFO] Running step 5 (of 6) with action {'benchmark': 'osu_allgather', 'message_size': '2:'}
[INFO] Job completed: Tests.5 (iteration 1 of 1)
[INFO] Step 5: Observation: [10.818], Reward: 0.0924

[INFO] Running step 6 (of 6) with action {'benchmark': 'osu_allgather', 'message_size': '64:512'}
[INFO] Job completed: Tests.6 (iteration 1 of 1)
[INFO] Step 6: Observation: [4.475], Reward: 0.2235
```

All tests also pass.
```logtalk
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_osu_multiple_bandwidth_message_rate_parsing PASSED [  9%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_osu_latency_parsing PASSED           [ 18%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_osu_bandwidth_parsing PASSED         [ 27%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_osu_multi_latency_short_header_parsing PASSED [ 36%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_get_metric_returns_mean_latency[default] PASSED [ 45%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_get_metric_returns_mean_latency[avg_lat] PASSED [ 54%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_get_metric_returns_error_for_unsupported_metric_or_output PASSED [ 63%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_extract_osu_bench_data_file_not_found_returns_empty_dataframe PASSED [ 72%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_extract_osu_bench_data_empty_file_returns_empty_dataframe PASSED [ 81%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_extract_osu_bench_data_no_recognizable_header_returns_empty_dataframe PASSED [ 90%]
tests/report_generation_strategy/test_osu_bench_report_generation_strategy.py::test_extract_osu_bench_data_valid_header_no_data_rows_returns_empty_dataframe PASSED [100%]
```